### PR TITLE
Add script to reshape data for machine learning

### DIFF
--- a/src/data/reshape.py
+++ b/src/data/reshape.py
@@ -12,23 +12,48 @@ import numpy as np
 import argparse
 from src.data import open_data
 
-chunk_size = 1000
-output_file = "data/interim/flattened.zarr"
-shuffle = False
-ds = open_data(sources=True)
 
-variables = 'u v w temp q1 q2 qv pres z'.split()
-sample_dims = ['time', 'grid_yt', 'grid_xt']
+def chunk_indices(chunks):
+    indices = []
 
-# stack data
-variables = list(variables) # needs to be a list for xarray
-stacked = (ds[variables]
-           .stack(sample=sample_dims)
-           .transpose('sample', 'pfull')
-           .drop('sample'))
+    start = 0
+    for chunk in chunks:
+        indices.append(list(range(start, start + chunk)))
+        start += chunk
+    return indices
 
 
-chunked = stacked.chunk({'sample': chunk_size})
+def shuffled_within_chunks(indices):
+    return np.concatenate([np.random.permutation(index) for index in indices])
 
-# save to disk
-chunked.to_zarr(output_file, mode='w')
+
+def shuffled(dataset, dim):
+    indices = chunk_indices(dataset.chunks[dim])
+    shuffled_inds = shuffled_within_chunks(indices)
+    return dataset.isel({dim: shuffled_inds})
+
+
+if __name__ == '__main__':
+    chunk_size = 500_000
+    output_file = "data/interim/flattened.zarr"
+    shuffle = True
+    ds = open_data(sources=True)
+
+    variables = 'u v w temp q1 q2 qv pres z'.split()
+    sample_dims = ['time', 'grid_yt', 'grid_xt']
+
+    # stack data
+    variables = list(variables) # needs to be a list for xarray
+    stacked = (ds[variables]
+               .stack(sample=sample_dims)
+               .transpose('sample', 'pfull')
+               .drop('sample'))
+
+    # Chunk the data
+    chunked = stacked.chunk({'sample': chunk_size})
+    
+    # Shuffle the indices
+    if shuffle:
+        chunked = shuffled(chunked, 'sample')
+        
+    chunked.to_zarr(output_file, mode='w')

--- a/src/data/test_reshape.py
+++ b/src/data/test_reshape.py
@@ -1,0 +1,11 @@
+import dask.array as da
+import numpy as np
+import xarray as xr
+from .reshape import *
+
+
+def test_chunk_indices():
+    chunks = (2, 3)
+    expected = [[0, 1], [2, 3, 4]]
+    ans = chunk_indices(chunks)
+    assert ans == expected


### PR DESCRIPTION
Stochastic gradient descent loads data sequentially, so it is fastest
to preshuffle it. To avoid python path issues call using

python -m src.data.reshape

This script currently uses too many resources and dies partway through.