### PR TITLE
use full absolute import when importing from vcm

### DIFF
--- a/external/vcm/vcm/calc/advect.py
+++ b/external/vcm/vcm/calc/advect.py
@@ -3,7 +3,7 @@ from scipy.ndimage import map_coordinates
 from numba import jit
 import xarray as xr
 import dask.array as da
-from vcm.convenience import open_dataset
+from external.vcm.vcm.convenience import open_dataset
 
 
 @jit

--- a/external/vcm/vcm/convenience.py
+++ b/external/vcm/vcm/convenience.py
@@ -3,8 +3,8 @@ import intake
 import yaml
 
 from dask import delayed
-from vcm import TOP_LEVEL_DIR
-from vcm.cloud.remote_data import open_gfdl_data_with_2d
+from external.vcm.vcm import TOP_LEVEL_DIR
+from external.vcm.vcm.cloud.remote_data import open_gfdl_data_with_2d
 from pathlib import Path
 
 # TODO Fix short tag yaml file get for fv3 installed as package


### PR DESCRIPTION
Tiny fix PR:

Imports from vcm are failing when they depend on a module that imports from vcm with `ModuleNotFoundError: No module named 'vcm'`, using the full `from external.vcm... import ...` fixes it