### PR TITLE
Fix cubedsphere import statement in coarsen.py

### DIFF
--- a/external/vcm/vcm/coarsen.py
+++ b/external/vcm/vcm/coarsen.py
@@ -11,7 +11,7 @@ import pandas as pd
 import xarray as xr
 from toolz import curry
 
-from ..data.cubedsphere import (
+from .cubedsphere import (
     block_coarsen,
     block_edge_sum,
     block_median,


### PR DESCRIPTION
cubedsphere.py is in the same directory as coarsen.py, so the import statement should reflect this. Without this fix, I get an error when trying to import vcm.coarsen.