### PR TITLE
Hotfix to add python Kubernetes to environment yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - hypothesis
   - intake
   - intake-xarray
-  - kubernetes
   - metpy
   - netcdf4>=1.4
   - numba
@@ -29,6 +28,7 @@ dependencies:
   - pyyaml==5.3
   - pytest
   - pytest-mpl
+  - python-kubernetes
   - scikit-image
   - scikit-learn
   - toolz


### PR DESCRIPTION
Our workflows that submit fv3gfs runs to kubernetes require the kubernetes python package. This fix adds that package to the `fv3net` environment.yml. Note that you have to delete the environment `conda env remove --name fv3net` prior to creating the environment again with `make create_environment`.