### PR TITLE
Specify python version in fv3net environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,5 +40,6 @@ dependencies:
   - jupyterlab
   - apache-beam
   - matplotlib=3.1
+  - python=3.7
   - pip:
     - gsutil


### PR DESCRIPTION
Python version set to 3.7 so that Conda doesn't randomly change the python version depending on other package requirements, as was happening in our CircleCI test environment