### PR TITLE
Fix/train data pipeline zarr write

### DIFF
--- a/fv3net/pipelines/create_training_data/pipeline.py
+++ b/fv3net/pipelines/create_training_data/pipeline.py
@@ -312,7 +312,6 @@ def _write_remote_train_zarr(
         if not zarr_name:
             zarr_name = helpers._path_from_first_timestep(ds, train_test_labels)
         output_path = os.path.join(gcs_output_dir, zarr_name)
-        chunks = ds.unify_chunks().chunks
         ds.chunk(_CHUNK_SIZES).to_zarr(zarr_name, mode="w", consolidated=True)
         gsutil.copy(zarr_name, output_path)
         logger.info(f"Done writing zarr to {output_path}")


### PR DESCRIPTION
Fixes issues where a lot of training data zarrs were not saved because of mismatched chunk size error in write step.