### PR TITLE
Fix bug in open_restarts_with_time_coordinate

### DIFF
--- a/external/vcm/tests/test_rundir.py
+++ b/external/vcm/tests/test_rundir.py
@@ -15,6 +15,7 @@ from vcm._rundir import (
     _config_from_fs_namelist,
     _get_current_date_from_coupler_res,
     _get_run_duration,
+    _get_prefixes,
 )
 
 FV_CORE_IN_RESTART = "./RESTART/fv_core.res.tile6.nc"
@@ -138,3 +139,20 @@ def test__get_current_date_from_coupler_res(fs, coupler_res_filename, expected):
 def test__get_run_duration(test_config):
     expected = timedelta(seconds=900)
     assert _get_run_duration(test_config) == expected
+
+
+def test_get_prefixes():
+    walker = [
+        ("blah/RESTART", [], ["20160101.000015.fv_core.res.tile6.nc"]),
+        ("blah/RESTART", [], ["20160101.000000.fv_core.res.tile6.nc"]),
+        ("blah/INPUT", [], ["fv_core.res.tile6.nc"]),
+        ("blah/RESTART", [], ["fv_core.res.tile6.nc"]),
+    ]
+
+    expected = [
+        "INPUT",
+        "RESTART/20160101.000000",
+        "RESTART/20160101.000015",
+        "RESTART",
+    ]
+    assert _get_prefixes(walker) == expected

--- a/external/vcm/vcm/_rundir.py
+++ b/external/vcm/vcm/_rundir.py
@@ -55,7 +55,7 @@ def get_prefix_time_mapping(
 
     """
     times = _get_restart_times(fs, url)
-    prefixes = _get_prefixes(fs, url)
+    prefixes = _get_prefixes(fs.walk(url))
     return dict(zip(prefixes, times))
 
 
@@ -64,14 +64,10 @@ def _append_if_not_present(list, item):
         list.append(item)
 
 
-def _get_prefixes(fs, url):
-    prefixes = ["INPUT"]
-    restarts = fs.glob(url + "/RESTART/????????.??????.*")
-    for restart in restarts:
-        time = parse_timestep_str_from_path(Path(restart).name)
-        _append_if_not_present(prefixes, os.path.join("RESTART", time))
-    prefixes.append("RESTART")
-    return prefixes
+def _get_prefixes(walker):
+    prefixes = set(prefix for prefix, _, _, _ in yield_restart_files(walker))
+    timestamped_prefixes = prefixes - {"INPUT", "RESTART"}
+    return ["INPUT"] + sorted(timestamped_prefixes) + ["RESTART"]
 
 
 def _sorted_file_prefixes(prefixes):


### PR DESCRIPTION
this function failed to discover the mapping between restart file_prefixes when
a trailing slash is included in the input url. This commit fixes the error