### PR TITLE
Add contributions guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributions Guides and Standards
+
+
+## fv3net
+
+- Only imports to `vcm`, `vcm.cubedsphere`, and `vcm.cloud` are allowed. No
+  deeper nesting (e.g. `vcm.cloud.fsspec`) or imports to other modules are
+  allowed.
+
+
+##  vcm
+
+- The external interfaces are the modules `vcm`, `vcm.cubedsphere`, and
+  `vcm.cloud`. All routines to be used externally should be imported into one
+   of these namespaces. This rule could change pending future changes to the vcm API.
+
+


### PR DESCRIPTION
Currently, fv3net and vcm have been converging towards each other, with
many routines in fv3net importing deeply into vcm, effectively
eliminating the natural division between these packages. This PR
codifies some clear standards around what imports are allowed in fv3net
and what the public API of vcm should be.

By following these guidelines, vcm/__init__.py,
vcm/cubedsphere/__init__.py, and vcm/cloud/__init__.py should list all
of the CURRENT  public API of `vcm`. Then, we can decide as a team what
portion of this API should remain in vcm, and refactor any workflow
specific code to fv3net.