### PR TITLE
Add bumpversion configuration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 0.1.1
+
+[bumpversion:file:Makefile]
+search = VERSION = v{current_version}
+replace = VERSION = v{new_version}
+
+[bumpversion:file:fv3net/__init__.py]
+
+[bumpversion:file:workflows/prognostic_run_diags/argo.yaml]
+
+[bumpversion:file:workflows/prognostic_c48_run/Makefile]

--- a/environment.yml
+++ b/environment.yml
@@ -48,3 +48,4 @@ dependencies:
     - gsutil
     - nc-time-axis>=1.2.0
     - yq
+    - bump2version


### PR DESCRIPTION
There are several version strings hiding throughout the code base in Makefiles,
setup.py, k8s yamls, etc.  This PR adds a configuration for the bump2version
tool which can be used to systematically update the version in some/all of
these files.