### PR TITLE
changed coarsen_restarts subdir arg to work with orchestrator by default

### DIFF
--- a/fv3net/pipelines/coarsen_restarts/__main__.py
+++ b/fv3net/pipelines/coarsen_restarts/__main__.py
@@ -37,12 +37,11 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "--no-target-subdir",
+        "--add-target-subdir",
         action="store_true",
         help=(
-            "Do not add subdirectory with C{target-resolution} to the destination "
-            "directory. If --gcs-dst-dir is not specified, then the subdir is "
-            "automatically added."
+            "Add subdirectory with C{target-resolution} to the specified "
+            "destination directory. "
         ),
     )
 

--- a/fv3net/pipelines/coarsen_restarts/pipeline.py
+++ b/fv3net/pipelines/coarsen_restarts/pipeline.py
@@ -107,12 +107,9 @@ def run(args, pipeline_args=None):
     source_resolution = args.source_resolution
     target_resolution = args.target_resolution
 
-    if args.gcs_dst_dir:
-        output_dir_prefix = args.gcs_dst_dir
-        if not args.no_target_subdir:
-            output_dir_prefix = os.path.join(output_dir_prefix, f"C{target_resolution}")
-    else:
-        output_dir_prefix = os.path.join(source_timestep_dir, f"C{target_resolution}")
+    output_dir_prefix = args.gcs_dst_dir
+    if args.add_target_subdir:
+        output_dir_prefix = os.path.join(output_dir_prefix, f"C{target_resolution}")
 
     coarsen_factor = source_resolution // target_resolution
     available_timesteps = list_timesteps(source_timestep_dir)

--- a/workflows/coarsen_restarts/README.md
+++ b/workflows/coarsen_restarts/README.md
@@ -8,20 +8,21 @@ using pressure-level coarsening defined in `vcm.coarsen`.
 ```python
 fv3net.pipelines.coarsen_restarts
 
-usage: __main__.py [-h] GCS_SRC_DIR GCS_GRID_SPEC_PATH SOURCE_RESOLUTION 
-    TARGET_RESOLUTION GCS_DST_DIR
+usage: __main__.py [-h] [--add-target-subdir]
+                   gcs_src_dir gcs_grid_spec_path source_resolution target_resolution gcs_dst_dir
 
 positional arguments:
-  -h, --help            show this help message and exit
-  GCS_SRC_DIR           Full GCS path to input data for downloading timesteps
-  GCS_GRID_SPEC_PATH    Full path with file wildcard 'grid_spec.tile*.nc' to
-                        select grid spec files with same resolution as the
-                        source data
-  SOURCE_RESOLUTION     Source data cubed-sphere grid resolution.
-  TARGET_RESOLUTION     Target coarsening resolution to output
-  GCS_DST_DIR           Full GCS path to output coarsened timestep data.
-                        Defaults to input pathwith target resolution appended
-                        as a directory
+  gcs_src_dir          Full GCS path to input data for downloading timesteps.
+  gcs_grid_spec_path   Full path with file wildcard 'grid_spec.tile*.nc' to select grid spec files with same resolution as the source data.
+  source_resolution    Source data cubed-sphere grid resolution.
+  target_resolution    Target coarsening resolution to output.
+  gcs_dst_dir          Full GCS path to output coarsened timestep data. Defaults to input pathwith target resolution
+                       appended as a directory
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --add-target-subdir  Add subdirectory with C{target-resolution} to the specified destination directory.
+
 ```
 
 See `workflows/coarsen_restarts/submit_job.sh` to see an example of calling this


### PR DESCRIPTION
This changes the default arguments to coarsen_restarts to avoid creating a resolution subdirectory in the outputs unless specified, so that the orchestrator can run subsequent steps by default.