### PR TITLE
Coarse-grain to C48 and one-step jobs from Big C384 Zarr

### DIFF
--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -5,6 +5,7 @@ from .fv3_restarts import (
     open_restarts,
     open_restarts_with_time_coordinates,
     standardize_metadata,
+    to_restart_netcdfs,
 )
 from .convenience import (
     TOP_LEVEL_DIR,

--- a/external/vcm/vcm/fv3_restarts.py
+++ b/external/vcm/vcm/fv3_restarts.py
@@ -1,19 +1,127 @@
-from typing import Any, Generator, Tuple
 import os
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Any, Generator, Tuple
+
 import xarray as xr
 from dask.delayed import delayed
 
-from vcm.combining import combine_array_sequence
-from vcm.xarray_loaders import open_delayed
-from vcm.schema_registry import impose_dataset_to_schema
 from vcm.cloud.fsspec import get_fs
-from vcm.cubedsphere.constants import TILE_COORDS_FILENAMES
-
+from vcm.combining import combine_array_sequence
+from vcm.cubedsphere.constants import (
+    COORD_X_CENTER,
+    COORD_X_OUTER,
+    COORD_Y_CENTER,
+    COORD_Y_OUTER,
+    FV_CORE_X_CENTER,
+    FV_CORE_X_OUTER,
+    FV_CORE_Y_CENTER,
+    FV_CORE_Y_OUTER,
+    FV_SRF_WND_X_CENTER,
+    FV_SRF_WND_Y_CENTER,
+    FV_TRACER_X_CENTER,
+    FV_TRACER_Y_CENTER,
+    RESTART_Z_CENTER,
+    SFC_DATA_X_CENTER,
+    SFC_DATA_Y_CENTER,
+    TILE_COORDS_FILENAMES,
+    COORD_Z_CENTER,
+    COORD_Z_SOIL,
+    COORD_Z_OUTER,
+    RESTART_Z_CENTER
+)
+from vcm.schema_registry import impose_dataset_to_schema
+from vcm.xarray_loaders import open_delayed
 
 from . import _rundir
+from .cubedsphere import constants
 
 SCHEMA_CACHE = {}
 FILE_PREFIX_DIM = "file_prefix"
+
+RESTART_CATEGORIES = {
+    "core": ["u", "v", "W", "DZ", "T", "delp", "phis"],
+    "srf_wnd": ["u_srf", "v_srf"],
+    "tracer": [
+        "sphum",
+        "liq_wat",
+        "rainwat",
+        "ice_wat",
+        "snowwat",
+        "graupel",
+        "o3mr",
+        "cld_amt",
+    ],
+    "sfc": [
+        "slmsk",
+        "tsea",
+        "sheleg",
+        "tg3",
+        "zorl",
+        "alvsf",
+        "alvwf",
+        "alnsf",
+        "alnwf",
+        "facsf",
+        "facwf",
+        "vfrac",
+        "canopy",
+        "f10m",
+        "t2m",
+        "q2m",
+        "vtype",
+        "stype",
+        "uustar",
+        "ffmm",
+        "ffhh",
+        "hice",
+        "fice",
+        "tisfc",
+        "tprcp",
+        "srflag",
+        "snwdph",
+        "shdmin",
+        "shdmax",
+        "slope",
+        "snoalb",
+        "sncovr",
+        "stc",
+        "smc",
+        "slc",
+    ],
+}
+
+
+CATEGORY_OF_VARIABLE = {
+    name: category
+    for category in RESTART_CATEGORIES
+    for name in RESTART_CATEGORIES[category]
+}
+
+FV_CORE_DIMS = {
+    COORD_X_CENTER: FV_CORE_X_CENTER,
+    COORD_Y_CENTER: FV_CORE_Y_CENTER,
+    COORD_X_OUTER: FV_CORE_X_OUTER,
+    COORD_Y_OUTER: FV_CORE_Y_OUTER,
+    COORD_Z_CENTER: "zaxis_1",
+}
+
+FV_TRACER_DIMS = {
+    COORD_X_CENTER: FV_TRACER_X_CENTER,
+    COORD_Y_CENTER: FV_TRACER_Y_CENTER,
+    COORD_Z_CENTER: "zaxis_1",
+}
+
+SFC_DATA_DIMS = {
+    COORD_X_CENTER: SFC_DATA_X_CENTER,
+    COORD_Y_CENTER: SFC_DATA_Y_CENTER,
+    COORD_Z_SOIL: "zaxis_1",
+}
+
+FV_SRF_WND_DIMS = {
+    COORD_X_CENTER: FV_SRF_WND_X_CENTER,
+    COORD_Y_CENTER: FV_SRF_WND_Y_CENTER,
+}
 
 
 def open_diagnostic(url, category):
@@ -89,6 +197,68 @@ def standardize_metadata(ds: xr.Dataset) -> xr.Dataset:
     except ValueError:
         ds_no_time = ds
     return impose_dataset_to_schema(ds_no_time)
+
+
+RestartCategories = namedtuple(
+    "RestartCategories", ("core", "tracer", "srf_wnd", "sfc")
+)
+
+
+def split_into_restart_categories(restart: xr.Dataset) -> RestartCategories:
+    categories = {}
+
+    for category, variable_list in RESTART_CATEGORIES.items():
+        categories[category] = restart[
+            [variable for variable in variable_list if variable in restart]
+        ]
+
+    return RestartCategories(
+        categories["core"],
+        categories["tracer"],
+        categories["srf_wnd"],
+        categories["sfc"],
+    )
+
+
+def _rename_restart_dims(data: RestartCategories) -> RestartCategories:
+    return RestartCategories(
+        data.core.rename(FV_CORE_DIMS),
+        data.tracer.rename(FV_TRACER_DIMS),
+        data.srf_wnd.rename(FV_SRF_WND_DIMS),
+        data.sfc.rename(SFC_DATA_DIMS),
+    )
+
+
+def _save_category(ds: xr.Dataset, name, output_dir):
+    for tile in range(6):
+        tile_data = ds.isel(tile=tile)
+        path = os.path.join(output_dir, name + ".tile{tile+1}.nc")
+        tile_data.to_netcdf(path)
+
+
+def to_restart_netcdfs(ds: xr.Dataset, output_dir: str):
+    """Save a single set of combined restart data as FV3 restart files
+
+    Args
+        ds: single set of restart data with standardized names
+        output_dir: a local output directory.
+
+    Notes:
+        remote output is not needed because this function should 
+        only be used when running fv3 locally.
+    """
+    restart = split_into_restart_categories(ds)
+    renamed = _rename_restart_dims(restart)
+    for name, data in [
+        ("fv_core.res", renamed.core),
+        ("fv_tracer.res", renamed.tracer),
+        ("sfc_data", renamed.sfc),
+        ("fv_srf_wnd", renamed.srf_wnd),
+    ]:
+        for tile in range(6):
+            tile_data = data.isel(tile=tile)
+            path = os.path.join(output_dir, name + f".tile{tile+1}.nc")
+            tile_data.to_netcdf(path)
 
 
 def _replace_1d_coord_by_mapping(ds, mapping, old_dim, new_dim="time"):


### PR DESCRIPTION
#210 contains a big job for transforming the run directory output to zarr. Here are some sample outputs: `gs://vcm-ml-data/2020-03-16-5-day-X-SHiELD-simulation-C384-restart-files.zarr/`

Changes in progress include
* a new function `vcm.to_restart_netcdfs` for saving combined restart data a seperate netCDF files. I envision using this for the one_step_jobs.
* new function `vcm.fv3_restarts.split_restart_categories` for splitting a combined restart Dataset into `fv_core`, etc.
* Begin refactoring pressure level coarsegraining to take in a single combined restart file. 