### PR TITLE
New contributing guide for workflow-specific code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,18 @@ compatibility so we can appropriately adjust the versioning.
   deeper nesting (e.g. `vcm.cloud.fsspec`) or imports to other modules are
   allowed.
 
+### Workflow changes
+
+Excessive coupling between our workflows has several negative consequences including:
+- Changes to shared code can potentially break any workflow importing that code, making it hard to predict what can break for a given change.
+- Depending on uneeded code can increase the number of dependencies required for a particular workflow. More dependencies result in more bugs related to upstream changes and more setup costs (e.g. huge docker images or slow dataflow startup times).
+
+To make each workflow as modular as possible, we need to make sure that workflow-specific code cannot effect other workflows. This is accomplished by following these rules:
+
+- Any new workflow code is assumed workflow-specific unless actually used by multiple workflows.
+- Workflow specific code should be contained within the  `workflows/<workflow name>/` folder.
+
+Of course, some workflow-specific code will become useful in other workflows. In this case, the shared functionality should be moved to a relevant python "micropackage" in `external`. If the new functionality does not seem like a good fit for an existing package e.g. (`external/vcm`) then a new package should be created. This is relatively easy to do with tools like [poetry](https://github.com/python-poetry/poetry). Each of these micropackages should have a minimal set of dependencies. 
 
 ##  vcm
 


### PR DESCRIPTION
This follows up on a discussion we just had about reducing the coupling
between workflow steps. These rules implies that **no new contributions to /fv3net**, we should refactor shared functionality at convenient times.