### PR TITLE
One step zarr fill values

### DIFF
--- a/workflows/one_step_jobs/runfile.py
+++ b/workflows/one_step_jobs/runfile.py
@@ -193,7 +193,9 @@ def _convert_time_delta_to_float_seconds(a):
 
 
 def _merge_monitor_data(paths: Mapping[str, str]) -> xr.Dataset:
-    datasets = {key: xr.open_zarr(val, mask_and_scale=False) for key, val in paths.items()}
+    datasets = {
+        key: xr.open_zarr(val, mask_and_scale=False) for key, val in paths.items()
+    }
     time = _get_forecast_time(datasets["begin"].time)
     datasets_no_time = [val.drop("time") for val in datasets.values()]
     steps = list(datasets.keys())
@@ -203,7 +205,6 @@ def _merge_monitor_data(paths: Mapping[str, str]) -> xr.Dataset:
 def _write_to_store(group: zarr.ABSStore, index: int, ds: xr.Dataset):
     for variable in ds:
         logger.info(f"Writing {variable} to {group}")
-        if variable == 'land_sea_mask':
         dims = group[variable].attrs["_ARRAY_DIMENSIONS"][1:]
         dask_arr = ds[variable].transpose(*dims).data
         dask_arr.store(group[variable], regions=(index,))


### PR DESCRIPTION
This accomplishes two things: 1) preventing true model 0s from being cast to NaNs in the one-step big zarr output, and 2) initializing big zarr arrays with NaNs via `full` so that if they are not filled in due to a failed timestep or other reason, it is more apparent than using `empty` which produces arbitrary output.