### PR TITLE
Automatically run end-to-end tests on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only:
+              ignore:
                 - master
       - build_default:
           requires:


### PR DESCRIPTION
The end to end tests no long run on master automatically, so this PR reenables that feature. I left the ability to trigger the end to end tests manually on the PRs, but I don't think that should be a requirement for merging a PR. 