### PR TITLE
Use v0.3.4 of fv3gfs-python

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,7 +28,7 @@ latest
 * new external package `report` created, which handles generation of workflow reports
 * new external package `gallery` created, which generates figures which can be used by multiple workflows
 * add __main__.py to fv3net/regression/sklearn in order to better separate model training from I/O and report generation
-* Build `prognostic_run` image from v0.3.3 of `fv3gfs-python`
+* Build `prognostic_run` image from v0.3.4 of `fv3gfs-python`
 * Adjust diagnostic outputs for prognostic run with name net_moistening instead of net_precip and add total_precipitation to outputs
 
 

--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/vcm-ml/fv3gfs-python:v0.3.3
+FROM us.gcr.io/vcm-ml/fv3gfs-python:v0.3.4
 
 COPY docker/prognostic_run/requirements.txt /tmp/requirements.txt
 RUN pip3 install wheel && pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
This new version of `fv3gfs` uses a set of physical constants that is 1) consistent with assumptions in `vcm`'s calculation of hydrostatic balance and 2) consistent with the constants used in SHiELD runs.