### PR TITLE
retry loading data on RuntimeError or ValueError

### DIFF
--- a/fv3net/regression/dataset_handler.py
+++ b/fv3net/regression/dataset_handler.py
@@ -18,14 +18,6 @@ fh.setLevel(logging.INFO)
 logger.addHandler(fh)
 
 
-class RemoteDataError(Exception):
-    """ Raised for errors reading data from the cloud that
-    may be resolved upon retry.
-    """
-
-    pass
-
-
 @dataclass
 class BatchGenerator:
     data_vars: List[str]
@@ -79,7 +71,7 @@ class BatchGenerator:
                 file_batch_urls, coord_z_center, init_time_dim
             )
 
-    @backoff.on_exception(backoff.expo, RemoteDataError, max_tries=3)
+    @backoff.on_exception(backoff.expo, (ValueError, RuntimeError), max_tries=3)
     def _load_datasets(self, urls):
         timestep_paths = [self.fs.get_mapper(url) for url in urls]
         return [xr.open_zarr(path).load() for path in timestep_paths]


### PR DESCRIPTION
Custom error was not getting raised after prior refactoring, and it is no longer needed now that we filter out data with NaNs in the prior create training data workflow. This should make sure the retries happen when either RuntimeError is raised (b/c of API requests) or ValueError (some other issue reading remote data that complains 'array not found' but resolves on retry). These errors tend to crash attempts to train models using larger numbers of timestep data (~> 100).