### PR TITLE
Fix/Pin cluster name in ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: Setup kubectl
           command: |
-            cluster_name=$(gcloud container clusters list --format="value(name)")
+            cluster_name="ml-cluster-dev"
             gcloud container clusters get-credentials --zone us-central1-c  $cluster_name
             kube_cluster_name=$(kubectl config get-clusters | tail -n 1)
             kubectl config set-cluster $kube_cluster_name --server="https://"$proxy_ip


### PR DESCRIPTION
There was temporarily another cluster to work on speeding up IO for fv3gfs simulation.  This ended up breaking the integration tests because there was an assumption of only a single cluster.  Hard-coding the cluster name for the integration tests for now.