### PR TITLE
K8S Magic to keep end-to-end pods alive at all costs

### DIFF
--- a/workflows/end_to_end/kustomization/job.yaml
+++ b/workflows/end_to_end/kustomization/job.yaml
@@ -9,6 +9,8 @@ spec:
   template:
     metadata:
       generateName: end-to-end-pod-
+      labels:
+        app: end-to-end
     spec:
       serviceAccountName: integration-tests
       containers:


### PR DESCRIPTION
Node scale-downs were killing our end-to-end tests in very mysterious
ways. This can be prevented by specifying a pod disruption budget.

Resolves #269