### PR TITLE
download remote test data

### DIFF
--- a/fv3net/diagnostics/sklearn_model_performance/__main__.py
+++ b/fv3net/diagnostics/sklearn_model_performance/__main__.py
@@ -55,7 +55,7 @@ def _cleanup_temp_dir(temp_dir):
 
 def _download_remote_data(remote_path, local_dir):
     copy(os.path.join(remote_path, "*"), local_dir)
-    if os.listdir(local_dir) == 0:
+    if len(os.listdir(local_dir)) == 0:
         raise IOError(f"No data downloaded from remote input path {remote_path}")
 
 


### PR DESCRIPTION
If offline diags workflow's input data path is remote, download first then read local data. This is much faster than reading from the remote location and helps prevent the step from crashing due to a read error.