### PR TITLE
Avoid running fv3config tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs = k8s-workflows data build
+norecursedirs = data build external/fv3config
 
 markers =
     regression: marks regression tests (deselect with '-m "not regression"')


### PR DESCRIPTION
these tests should not be run by fv3net, since they are already tested
in fv3config.

Resolves #335