### PR TITLE
use updated argo version with pod disruption budget option

### DIFF
--- a/docker/fv3net/Dockerfile
+++ b/docker/fv3net/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 RUN apt-get update && apt-get install -y google-cloud-sdk jq python3-dev python3-pip kubectl gfortran
 
 # install Argo CLI
-RUN curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v2.2.1/argo-linux-amd64
+RUN curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v2.7.0/argo-linux-amd64
 RUN chmod +x /usr/local/bin/argo
 
 # install gcloud sdk


### PR DESCRIPTION
The argo version pinned in the fv3net dockerfile is old, and needs updating to include the option to specify podDisruptionBudget in the spec.