### PR TITLE
Add c48 grid information to catalog

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -124,6 +124,15 @@ sources:
         access: read_only
       urlpath: "gs://vcm-ml-data/2020-03-27-T85-GFS-nudging-data-as-zarr/nudging_data_mean_1M.zarr"
 
+  grid/c48:
+    description: Lat, lon, and area of C48 data
+    driver: zarr
+    args:
+      storage_options:
+        project: 'vcm-ml'
+        access: read_only
+      urlpath: "gs://vcm-ml-data/latLonArea/c48/c48.zarr/"
+
   ## Local Data Intake ##
   # TODO: Could this be replicated with intake caching? Or switch to an ignored file?
   local_2019-09-24-GFDL-SHiELD-15-minute-2-days_regrid_1degree:


### PR DESCRIPTION
Saved some c48 data to GCS and added it to the catalog for easy access. 

Usage:
```
In [1]: import intake

In [2]: cat = intake.open_catalog('catalog.yml')

In [3]: cat['grid/c48'].to_dask()
/home/noahb/miniconda3/envs/fv3net/lib/python3.7/site-packages/google/auth/_default.py:69: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
Out[3]:
<xarray.Dataset>
Dimensions:      (tile: 6, x: 48, x_interface: 49, y: 48, y_interface: 49)
Coordinates:
  * x            (x) float64 1.0 2.0 3.0 4.0 5.0 ... 44.0 45.0 46.0 47.0 48.0
  * x_interface  (x_interface) float64 1.0 2.0 3.0 4.0 ... 46.0 47.0 48.0 49.0
  * y            (y) float64 1.0 2.0 3.0 4.0 5.0 ... 44.0 45.0 46.0 47.0 48.0
  * y_interface  (y_interface) float64 1.0 2.0 3.0 4.0 ... 46.0 47.0 48.0 49.0
Dimensions without coordinates: tile
Data variables:
    area         (tile, y, x) float32 dask.array<chunksize=(6, 48, 48), meta=np.ndarray>
    lat          (tile, y, x) float32 dask.array<chunksize=(6, 48, 48), meta=np.ndarray>
    latb         (tile, y_interface, x_interface) float32 dask.array<chunksize=(6, 49, 49), meta=np.ndarray>
    lon          (tile, y, x) float32 dask.array<chunksize=(6, 48, 48), meta=np.ndarray>
    lonb         (tile, y_interface, x_interface) float32 dask.array<chunksize=(6, 49, 49), meta=np.ndarray>
Attributes:
    filename:   atmos_dt_atmos.tile1.nc
    grid_tile:  N/A
    grid_type:  regular
    title:      one-step.onestepjobs.20160801.001500.d8d522cb
```