### PR TITLE
Fix: Update Proxy IP Filter in .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,8 @@ jobs:
           name: Submit integration tests
           # Note that 'end_to_end_configuration.yml' in k8s image used for orchestration was 
           # during the build job above
-          # $CIRCLE_SHA1
           command: |
-            kubectl config view
-            make run_integration_tests VERSION=31cf185c96e468c62d7f739bba48440257cf183c
+            make run_integration_tests VERSION=$CIRCLE_SHA1
       - run:
           name: Firewall rule deletion
           when: always
@@ -159,19 +157,19 @@ workflows:
   test_and_lint:
     jobs:
       - lint
-      # - pytest_default
-      # - hold:
-      #     type: approval
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      # - build_default:
-      #     requires:
-      #     - hold
+      - pytest_default
+      - hold:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - master
+      - build_default:
+          requires:
+          - hold
       - integration_tests:
           requires:
-            - lint
+            - build_default
   build_and_push:
     jobs:
       - build_default:


### PR DESCRIPTION
The end-to-end integration tests are currently failing with:

```make
Unable to connect to the server: x509: certificate signed by unknown authority 
(possibly because of "x509: invalid signature: parent certificate cannot sign this 
kind of certificate" while trying to verify candidate authority certificate " ")
make: *** [Makefile:66: run_integration_tests] Error 1
```

I think this is due to there now being multiple GKE clusters associated with our project.  

This PR updates CI to specifically connect to "ml-cluster-dev" for the proxy ip and makes sure operations that previously only had to contend with having one result for cluster resources can filter to the right cluster.