### PR TITLE
Feature/ml prediction mapper

### DIFF
--- a/fv3net/regression/sklearn/_mapper.py
+++ b/fv3net/regression/sklearn/_mapper.py
@@ -1,6 +1,5 @@
 from typing import Mapping
 
-from vcm import cloud
 from vcm import safe
 import xarray as xr
 

--- a/tests/sklearn_regression/test__ml_prediction.py
+++ b/tests/sklearn_regression/test__ml_prediction.py
@@ -103,7 +103,7 @@ def test_ml_predict_wrapper(mock_model, base_mapper, gridded_dataset):
 
 @pytest.mark.parametrize(
     "mock_model",
-    [([], ["pred0"]), (["feature0", "feature10"], ["pred0"]),],
+    [([], ["pred0"]), (["feature0", "feature10"], ["pred0"])],
     indirect=True,
 )
 def test_ml_predict_wrapper_invalid_usage(mock_model, base_mapper, gridded_dataset):
@@ -117,4 +117,4 @@ def test_ml_predict_wrapper_invalid_usage(mock_model, base_mapper, gridded_datas
     )
     with pytest.raises(Exception):
         for key in mapper.keys():
-            mapper_output = mapper[key]
+            mapper[key]


### PR DESCRIPTION
Adds a mapper to fv3net.regression.sklearn that does the ML model prediction when `__getitem__` is called. The dataset returned by `prediction_mapper[key]` is the dataset from `base_mapper[key]` merged with the ML prediction.

`SklearnPredictionMapper` is initialized using a base mapper and sklearn model wrapper. The optional arg `prediction_var_suffix` renames the predicted data variables to be appended with this suffix, as the test dataset usually already contains this variable (e.g. `dQ1, dQ2` are present in the base mapper datatsets as the "true" values of the prediction variables).
```
from fv3net.regression.sklearn._mapper import SklearnPredictionMapper
from fv3net.regression.loaders import open_one_step
import joblib

onestep_mapper = open_one_step("/home/AnnaK/scratch/data/train")
model = joblib.load("/home/AnnaK/scratch/sklearn_model.pkl")
pred_mapper = SklearnPredictionMapper(onestep_mapper, model, predicted_var_suffix="ml")

pred_mapper['20160908.234500']
```
