### PR TITLE
Parametrize fv3net image for prognostic report workflow

### DIFF
--- a/workflows/prognostic_run_diags/README.md
+++ b/workflows/prognostic_run_diags/README.md
@@ -12,12 +12,15 @@
 This folder contains a workflow for saving prognostic run metrics to netCDF
 files and then uploading [this report][1] to a public bucket. 
 
-This workflow depends on an up-to-date fv3net image. It also requires that argo be installed and the kubectl tool is properly configured.
+It requires that argo be installed and the kubectl tool is properly configured.
 
 To generate reports for all the directories in `rundirs.json` to the cluster,
 simply run
 
-    bash run_all.sh rundirs.json
+    bash run_all.sh rundirs.json docker_image
+
+where `docker_image` is full name of the specific fv3net image you wish to generate 
+the report with. Using the latest master commit for the fv3net image is a good bet.
 
 This command will make output like this:
 
@@ -27,7 +30,7 @@ This command will make output like this:
     Status:              Pending
     Created:             Thu Apr 30 12:01:17 -0700 (now)
 
-The data are stored at a directory based on the "Name" above. Specifically, the computed outputs wil be located at `gs://vcm-ml-scratch/argo/{{workflow.name}}`. The published report will be available at the url:
+The data are stored at a directory based on the "Name" above. Specifically, the computed outputs wil be located at `gs://vcm-ml-public/argo/{{workflow.name}}`. The published report will be available at the url:
 
     http://storage.googleapis.com/vcm-ml-public/argo/{{workflow.name}}/index.html
 

--- a/workflows/prognostic_run_diags/argo.yaml
+++ b/workflows/prognostic_run_diags/argo.yaml
@@ -6,6 +6,7 @@ spec:
   arguments:
     parameters:
     - name: runs
+    - name: docker-image
   entrypoint: all
   volumes:
   - name: gcp-credentials-user-gcp-sa
@@ -32,7 +33,7 @@ spec:
        value: "climate-sim-pool"
        effect: "NoSchedule"
      container:
-      image: us.gcr.io/vcm-ml/fv3net:2bef18e9b67156fbaedf12c41ac35aea8db0d94a
+      image: '{{workflow.parameters.docker-image}}'
       command:
       - python
       - generate_report.py
@@ -70,7 +71,7 @@ spec:
        value: "climate-sim-pool"
        effect: "NoSchedule"
      container:
-      image: us.gcr.io/vcm-ml/fv3net:2bef18e9b67156fbaedf12c41ac35aea8db0d94a
+      image: '{{workflow.parameters.docker-image}}'
       command: ["bash", "-x", "-e"]
       args:
       - entrypoint.sh

--- a/workflows/prognostic_run_diags/run_all.sh
+++ b/workflows/prognostic_run_diags/run_all.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-if [ "$#" -lt 1 ]; then
-    echo "WARNING: no rundirs.json specified for prognostic run diags."
+function usage {
+  echo "Usage: "
+  echo "  run_all.sh rundirs.json docker_image"
+}
+
+if [ "$#" -lt 2 ]; then
+    usage
     exit 1
 fi
 
 runs=$(cat $1)
-shift
-argo submit argo.yaml -p runs="$runs" $@
+docker_image=$2
+shift 2
+argo submit argo.yaml -p docker-image=$docker_image -p runs="$runs" $@


### PR DESCRIPTION
Have to do this as a subsequent PR since I don't want the `argo.yaml` pointing to a dangling commit of fv3net.