### PR TITLE
Add filter on state set to only include nudged quantities

### DIFF
--- a/workflows/nudging/runfile.py
+++ b/workflows/nudging/runfile.py
@@ -175,8 +175,7 @@ if __name__ == "__main__":
         monitor.store(state, stage="after_nudging")
 
         nudged_state_members = {
-            key: quantity for key, quantity in state.items()
-            if key in nudging_names
+            key: quantity for key, quantity in state.items() if key in nudging_names
         }
         fv3gfs.set_state(nudged_state_members)
     fv3gfs.cleanup()


### PR DESCRIPTION
The nudging runfile can output variables that may not be reinserted when attempting to update the state due to a lack of setter (e.g., `surface_precipitation_rate`).  This PR fixes the final `fv3gfs.set_state` call to only include variables affected by the nudging.