### PR TITLE
add loaders to prognostic run image

### DIFF
--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -6,6 +6,7 @@ RUN pip3 install wheel && pip3 install -r /tmp/requirements.txt
 # cache external package installation
 COPY external/fv3config /fv3net/external/fv3config
 COPY external/vcm /fv3net/external/vcm
+COPY external/loaders /fv3net/external/loaders
 RUN pip3 install -e /fv3net/external/vcm -e /fv3net/external/fv3config -e /fv3net/external/loaders
 
 COPY . /fv3net


### PR DESCRIPTION
A prior PR that added an ML prediction mapper to `fv3net.regression` introduced a dependency on the external `loaders` package. The prognostic run test started failing because it imports from `fv3net.regression` but didn't have `loaders` installed. 

This PR adds external/loaders to the list of external packages getting installed in the prognostic_run Dockerfile.

This looks kind of lame since 1) the loaders aren't used in the prognostic run, and 2) currently the only use of this import in fv3net.regression is for a constant, which could just be hard coded. 

I went with installing the package over hard coding and removing the constant because in a future PR I wanted to have the geospatial mappers all inherit from a base class, so that would get imported in addition to the current constant. I'm open to discussing the alternative though.