### PR TITLE
modify ML sample datasets to use sample as first dimension

### DIFF
--- a/external/loaders/loaders/_utils.py
+++ b/external/loaders/loaders/_utils.py
@@ -56,7 +56,7 @@ def stack_dropnan_shuffle(
         raise ValueError(
             "No Valid samples detected. Check for errors in the training data."
         )
-    ds = ds_no_nan.load()
+    ds = ds_no_nan.transpose()
     return shuffled(ds, SAMPLE_DIM_NAME, random_state)
 
 

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -3,7 +3,7 @@ import pytest
 import synth
 import xarray as xr
 import numpy as np
-
+import loaders
 from loaders.batches._batch import (
     batches_from_mapper,
     diagnostic_batches_from_mapper,
@@ -69,6 +69,8 @@ def test_batches_from_mapper(mapper):
     for i, batch in enumerate(batched_data_sequence):
         assert len(batch["z"]) == Z_DIM_SIZE
         assert set(batch.data_vars) == set(DATA_VARS)
+        for name in batch.data_vars.keys():
+            assert batch[name].dims[0] == loaders.SAMPLE_DIM_NAME
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I was writing a test to ensure that the new Keras models produce datasets which have the same metadata as the "target" batch data, and the data wasn't matching because the "sample" dimension was last in the batch data. The ordering either way doesn't affect training, because the pack routines automatically move the sample dimension to the first dimension. Because it makes some sense to have the training arrays in the batch dataset use the same convention as when training occurs, I've transposed the batch arrays so that the sample dimension is first.

I also removed an unnecessary eager load in the batch dataset creation routine, which may avoid downloading data twice when generating arrays with just inputs and just outputs from a batch.