### PR TITLE
Specify nudging output times via CLI

### DIFF
--- a/workflows/nudging/prepare_config.py
+++ b/workflows/nudging/prepare_config.py
@@ -13,6 +13,11 @@ def parse_args():
         description="prepare fv3config yaml file for nudging run"
     )
     parser.add_argument("config", type=str, help="base yaml file to configure")
+    parser.add_argument(
+        "--timesteps",
+        type=str,
+        help="path to yaml-encoded list of YYYYMMDD.HHMMSS timesteps",
+    )
 
     return parser.parse_args()
 
@@ -27,6 +32,11 @@ if __name__ == "__main__":
 
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
+
+    if args.timesteps:
+        with open(args.timesteps) as f:
+            timesteps = yaml.safe_load(f)
+        config["nudging"]["output_times"] = timesteps
 
     reference_dir = config["nudging"]["restarts_path"]
     time = datetime(*config["namelist"]["coupler_nml"]["current_date"])


### PR DESCRIPTION
To easily orchestrate the nudging run, we need a way to
specify the output times separately from the other configurations.

With this feature, I can now load the output times from a file within a
mounted config map.