### PR TITLE
Refactor time loop of prognostic runfile

### DIFF
--- a/workflows/prognostic_c48_run/sklearn_runfile.py
+++ b/workflows/prognostic_c48_run/sklearn_runfile.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 State = MutableMapping[Hashable, xr.DataArray]
+Diagnostics = Mapping[str, xr.DataArray]
 
 # following variables are required no matter what feature set is being used
 TEMP = "air_temperature"
@@ -115,9 +116,6 @@ def apply(state: State, tendency: State, dt: float) -> State:
     return updated  # type: ignore
 
 
-Diagnostics = Mapping[str, xr.Dataset]
-
-
 class TimeLoop(Iterable[Tuple[datetime, Diagnostics]]):
     """An iterable defining the master time loop of a prognostic simulation
 
@@ -150,10 +148,10 @@ class TimeLoop(Iterable[Tuple[datetime, Diagnostics]]):
         self._diagnostics = {}
 
         args = runtime.get_config()
-        NML = runtime.get_namelist()
+        namelist = runtime.get_namelist()
 
         # get timestep
-        timestep = NML["coupler_nml"]["dt_atmos"]
+        timestep = namelist["coupler_nml"]["dt_atmos"]
         self._timestep = timestep
         self._log_info(f"Timestep: {timestep}")
 

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -11,12 +11,10 @@ from sklearn.dummy import DummyRegressor
 from fv3net.regression.sklearn import SklearnWrapper
 import subprocess
 
-# need to check if fv3gfs exists in a subprocess, importing fv3gfs into this module
-# causes tests to fail. Not sure why.
-# See https://github.com/VulcanClimateModeling/fv3gfs-python/issues/79
-# - noah
+#  Importing fv3gfs causes a call to MPI_Init but not MPI_Finalize. When the
+#  subprocess subsequently calls MPI_Init from a process not managed by MPI,
+#  mpirun throws a fit. Use a subprocess as a workaround.
 FV3GFS_INSTALLED = subprocess.call(["python", "-c", "import fv3gfs"]) == 0
-with_fv3gfs = pytest.mark.skipif(not FV3GFS_INSTALLED, reason="fv3gfs not installed")
 
 
 default_fv3config = r"""


### PR DESCRIPTION
The sklearn_runfile time loop is getting complicated and combines time-stepping with I/O logic. Any modifications required manually patching code into the time-loop, which violates the [open/closed principle](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle), and could lead to spaghetti code.

This PR refactors the actual time-stepping logic to a new class, which should be somewhat easier to extend. The I/O logic is a separate concern so I left it in `__main__`.

I don't think this is final state of this refactor but I think it is a positive improvement.

Other changes:
- the tests now verify that the checksum of one of the restart files remains unchanged. This makes the refactor easier.