### PR TITLE
Verify checksum of a restart file in prognostic run tes

### DIFF
--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -376,6 +376,8 @@ def completed_rundir(tmpdir_factory):
 
 
 def test_fv3run_checksum_restarts(completed_rundir):
+    # This checksum can be updated if checksum is expected to change
+    # perhaps if an external library is updated.
     excepted_checksum = "fa79cf48c0774db1f1d13d3599536609"
     fv_core = completed_rundir.join("RESTART").join("fv_core.res.tile1.nc")
     assert excepted_checksum == fv_core.computehash()


### PR DESCRIPTION
Add regression test which verifies that the checksum of one of the restart files is unchanged. I tested offline that this actually catches errors by slightly modifying the `constant` of the `DummyRegressor` class.

This should make refactors less scary.