### PR TITLE
Load external grid spec for diag coarsening

### DIFF
--- a/workflows/coarsen_c384_diagnostics/coarsen_c384_diagnostics.py
+++ b/workflows/coarsen_c384_diagnostics/coarsen_c384_diagnostics.py
@@ -53,6 +53,9 @@ def coarsen_c384_diagnostics(args):
     diags384 = diags[hires_data_vars]
     dims_to_rename = {k: v for k, v in DIM_RENAME.items() if k in diags384}
     diags384 = diags384.rename(dims_to_rename)
+    if "tile" in diags384.coords:
+        # drop possibly 1-based tile coordinate
+        diags384 = diags384.drop("tile")
     logging.info(f"Size of diagnostic data: {diags384.nbytes / 1e9:.2f} GB")
 
     # coarsen the data


### PR DESCRIPTION
Currently the C384 SHiELD diagnostics coarsening workflow assumes that the `area` variable is within the dataset being coarsened. That is not always true (e.g. for the dycore 8xdaily outputs) so this PR modifies the workflow to load in a separate C384 grid spec and use the area from there. It also removes the assumption that the output diagnostics should be saved as `gfsphysics_15min_coarse.zarr`.