### PR TITLE
Relax synth schema equivalence check

### DIFF
--- a/external/synth/synth/core.py
+++ b/external/synth/synth/core.py
@@ -70,9 +70,9 @@ class Array:
 
 @dataclass
 class ChunkedArray:
-    shape: Sequence[int] = field(compare=True)
-    dtype: np.dtype = field(compare=True)
-    chunks: Tuple[Tuple[int]] = field(compare=True)
+    shape: Sequence[int]
+    dtype: np.dtype
+    chunks: Tuple[Tuple[int]]
 
     # TODO probably remove these generating functions
     # seems a poor separation of concerns.
@@ -84,7 +84,7 @@ class ChunkedArray:
 class VariableSchema:
     name: str = field(compare=True)
     dims: Sequence[str] = field(compare=True)
-    array: ChunkedArray = field(compare=True)
+    array: ChunkedArray = field(compare=False)
     attrs: Mapping = field(default_factory=dict, compare=False)
 
 

--- a/external/synth/tests/test_synth.py
+++ b/external/synth/tests/test_synth.py
@@ -77,24 +77,28 @@ variable2 = VariableSchema(
     attrs={"attr1": "something"},
 )
 variable3 = VariableSchema(
+    "a", ["x"], ChunkedArray(shape=[4], chunks=[2], dtype=np.dtype("float64"))
+)
+variable4 = VariableSchema(
     "a",
     ["x", "y"],
     ChunkedArray(shape=[3, 2], chunks=[1, 1], dtype=np.dtype("float32")),
 )
-variable4 = VariableSchema(
+variable5 = VariableSchema(
     "b", ["x"], ChunkedArray(shape=[3], chunks=[1], dtype=np.dtype("float32"))
 )
 
 
 @pytest.mark.parametrize(
-    "variableA,variableB", [(variable1, variable1), (variable1, variable2)],
+    "variableA,variableB",
+    [(variable1, variable1), (variable1, variable2), (variable1, variable3)],
 )
 def test_variable_schema_equivalence(variableA, variableB):
     assert variableA == variableB
 
 
 @pytest.mark.parametrize(
-    "variableA,variableB", [(variable1, variable3), (variable1, variable4)],
+    "variableA,variableB", [(variable1, variable4), (variable1, variable5)],
 )
 def test_variable_schema_not_equivalent(variableA, variableB):
     assert variableA != variableB
@@ -102,8 +106,8 @@ def test_variable_schema_not_equivalent(variableA, variableB):
 
 dataset1 = DatasetSchema({"x": coord1}, {"a": variable1})
 dataset2 = DatasetSchema({"x": coord2}, {"a": variable2})
-dataset3 = DatasetSchema({"y": coord1}, {"a": variable3})
-dataset4 = DatasetSchema({"x": coord1}, {"a": variable1, "b": variable4})
+dataset3 = DatasetSchema({"y": coord1}, {"a": variable4})
+dataset4 = DatasetSchema({"x": coord1}, {"a": variable1, "b": variable5})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Synth's checks against variable array shape, dtype, and chunks made it overly difficult to update code and generate new reference schema to check output against. For example, the C12 test fixtures's output weren't equivalent to the schema of actual routine output, and routines with output in single precision couldn't be tested against synth output schema (always in double). Since these requirements seemed overly particular they have been removed. 