### PR TITLE
Allow runs beyond verification period in prognostic run diags

### DIFF
--- a/workflows/prognostic_run_diags/transform.py
+++ b/workflows/prognostic_run_diags/transform.py
@@ -106,7 +106,7 @@ def _inner_join_time(
     prognostic: xr.Dataset, verification: xr.Dataset
 ) -> Tuple[xr.Dataset, xr.Dataset]:
     """ Subset times within the prognostic data to be within the verification data,
-    and vice versa, as necessary, and return the subset datasets
+    as necessary and vice versa, and return the subset datasets
     """
 
     inner_join_time = xr.merge(


### PR DESCRIPTION
Description: Currently the prog run diagnostic report code assumes (reasonably) that the prog run ends before the end of the 40-day SHiELD run, for the purposes of computing metrics. However we may want to extend prognostic runs beyond that time period for climate evaluation. This PR allows that to happen

Added public API: None

Refactored public API: None

Significant internal changes: Adds an inner join function that subsets both the prognostic run and the verification data to the common indices of both. 

Bulleted list of changes to non-public API: Adds an `_inner_join_times` function to `workflows/prognostic_run_diags/transform.py`

Requirement changes: None

Tests added: None