### PR TITLE
update google/cloud-sdk image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
 
   integration_tests:
     docker:
-      - image: google/cloud-sdk
+      - image: google/cloud-sdk:303.0.0
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       CLUSTER_NAME: ml-cluster-dev


### PR DESCRIPTION
Description: Update google/cloud-sdk image to fix permissions issue that popped up in CircleCI integration test.
```
apt-get install -y wget jq make gettext 
wget -qO /bin/yq https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_386
chmod +x /bin/yq
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
```

Added public API:


Refactored public API:


Significant internal changes:


Requirement changes:




You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
