### PR TITLE
Fix sqrt in RMSE calculation to be after averaging

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/_metrics.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/_metrics.py
@@ -187,16 +187,16 @@ def _insert_r2(
     predict_coord: str = "predict",
     target_coord: str = "target",
 ):
-    rmse_vars = [
+    mse_vars = [
         var
         for var in ds.data_vars
         if (var.endswith(f"{predict_coord}_vs_{target_coord}") and mse_coord in var)
     ]
-    for rmse_var in rmse_vars:
-        name_pieces = rmse_var.split("/")
+    for mse_var in mse_vars:
+        name_pieces = mse_var.split("/")
         std_var = "/".join(name_pieces[:-1] + [f"mean_vs_{target_coord}"])
         r2_var = "/".join([s if s != mse_coord else r2_coord for s in name_pieces])
-        ds[r2_var] = 1.0 - (ds[rmse_var] / ds[std_var])
+        ds[r2_var] = 1.0 - ds[mse_var] / (ds[std_var] ** 2)
     return ds
 
 


### PR DESCRIPTION
Description: This corrects an error in the RMSE calculation where the root was taken before the averaging. https://github.com/VulcanClimateModeling/fv3net/issues/543

Added public API:


Refactored public API:


Significant internal changes:


Requirement changes:


- [ ] Tests added: n/a

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
