### PR TITLE
Make PR template more suitable as a commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Requirement changes:
 
 - [ ] Tests added
 
-Resolves <github issues>
+Resolves #<github issues> [JIRA-TAG]
 
 (Delete this for the commit message)
 You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).


### PR DESCRIPTION
Currently, the PR template is very informative as a PR description, but
add some boiler plate to our commit messages especially if authors don't delete unused sections. This PR makes some very small changes to the template which make the PR description more suitable as a commit message.

Changes:
- Make the description be in sentence form by removing the
"Description:" boiler plate. I think it's pretty clear the prose at the top of a commit is a description.
-  Indicate that unused sections should be deleted
- Add a line for listing related github issues (we've been forgetting
to do this).