### PR TITLE
Parametrize cpu and memory requests for nudge-to-obs workflow

### DIFF
--- a/workflows/argo/nudge_to_obs/workflow.yaml
+++ b/workflows/argo/nudge_to_obs/workflow.yaml
@@ -146,6 +146,16 @@ spec:
         operator: "Equal"
         value: "climate-sim-pool"
         effect: "NoSchedule"
+      podSpecPatch: |
+        containers:
+          - name: main
+            resources:
+              limits:
+                cpu: "{{inputs.parameters.cpu}}"
+                memory: "{{inputs.parameters.memory}}"
+              requests:
+                cpu: "{{inputs.parameters.cpu}}"
+                memory: "{{inputs.parameters.memory}}"
       container:
         command:
           - python
@@ -161,13 +171,6 @@ spec:
             value: /secret/gcp-credentials/key.json
         image: '{{inputs.parameters.fv3gfs-image}}'
         imagePullPolicy: Always
-        resources:
-          limits:
-            cpu: "{inputs.parameters.cpu}"
-            memory: "{inputs.parameters.memory}"
-          requests:
-            cpu: "{inputs.parameters.cpu}"
-            memory: "{inputs.parameters.memory}"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:


### PR DESCRIPTION
Want to do year-long nudge-to-obs fv3gfs run. Using only 6 cores is too slow. This PR parametrizes the cpu and memory requests for the relevant argo workflow to allow using more compute.

Added public API:
- `nudge-to-obs` workflow template now takes optional parameters `fv3gfs-cpu` and `fv3gfs-memory` which control the cpu and memory requests for the fv3gfs part of the workflow. The defaults are the same as the current requests.
