### PR TITLE
Test latest google/cloud-sdk image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
 
   integration_tests:
     docker:
-      - image: google/cloud-sdk:303.0.0
+      - image: google/cloud-sdk
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       CLUSTER_NAME: ml-cluster-dev


### PR DESCRIPTION
There was an update on the google/cloud-sdk image in dockerhub (304.0.0, I believe) which ended up breaking the dependency installation using `apt-get` and failing the ` integration_tests`.  Retrying with the latest (which is now 305.0.0).

Resolves  [VCMML-436]



[VCMML-436]: https://vulcan.atlassian.net/browse/VCMML-436