### PR TITLE
fix scale factor default and clarify behaviro in  docstring

### DIFF
--- a/external/fv3fit/fv3fit/_shared/scaler.py
+++ b/external/fv3fit/fv3fit/_shared/scaler.py
@@ -156,7 +156,7 @@ def _create_scaling_array(
             "Packer's feature count information is empty. Make sure the packer has "
             "been packed at least once so that dimension lengths are known."
         )
-    variable_scale_factors = variable_scale_factors or {"dQ2": 1000000.}
+    variable_scale_factors = variable_scale_factors or {"dQ2": 1000000.0}
     vertical_scales = vertical_scales / vertical_scales.sum()
     n_vertical_levels = len(vertical_scales)
     scales = {}


### PR DESCRIPTION
Fixes a bug in `fv3fit._shared.scaler.ManualScaler` where the default scale factor for dQ2 scaled the loss term by 1000, not the feature value.

I chose to fix this by changing the default dQ2 scale factor, instead of not square rooting the scale factors, because I think it is more straightforward for the user to have both the scale factors and the vertical scalings be given in terms of how they affect the loss term (as opposed to the vertical scalings affect the loss term but the scale factors affecting the transformed target values).