### PR TITLE
Try removing restart pvc from nudging workflow (for e2e test)

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -18,9 +18,6 @@ spec:
           requests:
             storage: 20Gi
   volumes:
-    - name: restart-data
-      persistentVolumeClaim:
-        claimName: '{{workflow.parameters.restart-pvc}}'
     - name: gcp-key-secret
       secret:
         defaultMode: 420
@@ -39,8 +36,6 @@ spec:
             value: "us.gcr.io/vcm-ml/fv3net:{{workflow.parameters.image-tag}}"
           - name: times
             value: "{{workflow.parameters.nudging-times}}"
-          - name: restart-volume
-            value: restart-data
           - name: working-volume
             value: output-data
           - name: output-url

--- a/tests/end_to_end_integration/config_template.yaml
+++ b/tests/end_to_end_integration/config_template.yaml
@@ -17,7 +17,7 @@ nudging-config: |
   base_version: v0.5
   forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
   nudging:
-    restarts_path: /mnt/input/coarsen_restarts/
+    restarts_path: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
     timescale_hours:
       air_temperature: 3
       specific_humidity: 3

--- a/workflows/argo/nudging/nudging.yaml
+++ b/workflows/argo/nudging/nudging.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   arguments:
     parameters:
-      - name: restart-pvc
-        value: nudging-read-only
       - name: nudging-config
       - name: output-url
       - name: fv3gfs-image
@@ -26,9 +24,6 @@ spec:
           requests:
             storage: 1333Gi
   volumes:
-    - name: restart-data
-      persistentVolumeClaim:
-        claimName: '{{workflow.parameters.restart-pvc}}'
     - name: gcp-key-secret
       secret:
         defaultMode: 420
@@ -51,15 +46,11 @@ spec:
               - name: nudging-config
                 value: "{{workflow.parameters.nudging-config}}"
               # do not need templates
-              - name: restart-volume
-                value: restart-data
               - name: working-volume
                 value: output-data
     - name: nudging
       inputs:
         parameters:
-          - name: restart-volume
-            value: restart-data
           - name: nudging-config
           - name: times
           - name: working-volume
@@ -82,7 +73,6 @@ spec:
             arguments:
               parameters:
                 - {name: working-volume, value: "{{inputs.parameters.working-volume}}"}
-                - {name: restart-volume, value: "{{inputs.parameters.restart-volume}}"}
                 - {name: fv3gfs-image, value: "{{inputs.parameters.fv3gfs-image}}"}
         - - name: upload-outputs
             template: upload-data
@@ -165,7 +155,6 @@ spec:
       inputs:
         parameters:
           - {name: working-volume}
-          - {name: restart-volume}
           - {name: fv3gfs-image}
       tolerations:
       - key: "dedicated"
@@ -196,8 +185,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-          - name: "{{inputs.parameters.restart-volume}}"
-            mountPath: /mnt/input
           - name: "{{inputs.parameters.working-volume}}"
             mountPath: /mnt/data
           - name: gcp-key-secret


### PR DESCRIPTION
e2e integration test is occasionally timing out, possibly because the nudging-read-only restart volume cannot be mounted. To test this hypothesis, this PR removes the volume mount from the nudging workflow template and from the e2e workflow.
