### PR TITLE
Add cftime.DatetimeJulian compatibility to vcm.cos_zenith_angle

### DIFF
--- a/external/vcm/tests/test__zenith_angle.py
+++ b/external/vcm/tests/test__zenith_angle.py
@@ -1,4 +1,6 @@
+from cftime import DatetimeJulian, DatetimeNoLeap
 from datetime import datetime
+import numpy as np
 import pytest
 
 from vcm import cos_zenith_angle
@@ -7,6 +9,12 @@ from vcm import cos_zenith_angle
 @pytest.mark.parametrize(
     "time, lon, lat, expected",
     (
+        [DatetimeJulian(2020, 3, 21, 12, 0, 0), 0.0, 0.0, 1.0],
+        [DatetimeJulian(2020, 3, 21, 18, 0, 0), -90.0, 0.0, 1.0],
+        [DatetimeJulian(2020, 3, 21, 18, 0, 0), 270.0, 0.0, 1.0],
+        [DatetimeJulian(2020, 7, 6, 12, 0, 0), -90.0, 0.0, -0.0196310],
+        [DatetimeJulian(2020, 7, 6, 9, 0, 0), 40.0, 40.0, 0.9501915],
+        [DatetimeJulian(2020, 7, 6, 12, 0, 0), 0.0, 90.0, 0.3843733],
         [datetime(2020, 3, 21, 12, 0, 0), 0.0, 0.0, 1.0],
         [datetime(2020, 3, 21, 18, 0, 0), -90.0, 0.0, 1.0],
         [datetime(2020, 3, 21, 18, 0, 0), 270.0, 0.0, 1.0],
@@ -17,3 +25,16 @@ from vcm import cos_zenith_angle
 )
 def test__sun_zenith_angle(time, lon, lat, expected):
     assert cos_zenith_angle(time, lon, lat) == pytest.approx(expected, abs=1e-3)
+
+
+@pytest.mark.parametrize(
+    "invalid_time",
+    (
+        DatetimeNoLeap(2000, 1, 1),
+        np.array([DatetimeNoLeap(2000, 1, 1), DatetimeNoLeap(2000, 2, 1)]),
+    ),
+    ids=["scalar", "array"],
+)
+def test__sun_zenith_angle_invalid_time(invalid_time):
+    with pytest.raises(ValueError, match="model_time has an invalid date type"):
+        cos_zenith_angle(invalid_time, 0.0, 0.0)

--- a/external/vcm/vcm/calc/_zenith_angle.py
+++ b/external/vcm/vcm/calc/_zenith_angle.py
@@ -32,7 +32,7 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGEN
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-
+import cftime
 import datetime
 import numpy as np
 from typing import Union
@@ -42,7 +42,7 @@ RAD_PER_DEG = np.pi / 180.0
 
 
 def cos_zenith_angle(
-    model_time: np.ndarray,
+    model_time: Union[np.ndarray, datetime.datetime, cftime.DatetimeJulian],
     lon: Union[float, xr.DataArray, np.ndarray],
     lat: Union[float, xr.DataArray, np.ndarray],
 ) -> np.ndarray:
@@ -59,7 +59,13 @@ def cos_zenith_angle(
 def _days_from_2000(model_time):
     """Get the days since year 2000.
     """
-    return _total_days(model_time - datetime.datetime(2000, 1, 1, 12, 0))
+    date_type = type(np.asarray(model_time).ravel()[0])
+    if date_type not in [datetime.datetime, cftime.DatetimeJulian]:
+        raise ValueError(
+            f"model_time has an invalid date type. It must be either "
+            f"datetime.datetime or cftime.DatetimeJulian. Got {date_type}."
+        )
+    return _total_days(model_time - date_type(2000, 1, 1, 12, 0))
 
 
 def _total_days(time_diff):


### PR DESCRIPTION
The Python wrapper now uses `cftime.DatetimeJulian` dates internally.  To be able to use `vcm.cos_zenith_angle` to compute the cosine zenith angle feature in prognostic simulations we therefore need to make `vcm.cos_zenith_angle` compatible with `cftime.DatetimeJulian` objects.

Refactored public API:
- `vcm.cos_zenith_angle` now accepts `cftime.DatetimeJulian` or arrays of `cftime.DatetimeJulian` objects.  It still accepts `datetime.datetime` objects for backwards compatibility.

- [x] Tests added

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

