### PR TITLE
use gcloud commands rather than circle ci orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ jobs:
       image:
         default: fv3net
         type: enum
+        enum: ["prognostic_run", "post_process_run", "fv3net", "fv3fit"]
     docker:
       - image: google/cloud-sdk
-        enum: ["prognostic_run", "post_process_run", "fv3net", "fv3fit"]
     environment:
       GOOGLE_PROJECT_ID: vcm-ml
       GOOGLE_COMPUTE_ZONE: us-central1
@@ -117,8 +117,6 @@ jobs:
           name: Build fv3net images
           command: |
             make build_image_$IMAGE
-      - gcp-gcr/gcr-auth:
-          gcloud-service-key: DECODED_GOOGLE_CREDENTIALS
       - run:
           name: Push fv3net images
           command: |


### PR DESCRIPTION
Circle CI was not able to pull the fvgfs-python docker image anymore. It's not 100% clear why, but I suspected it was related to the special "orb" that we were using for google authentication. This PR replaces this orb with manual gcloud commands.

Significant internal changes:
- Use google/cloud-sdk image for the default_build jobs
- Use manual authentication rather than the circle ci orb
