### PR TITLE
Continue e2e test if job phase is Pending or null

### DIFF
--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -28,7 +28,8 @@ function waitForComplete {
     NAMESPACE=$2
     timeout=$(date -ud "30 minutes" +%s)
     job_phase=$(getPhase $jobName $NAMESPACE)
-    while [[ $(date +%s) -le $timeout ]] && [[ $job_phase == Running ]]
+    continue_phases="Running Pending null"  # job phase may be Pending or null initially
+    while [[ $(date +%s) -le $timeout && "$(grep $job_phase <<< $continue_phases )" ]]
     do
         echo "$(getJob $jobName $NAMESPACE)"
         echo "$(date '+%Y-%m-%d %H:%M')" Job active: "$jobName" ... sleeping ${SLEEP_TIME}s


### PR DESCRIPTION
The e2e test occasionally fails immediately. This is because the `waitForComplete` function in `run_test.sh` only allowed the workflow to proceed if its status is `Running`, but occasionally the status will be briefly `Pending` or `null` before it becomes `Running`. This PR will keep watching the job if its status is `Pending` or `null` (but still times out in 30min).

