### PR TITLE
increase test timeout when no output to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,12 @@ jobs:
       - run:
           name: "Install fv3net packages"
           command: make install_local_packages
-      - run: |
-          source activate fv3net
-          make <<parameters.kind>>
+      - run: 
+          name: "Run test"
+          no_output_timeout: 20m
+          command: |
+            source activate fv3net
+            make <<parameters.kind>>
       - run:
           name: "Coverage Report"
           command: |


### PR DESCRIPTION
Commit 502e68c48a98755c77925ddd10bca774fec6c1c0 fixed a bunch of dependency issues, but had a weird side effect where the log info stopped getting output in the dataflow test. This causes the test to fail if the job takes > 10 min (the default no output timeout). 

This PR increases the test step timeout to 20 min, which should be more than enough time for the job to succeed.
