### PR TITLE
Cleanup dumped training configuration

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -28,6 +28,10 @@ class ModelTrainingConfig:
             if DELP not in self.additional_variables:
                 self.additional_variables.append(DELP)
 
+    def dump(self, f):
+        dict_ = dataclasses.asdict(self)
+        yaml.safe_dump(dict_, f)
+
 
 def load_model_training_config(config_path: str) -> ModelTrainingConfig:
     """

--- a/external/fv3fit/fv3fit/sklearn/__main__.py
+++ b/external/fv3fit/fv3fit/sklearn/__main__.py
@@ -12,13 +12,13 @@ MODEL_CONFIG_FILENAME = "training_config.yml"
 TIMESTEPS_USED_FILENAME = "timesteps_used.yml"
 
 
-def _save_config_output(output_url, config):
+def _save_config_output(output_url: str, config: shared.ModelTrainingConfig):
     fs = vcm.cloud.fsspec.get_fs(output_url)
     fs.makedirs(output_url, exist_ok=True)
     config_url = os.path.join(output_url, MODEL_CONFIG_FILENAME)
 
     with fs.open(config_url, "w") as f:
-        yaml.dump(config, f)
+        config.dump(f)
 
 
 def parse_args():


### PR DESCRIPTION
Currently the training configuration information is dumped with python
object information, which makes it challenging to load with
yaml.safe_load, which will actually try to instantiate the object:

    !!python/object:fv3fit._shared.config.ModelTrainingConfig
    batch_function: batches_from_geodata
    batch_kwargs:
      mapping_function: open_fine_resolution_nudging_hybrid_clouds_off
      mapping_kwargs:
        fine_res:
          fine_res_url: gs://vcm-ml-experiments/2020-07-30-fine-res
          rename_vars:
            delp: pressure_thickness_of_atmospheric_layer
            grid_xt: x
            grid_yt: y
            pfull: z

This PR strips this python boilerplate starting with `!!` from the saved yaml, and allows
opening this imported metadata from any language or python installation.

I didn't add new tests since this feature wasn't tested before.
