### PR TITLE
Load additional_variables list from training config 

### DIFF
--- a/external/fv3fit/fv3fit/_shared/data.py
+++ b/external/fv3fit/fv3fit/_shared/data.py
@@ -21,7 +21,7 @@ def load_data_sequence(
         data_path,
         list(train_config.input_variables)
         + list(train_config.output_variables)
-        + list(train_config.additional_variables),
+        + list(train_config.additional_variables),  # type: ignore
         **train_config.batch_kwargs,
     )
     return ds_batches


### PR DESCRIPTION
I accidentally reverted a change before merging in  https://github.com/VulcanClimateModeling/fv3net/pull/628, which was meant to add the `additional_variables` in the training config to be added to the list of variables to load for each batch. This adds that line back.

