### PR TITLE
Remove --no-train-subdir-append flag

### DIFF
--- a/external/fv3fit/fv3fit/_shared/utils.py
+++ b/external/fv3fit/fv3fit/_shared/utils.py
@@ -1,14 +1,10 @@
-import os
 from typing import List
 
 
 def parse_data_path(args):
     # allows the data path to be provided as a sequence of urls,
     # which is useful for hybrid training data
-    if not args.no_train_subdir_append:
-        data_path = [os.path.join(path, "train") for path in args.train_data_path]
-    else:
-        data_path = args.train_data_path
+    data_path = args.train_data_path
     if isinstance(args.train_data_path, List) and len(data_path) == 1:
         return data_path[0]
     else:

--- a/external/fv3fit/fv3fit/keras/__main__.py
+++ b/external/fv3fit/fv3fit/keras/__main__.py
@@ -60,11 +60,6 @@ def parse_args():
         default=None,
         help="json file containing a list of timesteps in YYYYMMDD.HHMMSS format",
     )
-    parser.add_argument(
-        "--no-train-subdir-append",
-        action="store_true",
-        help="Omit the appending of 'train' to the input training data path",
-    )
     return parser.parse_args()
 
 

--- a/external/fv3fit/fv3fit/sklearn/__main__.py
+++ b/external/fv3fit/fv3fit/sklearn/__main__.py
@@ -47,11 +47,6 @@ def parse_args():
         default=None,
         help="json file containing a list of timesteps in YYYYMMDD.HHMMSS format",
     )
-    parser.add_argument(
-        "--no-train-subdir-append",
-        action="store_true",
-        help="Omit the appending of 'train' to the input training data path",
-    )
     return parser.parse_args()
 
 

--- a/external/fv3fit/tests/training/test_train_keras.py
+++ b/external/fv3fit/tests/training/test_train_keras.py
@@ -115,7 +115,6 @@ def test_training_integration(
             data_source_path,
             train_config_filename,
             tmp_path,
-            "--no-train-subdir-append",
         ]
     )
     required_names = ["model_data", "training_config.yml"]

--- a/external/fv3fit/tests/training/test_train_sklearn.py
+++ b/external/fv3fit/tests/training/test_train_sklearn.py
@@ -66,7 +66,6 @@ def test_training_integration(
             data_source_path,
             train_config_filename,
             tmp_path,
-            "--no-train-subdir-append",
         ]
     )
     required_names = [

--- a/tests/training/test_fineres_source.sh
+++ b/tests/training/test_fineres_source.sh
@@ -6,5 +6,4 @@ gsutil -m rm -r $OUTPUT
 python -m fv3fit.sklearn \
     $TRAINING_DATA \
     tests/training/test_training_regression/train_sklearn_model_fineres_source.yml  \
-    $OUTPUT \
-    --no-train-subdir-append 
+    $OUTPUT

--- a/tests/training/test_nudged_source.sh
+++ b/tests/training/test_nudged_source.sh
@@ -8,5 +8,4 @@ gsutil -m rm -r $OUTPUT
 python -m fv3fit.sklearn \
     $TRAINING_DATA \
     tests/training/test_training_regression/train_sklearn_model_nudged_source.yaml  \
-    $OUTPUT \
-    --no-train-subdir-append
+    $OUTPUT

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -45,8 +45,7 @@ spec:
               {{inputs.parameters.input}} \
               config.yaml \
               {{inputs.parameters.output}} \
-              --timesteps-file times.json \
-              --no-train-subdir-append
+              --timesteps-file times.json
         resources:
           requests:
             memory: "6Gi"


### PR DESCRIPTION
Since we deprecated the one step jobs, the `--no-train-subdir-append` should no longer be necessary. Every current training dataset/mapper expects data without `train/` appended to the path. This PR makes this behavior the default and removes this flag. This simplifies the configuration/running of the training.

Added public API:
- remove `--no-train-subdir-append` flag to `fvfit.sklearn` and `fv3fit.keras`. This is now the default behavior.