### PR TITLE
Update docs for #653

### DIFF
--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -64,7 +64,7 @@ template.
 | fv3config            | String representation of an fv3config object                                                          |
 | runfile              | String representation of an fv3gfs runfile                                                            |
 | output-url           | GCS url for outputs                                                                                   |
-| fv3gfs-image         | Docker image used to run model. Must have fv3gfs-wrapper and fv3config installed.                     |
+| fv3gfs-image         | Docker image used to run model. Currently only `us.gcr.io/vcm-ml/prognostic_run` supported.           |
 | post-process-image   | Docker image used to post-process and upload outputs                                                  |
 | chunks               | (optional) String describing desired chunking of diagnostics                                          |
 | cpu                  | (optional) Requested cpu for run-model step                                                           |

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -7,7 +7,7 @@ spec:
     parameters:
       - name: fv3config
       - name: runfile
-      - name: fv3gfs-image  # any image with fv3gfs-wrapper and fv3config installed
+      - name: fv3gfs-image
       - name: output-url
       - name: post-process-image
       - {name: chunks, value: "{}"}


### PR DESCRIPTION
9f172776a838409936b98e59da8043385641b287 introduced some backwards
incompatible changes, requiring that runfv3_gfs only works with the
prognostic_run image.  Oliwm approved that PR, and the automerge bot
merged it but had some requested doc changes. Here they are.