### PR TITLE
Make e2e prognostic run be nudged to observations

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -76,7 +76,7 @@ spec:
           - name: reference-restarts
             value: "{{workflow.parameters.reference-restarts}}"
           - name: store-true-args
-            value: " "
+            value: "--nudge-to-observations"
           - name: test-times
             value: "{{workflow.parameters.test-times}}"
           - name: public-report-output


### PR DESCRIPTION
Improves coverage of 'nudge-to-obs' feature.

