### PR TITLE
Add -o pipefail to runfv3.sh

### DIFF
--- a/workflows/prognostic_c48_run/runfv3.sh
+++ b/workflows/prognostic_c48_run/runfv3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 CONFIG="$1"
 RUNDIR="$2"


### PR DESCRIPTION
Currently the `runfv3.sh` script returns an exit code of 0 even if the model crashes because of the piping through `tee`. This PR ensures that the script will fail if the model crashes. 

Resolves #663.