### PR TITLE
[VCMML-615] Allow nudging towards a coarser dataset

### DIFF
--- a/workflows/prognostic_c48_run/nudging/README.md
+++ b/workflows/prognostic_c48_run/nudging/README.md
@@ -24,8 +24,8 @@ nudging:
     x_wind: 3
     y_wind: 3
     pressure_thickness_of_atmospheric_layer: 3
-  initial_time: "20160801.001500"
-  frequency_seconds: 900
+  reference_initial_time: "20160801.001500"
+  reference_frequency_seconds: 900
 namelist: {}
 ```
 

--- a/workflows/prognostic_c48_run/nudging/nudging_runfile.py
+++ b/workflows/prognostic_c48_run/nudging/nudging_runfile.py
@@ -105,13 +105,13 @@ def _get_reference_state(time, reference_dir, communicator, only_names):
 
 
 def average_states(state_0, state_1, weight: float) -> fv3gfs.util.Quantity:
-    common_keys = set(state_1) & set(state_2)
+    common_keys = set(state_0) & set(state_1)
     out = {}
     for key in common_keys:
         if isinstance(state_1[key], fv3gfs.util.Quantity):
-            array = state_1[key].view[:] * weight + (1 - weight) * state_2[key].view[:]
+            array = state_0[key].view[:] * weight + (1 - weight) * state_1[key].view[:]
             out[key] = fv3gfs.util.Quantity(
-                array, dims=state_1[key].dims, units=state_1[key].units
+                array, dims=state_0[key].dims, units=state_0[key].units
             )
     return out
 
@@ -353,12 +353,14 @@ if __name__ == "__main__":
         only_names=store_names,
     )
 
-    initial_time_label = config["nudging"].get("initial_time")
+    initial_time_label = config["nudging"].get("reference_initial_time")
     if initial_time_label is not None:
         get_reference_state = time_interpolate_func(
             get_reference_state,
             initial_time=label_to_time(initial_time_label),
-            frequency=timedelta(seconds=config["nudging"]["frequency_seconds"]),
+            frequency=timedelta(
+                seconds=config["nudging"]["reference_frequency_seconds"]
+            ),
         )
 
     wrapper.initialize()

--- a/workflows/prognostic_c48_run/nudging/test_nudging_runfile.py
+++ b/workflows/prognostic_c48_run/nudging/test_nudging_runfile.py
@@ -109,8 +109,10 @@ def test_time_interpolate_func_only_grabs_correct_points():
 
     # will raise error if incorrect times grabbed
     myfunc(initial_time + frequency / 3)
-with pytest.raises(AssertionError):
-    myfunc(initial_time + 4 * frequency / 3)
+
+    with pytest.raises(AssertionError):
+        myfunc(initial_time + 4 * frequency / 3)
+
 
 def test_time_to_label():
     time, label = cftime.DatetimeJulian(2015, 1, 20, 6, 30, 0), "20150120.063000"


### PR DESCRIPTION
Previously, the nudging runfile assumed that every time is present in
the nudging dataset. This severely constrains the model timestep, and in
particular, the nudging runfile will not work when the FV3 timestep shorter than that of the nudging reference dataset.

This approach is also innefficient, and does much more I/O than is
probably necessary given the smooth nature of the nudging tendency.

This PR adds options to the nudging configuration to specify the
frequency at which target data will be retrieved. This can also be used
to subsample a target dataset with full output frequency.

