### PR TITLE
Make training config more production-like

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -85,19 +85,22 @@ spec:
           input_variables:
             - air_temperature
             - specific_humidity
+            - cos_zenith_angle
+            - land_sea_mask
+            - surface_geopotential
+            - eastward_wind
+            - northward_wind
           output_variables:
             - dQ1
             - dQ2
+            - dQu
+            - dQv
           batch_function: batches_from_geodata
           batch_kwargs:
             timesteps_per_batch: 1
             mapping_function: open_merged_nudged_full_tendencies
             mapping_kwargs:
               consolidated: True
-              open_merged_nudged_kwargs:
-                rename_vars:
-                  air_temperature_tendency_due_to_nudging: dQ1
-                  specific_humidity_tendency_due_to_nudging: dQ2
       - name: prognostic-run-config
         value: |
           base_version: v0.5


### PR DESCRIPTION
Modify the input/output variables for the e2e test training config to include the standard set used for "production" nudging models. Hopefully this will help catch issues before they get merged to master (like the currently failing train step).

I suspect the failing test in this PR will be fixed by #757.

