### PR TITLE
Fix: Make calendar comparison non case-sensitive

### DIFF
--- a/external/fv3kube/fv3kube/base_yamls/v0.5/fv3config.yml
+++ b/external/fv3kube/fv3kube/base_yamls/v0.5/fv3config.yml
@@ -60,7 +60,7 @@ namelist:
     calendar: julian
     current_date:
     - 2016
-    - 
+    - 8
     - 1
     - 0
     - 15


### PR DESCRIPTION
xarray/cftime are not case sensitive for the encoding of calendar type. So the `append.py` script shouldn't be either. Fixes an issue that sometimes occurs after #761 was merged.