### PR TITLE
Prognostic tke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ build_image_post_process_run:
 	tools/docker_build_cached.sh us.gcr.io/vcm-ml/post_process_run:$(CACHE_TAG) \
 		workflows/post_process_run -t $(REGISTRY)/post_process_run:$(VERSION)
 
+build_image_dev_prognostic_run:
+	tools/docker_build_cached.sh us.gcr.io/vcm-ml/prognostic_run:$(CACHE_TAG) \
+		-f docker/prognostic_run/Dockerfile --target bld -t dev .
+
 enter_%:
 	docker run -ti -w /fv3net -v $(shell pwd):/fv3net $* bash
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,65 @@
+To start, clean up any lingering build artifacts in the fortran submodule
+
+    cd external/fv3gfs-fortran/ && git clean -fxd
+
+Build image
+
+    VERSION=latest make build_image_prognostic_run 
+
+Prepare run directory (rundir):
+
+    sh prepare_rundir.sh
+
+Enter the docker image:
+
+    docker run -ti --entrypoint bash -v (pwd):/workdir -w /workdir  us.gcr.io/vcm-ml/prognostic_run:latest
+
+This should give you bash prompt in the docker container. fv3.exe is installed to /usr/bin/fv3.exe.
+
+Once inside of the image, change to the rundir, and run the model via the `run.sh` script:
+
+    cd rundir
+    sh run.sh
+
+You can check out the logs (saved to `logs` and `err`). The
+GFS_physics_driver.F90 currently contains this code demonstrating how to use
+the call_py_fort routines:
+
+    call set_state("prsi", Statein%prsi)
+    call call_function("builtins", "print")
+    call get_state("pris", Statein%prsi)
+
+Call_py_fort basically operates by pushing fortran arrays into a global
+python dictionary, calling functions with this dictionary as input, and then
+reading numpy arrays from this dictionary back into fortran. Let this
+dictionary by called STATE. In terms of python operations, the above lines
+roughly translate to
+
+    STATE: Mapping[str, Union[np.ndarray, str, float]]
+
+    # abuse of notation signifyling that the left-hand side is a numpy array
+    STATE["prsi"] = Statein%prsi as a numpy array
+    # same as `print` but with module name
+    builtins.print(STATE)
+    # transfer from python back to fortran memory
+    Statein%prsi[:] = STATE["prsi"]
+
+
+Thus, if succesful, the logs should print dictionary with a "prsi" entry for every timestep. Indeed this is what happens:
+
+    {'prsi': array([[9.94275280e+04, 9.98183565e+04, 1.00298827e+05, ...,
+        1.00847785e+05, 1.01756696e+05, 1.02275592e+05],
+       [9.88979682e+04, 9.92862450e+04, 9.97635772e+04, ...,
+        1.00308952e+05, 1.01211927e+05, 1.01727435e+05],
+       [9.82987610e+04, 9.86841501e+04, 9.91579304e+04, ...,
+        9.96992493e+04, 1.00595508e+05, 1.01107181e+05],
+       ...,
+       [2.21958000e+02, 2.21958000e+02, 2.21958000e+02, ...,
+        2.21958000e+02, 2.21958000e+02, 2.21958000e+02],
+       [1.37790000e+02, 1.37790000e+02, 1.37790000e+02, ...,
+        1.37790000e+02, 1.37790000e+02, 1.37790000e+02],
+       [6.42470000e+01, 6.42470000e+01, 6.42470000e+01, ...,
+        6.42470000e+01, 6.42470000e+01, 6.42470000e+01]])}
+    
+By modifying, the arguments of `call_function` you can call any python
+function in the pythonpath.

--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -51,69 +51,10 @@ RUN cd /tmp/fortran-build/FV3 && \
     make -j 8 && \
     PREFIX=/usr/local make install
 
-#
-# Python Stuff Here
-#
+COPY external/fv3config /tmp/fv3config
+RUN pip3 install wheel
+RUN pip3 install /tmp/fv3config numpy
 
-# Python components here
-COPY docker/prognostic_run/requirements.txt /tmp/requirements.txt
-COPY constraints.txt /tmp/constraints.txt
-
-RUN pip3 install wheel && \
-    pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir -c /tmp/constraints.txt -r /tmp/requirements.txt && \
-    ln -s /bin/python3 /bin/python && \
-    ln -s /bin/pip3 /bin/pip
-
-# Build the wrapper
-RUN apt-get install -y pkg-config
-COPY /external/fv3gfs-wrapper /fv3gfs-wrapper
-RUN make -C /fv3gfs-wrapper/lib
-
-# copy dependency packages
-COPY /external/fv3config /external/fv3config
-COPY /external/fv3gfs-util /external/fv3gfs-util
-
-RUN echo "ulimit -s unlimited" >> /etc/bash.bashrc && \
-    mkdir /outdir && \
-    chmod -R 777 /outdir
-
-# cache external package installation
-RUN mkdir -p /fv3net/external /fv3net/workflows && \
-    mv /external/* /fv3net/external/ && \
-    mv /fv3gfs-wrapper /fv3net/external/fv3gfs-wrapper
-
-COPY external/fv3fit /fv3net/external/fv3fit
-COPY external/fv3kube /fv3net/external/fv3kube
-COPY external/vcm /fv3net/external/vcm
-COPY external/loaders /fv3net/external/loaders
-
-COPY workflows/prognostic_c48_run/ /fv3net/workflows/prognostic_c48_run
-
-COPY docker/prognostic_run/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-# Install fv3gfs run script
-COPY workflows/prognostic_c48_run/runfv3.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/runfv3.sh
-
-# install the packages
-RUN /entrypoint.sh
-CMD ["bash"]
-
-ENV PYTHONPATH=/fv3net/workflows/prognostic_c48_run:${PYTHONPATH}
-WORKDIR /fv3net/workflows/prognostic_c48_run
-ENTRYPOINT [ "/entrypoint.sh" ]
-
-FROM bld as test
-
-ENV GOOGLE_APPLICATION_CREDENTIALS /tmp/key.json
-RUN --mount=type=secret,id=gcp,dst=/tmp/key.json \
-    ["bash", "-o", "pipefail", "-c", "pytest | tee /tmp/test-results.txt"]
-
-FROM bld
-# Copy results from test stage to ensure docker buildkit executes it
-COPY --from=test /tmp/test-results.txt .
 
 ARG COMMIT_SHA_ARG
 ENV COMMIT_SHA=$COMMIT_SHA_ARG

--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -13,6 +13,38 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ESMF_LIB}:${FMS_LIB}
 COPY --from=us.gcr.io/vcm-ml/esmf-build /usr/local/esmf ${ESMF_DIR}
 COPY --from=us.gcr.io/vcm-ml/esmf-build /usr/local/esmf/lib/libO3/Linux.gfortran.64.mpiuni.default/*.so* ${ESMF_LIB}/
 
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
+    apt-get install -y  --no-install-recommends \
+    cmake \
+    python3 \
+    libpython3-dev \
+    python3-dev \
+    python3-setuptools \
+    python3-pip \
+    python3-cffi \
+    cython3
+
+
+# install pfunit
+RUN cd /tmp && curl -L https://github.com/Goddard-Fortran-Ecosystem/pFUnit/archive/3.2.9.tar.gz | tar xz
+ENV F90=gfortran
+ENV F90_VENDOR=GNU
+ENV PFUNIT=/usr/local
+RUN ls /tmp/pFUnit-3.2.9
+RUN cd /tmp/pFUnit-3.2.9 && \
+    cmake . && \
+    make &&\
+    make install INSTALL_DIR=${PFUNIT}
+
+# install call-py-fort
+COPY external/fv3gfs-fortran/FV3/call_py_fort/ /opt/call_py_fort
+ENV PYTHONPATH=/opt/call_py_fort/src/:/opt/call_py_fort/test:$PYTHONPATH
+ENV CALLPY=/opt/call_py_fort
+RUN cd /opt/call_py_fort/ && make && make install
+
+FROM bld
+
 # build/install the fortran model
 COPY external/fv3gfs-fortran/ /tmp/fortran-build
 RUN cd /tmp/fortran-build/FV3 && \
@@ -22,16 +54,6 @@ RUN cd /tmp/fortran-build/FV3 && \
 #
 # Python Stuff Here
 #
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
-    apt-get install -y  --no-install-recommends \
-    python3 \
-    libpython3-dev \
-    python3-dev \
-    python3-setuptools \
-    python3-pip \
-    cython3
 
 # Python components here
 COPY docker/prognostic_run/requirements.txt /tmp/requirements.txt

--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -38,12 +38,12 @@ RUN cd /tmp/pFUnit-3.2.9 && \
     make install INSTALL_DIR=${PFUNIT}
 
 # install call-py-fort
-COPY external/fv3gfs-fortran/FV3/call_py_fort/ /opt/call_py_fort
+RUN ln -s /usr/bin/python3 /usr/bin/python
+COPY external/fv3gfs-fortran/FV3/call_py_fort /opt/call_py_fort
 ENV PYTHONPATH=/opt/call_py_fort/src/:/opt/call_py_fort/test:$PYTHONPATH
 ENV CALLPY=/opt/call_py_fort
 RUN cd /opt/call_py_fort/ && make && make install
 
-FROM bld
 
 # build/install the fortran model
 COPY external/fv3gfs-fortran/ /tmp/fortran-build

--- a/prepare_rundir.sh
+++ b/prepare_rundir.sh
@@ -1,0 +1,7 @@
+write_run_directory external/fv3gfs-fortran/tests/pytest/config/default.yml rundir
+
+# write a runscript for convenience
+cat << EOF > rundir/run.sh
+export LD_LIBRARY_PATH=/usr/local/lib/:/usr/local/esmf/lib/libO3/Linux.gfortran.64.mpiuni.default/:/FMS/libFMS/.libs/
+mpirun -np 6 --allow-run-as-root --oversubscribe --mca btl_vader_single_copy_mechanism none fv3.exe > logs 2> err
+EOF


### PR DESCRIPTION
This PR installs my [call_py_fort](https://github.com/VulcanClimateModeling/call_py_fort) library into the prognostic run image, and shows a proof of concept of how to use it. Hopefully, this should be enough to get you started with replacing the satmedmf subroutine with your emulator.

I wrote a [quickstart guide](https://github.com/VulcanClimateModeling/fv3net/blob/prognostic-tke/QUICKSTART.md) that should get you up and running developing this workflow. Let me know if you run into any problems. `call_py_fort` currently only supports getting/setting single or double arrays of dimensionalities 1-3. I can add support for integer arrays if needed.

cc @frodre 
