### PR TITLE
Fix bug in interpolate_to_pressure_levels

### DIFF
--- a/external/vcm/vcm/interpolate.py
+++ b/external/vcm/vcm/interpolate.py
@@ -70,7 +70,7 @@ def interpolate_to_pressure_levels(
         the atmospheric quantity defined on ``pressure_levels``.
     """
     return interpolate_1d(
-        levels, field, vcm.calc.thermo.pressure_at_midpoint_log(delp, dim=dim), dim=dim,
+        levels, vcm.calc.thermo.pressure_at_midpoint_log(delp, dim=dim), field, dim=dim,
     )
 
 


### PR DESCRIPTION
@AnnaKwa found this routine was returning NaNs since a5566f9b64750e80452c01e1bafa9bd4500f5c96. I added a test and fixed the bug.