### PR TITLE
Fix indentation in training argo template

### DIFF
--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -46,6 +46,11 @@ spec:
               config.yaml \
               {{inputs.parameters.output}} \
               --timesteps-file times.json
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "climate-sim-pool"
+        effect: "NoSchedule"      
       podSpecPatch: |
         containers:
           - name: main


### PR DESCRIPTION
This fixes an extra indentation error affecting the block that set CPU and memory requests for the training template, which was causing the request to be ignored. Previously, request & limit for CPU and memory were showing up as 0 in the job. Now, they are the appropriate parameter value.