### PR TITLE
Move tolerations to proper part of offline-diags argo workflow

### DIFF
--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -10,12 +10,12 @@ spec:
         defaultMode: 420
         secretName: gcp-key
   serviceAccountName: integration-tests
-  tolerations:
-    - effect: NoSchedule
-      key: dedicated
-      value: climate-sim-pool
   templates:
     - name: offline-diags
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          value: climate-sim-pool
       inputs:
         parameters:
           - name: ml-model


### PR DESCRIPTION
I noticed the offline diags workflow was getting assigned to our "base" node pool (i.e. single cpu nodes not meant for computation). This PR moves the "tolerations" section of the workflow to within the offline-diags template so that it will have its intended effect.