### PR TITLE
By default use first test timestep as snapshot time

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/compute_diags.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/compute_diags.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
     ds_diurnal["time"] = times_used
 
     # compute transected and zonal diags
-    snapshot_time = args.snapshot_time or sorted(list(pred_mapper.keys()))[0]
+    snapshot_time = args.snapshot_time or sorted(timesteps)[0]
     snapshot_key = nearest_time(snapshot_time, list(pred_mapper.keys()))
     ds_snapshot = pred_mapper[snapshot_key]
     ds_transect = _get_transect(ds_snapshot, grid, config["output_variables"])


### PR DESCRIPTION
Currently the offline diags uses the first key in the sorted `pred_mapper` keys for the snapshot transect plot. However this key can fall outside the user's specified test timesteps. This PR makes the snapshot time be the first item in the sorted `timesteps` list (which will be all the keys in `pred_mapper` if a custom set of timesteps is not provided).