### PR TITLE
Fix bug when loading packed-keras models

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -23,7 +23,6 @@ EpochLossHistory = Sequence[Sequence[Union[float, int]]]
 History = Mapping[str, EpochLossHistory]
 
 
-@io.register("packed-keras")
 class PackedKerasModel(Estimator):
     """
     Abstract base class for a keras-based model which operates on xarray
@@ -300,6 +299,7 @@ class PackedKerasModel(Estimator):
             return obj
 
 
+@io.register("packed-keras")
 class DenseModel(PackedKerasModel):
     """
     A simple feedforward neural network model with dense layers.


### PR DESCRIPTION
Loading a keras model gives this error:
```
TypeError: Can't instantiate abstract class PackedKerasModel with abstract methods get_model
```

Since the `get_model` method is only relevant for training this error does not need to be raised until the `.fit` method is called.

