### PR TITLE
Add gsutil to fv3fit image

### DIFF
--- a/docker/fv3fit/Dockerfile
+++ b/docker/fv3fit/Dockerfile
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:experimental
 FROM python:3.7.8-stretch AS bld
 
+# install gcloud
+RUN apt-get update && apt-get install -y  apt-transport-https ca-certificates gnupg curl gettext
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&\
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update && apt-get install -y google-cloud-sdk 
+
 COPY constraints.txt /tmp/constraints.txt
 COPY external/fv3fit/requirements.txt fv3fit/requirements.txt
 RUN pip install -c /tmp/constraints.txt -r fv3fit/requirements.txt

--- a/external/fv3fit/requirements.txt
+++ b/external/fv3fit/requirements.txt
@@ -33,7 +33,6 @@ entrypoints
 gcsfs
 google-auth
 google-auth-oauthlib
-gsutil
 idna
 imageio
 importlib-metadata


### PR DESCRIPTION
A previous PR to save the keras training history used vcm's gsutil.copy, but gsutil was not in the fv3fit image. This installs google cloud sdk in the fv3fit image, which is how gsutil gets into the other images that use it (needs to installed this way to work and not via pip).

This fix isn't testable through the integration test since that uses the sklearn training script. I verified that it worked by running a short keras training in an argo workflow using this image and checking that the outputs got uploaded correctly to GCS.