### PR TITLE
Disable keras history saving

### DIFF
--- a/external/fv3fit/fv3fit/keras/__main__.py
+++ b/external/fv3fit/fv3fit/keras/__main__.py
@@ -6,7 +6,6 @@ import numpy as np
 import sys
 import random
 from . import get_model
-from ._save_history import save_history
 from .. import _shared as shared
 import fv3fit._shared.io
 import loaders
@@ -105,6 +104,3 @@ if __name__ == "__main__":
     batches = shared.load_data_sequence(data_path, train_config)
     history = model.fit(batches, **fit_kwargs)  # type: ignore
     fv3fit._shared.io.dump(model, args.output_data_path)
-    save_history(
-        history, os.path.join(args.output_data_path, HISTORY_OUTPUT_DIR),
-    )


### PR DESCRIPTION
This disables the training history saving during keras model training. The `gsutil.copy` call in the keras training script has errors in the fv3fit image, so I am temporarily removing this part that uploads the history to GCS so that keras model training can still work in the master branch. I will put this back after I fix the gsutil issue. The tests currently do not alert this error because the integration test uses the sklearn training.

If no one is affected by this currently, this band aid fix can be skipped and fixed by getting the correct gsutil installed in the fv3fit image. I made this quick fix option in case I run into issues getting gsutil in the image (because there is a 'wrong' gsutil to use)