### PR TITLE
Add loaders.mapper.open_zarr

### DIFF
--- a/external/loaders/loaders/mappers/__init__.py
+++ b/external/loaders/loaders/mappers/__init__.py
@@ -26,4 +26,4 @@ from ._high_res_diags import open_high_res_diags
 # mapper classes used externally
 from ._base import GeoMapper, LongRunMapper, MultiDatasetMapper
 from ._merged import MergeOverlappingData
-from ._xarray import XarrayMapper
+from ._xarray import XarrayMapper, open_zarr

--- a/external/loaders/loaders/mappers/_xarray.py
+++ b/external/loaders/loaders/mappers/_xarray.py
@@ -1,4 +1,5 @@
 import xarray as xr
+import fsspec
 import vcm
 from ._base import GeoMapper
 
@@ -46,3 +47,8 @@ class XarrayMapper(GeoMapper):
 
     def keys(self):
         return self.time_lookup.keys()
+
+
+def open_zarr(url: str, consolidated: bool = True, dim: str = "time") -> XarrayMapper:
+    ds = xr.open_zarr(fsspec.get_mapper(url), consolidated=consolidated)
+    return XarrayMapper(ds, dim)

--- a/external/loaders/setup.py
+++ b/external/loaders/setup.py
@@ -17,6 +17,7 @@ setup(
         "toolz>=0.10.0",
         "xarray>=0.15.1",
         "zarr>=2.4.0",
+        "joblib>=0.16.0",
         "vcm",
     ],
     dependency_links=["../vcm"],

--- a/external/loaders/tests/test__xarray.py
+++ b/external/loaders/tests/test__xarray.py
@@ -1,9 +1,26 @@
 import doctest
 import loaders.mappers._xarray
+import xarray as xr
+import numpy as np
+import cftime
 
 # ensure that imported path exists
-from loaders.mappers import XarrayMapper  # noqa
+from loaders.mappers import XarrayMapper, open_zarr  # noqa
 
 
 def test_xarray_wrapper_doctests():
     doctest.testmod(loaders.mappers._xarray, raise_on_error=True)
+
+
+def test_open_zarr(tmpdir):
+    time = cftime.DatetimeJulian(2020, 1, 1)
+    time_str = "20200101.000000"
+    ds = xr.Dataset(
+        {"a": (["time", "tile", "z", "y", "x"], np.ones((1, 2, 3, 4, 5)))},
+        coords={"time": [time]},
+    )
+    ds.to_zarr(str(tmpdir), consolidated=True)
+
+    mapper = open_zarr(str(tmpdir))
+    assert isinstance(mapper, XarrayMapper)
+    xr.testing.assert_equal(mapper[time_str], ds.isel(time=0))


### PR DESCRIPTION
zarr is a generic file format that any data can be transformed into.
This general purpose mapper will allow loading new datasets for fv3fit
training without needing to add a bespoke mapper to the source code.

Added public API:
- `loaders.mappers.open_zarr`

Requirement changes:
- `loaders` actually depends on joblib, so I added that to the setup.py

- [x] Tests added


