### PR TITLE
Fix CI build_and_push failure related to auth

### DIFF
--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -11,7 +11,7 @@ then
     CIRCLE_SHA1=$(git rev-parse HEAD)
 fi
 
-apt-get install -y make jq
+sudo apt-get install -y make jq
 make build_image_$IMAGE
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GOOGLE_CREDENTIALS | base64 --decode)" >> $BASH_ENV
       - gcp-gcr/gcr-auth
-      - run: sudo -E .circleci/build_and_push_image.sh
+      - run: .circleci/build_and_push_image.sh
   mypy:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
Switching into the root environment when running `build_and_push_image` was messing with the ability of gcloud to see the credentials invoked by the CircleCI orb.  Potentially due to an update somewhere in our toolchain.

