### PR TITLE
Improve reliability of nudging I/O

### DIFF
--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -1,4 +1,7 @@
 import fv3gfs.util
+from mpi4py import MPI
+import shutil
+import fsspec
 import xarray as xr
 import dataclasses
 import cftime
@@ -109,13 +112,28 @@ def _get_reference_state(
 ):
     label = _time_to_label(time)
     dirname = os.path.join(reference_dir, label)
+
+    localdir = "download"
+
+    if MPI.COMM_WORLD.rank == 0:
+        fs = fsspec.get_fs_token_paths(dirname)[0]
+        fs.get(dirname, localdir, recursive=True)
+
+    # need this for synchronization
+    MPI.COMM_WORLD.barrier()
+
     state = fv3gfs.util.open_restart(
-        dirname,
+        localdir,
         communicator,
         label=label,
         only_names=only_names,
         tracer_properties=tracer_metadata,
     )
+
+    # clean up the local directory
+    if MPI.COMM_WORLD.rank == 0:
+        shutil.rmtree(localdir)
+
     return _to_state_dataarrays(state)
 
 


### PR DESCRIPTION
This pre-downloads all the data for a timestep before calling fv3gfs.util.open_restart.

Resolves #951 