### PR TITLE
Install git in fv3net image

### DIFF
--- a/docker/fv3net/Dockerfile
+++ b/docker/fv3net/Dockerfile
@@ -64,4 +64,6 @@ ENV COMMIT_SHA=$COMMIT_SHA_ARG
 COPY --from=test /tmp/tests-done /tmp
 
 # add development tools
-RUN apt-get install git
+USER root
+RUN apt-get install -y git
+USER $NB_UID


### PR DESCRIPTION
I've been using the fv3net image for data exploration and other work lately,
but it doesn't have git installed, so I cannot checkout the explore repo inside
of it.  Bind-mounts don't really work since the jovyan user doesn't have
permissions to edit files on the host. Besides bind mounts lead to coupling
between the host and docker container. It's much simpler to treat the container as an
isolate universe with 0 interaction with the host.

Here is an example of the docker-compose I am using:
```
# this is only for development purposes and integration with visual studio code
version: '3.4'
services:
  fv3:
    image: us.gcr.io/vcm-ml/fv3net:2d7540fc631e65dcddbc5a4eaaef31f14f208733
    entrypoint: ["bash"]
    command: [-c, "jupyter lab --port 8888"]
    volumes:
      - notebooks:/home/jovyan/work
      - ${HOME}/.ssh:/home/jovyan/.ssh
      - ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/key.json
    environment:
      - GOOGLE_APPLICATION_CREDENTIALS=/tmp/key.json
      - GIT_AUTHOR_NAME="Noah D. Brenowitz"
      - EMAIL="noahb@vulcan.com"
      - FSSPEC_GS_TOKEN=cloud
    working_dir: "/home/jovyan/work"
    ports:
      - "8888:8888"
volumes:
  notebooks:
    external:
      name: explore_notebooks
```

This docker compose propogates my user credentials for ssh and GCP into the container, and uses a volume (that persists) between executions.