### PR TITLE
Update --nudge-to-observations option in e2e config

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -220,7 +220,7 @@ spec:
           - name: reference-restarts
             value: "{{workflow.parameters.reference-restarts}}"
           - name: flags
-            value: "--nudge-to-observations"
+            value: "--nudge-to-observations gs://vcm-ml-data/2019-12-02-year-2016-T85-nudging-data"
           - name: test-times
             value: "{{workflow.parameters.test-times}}"
           - name: public-report-output


### PR DESCRIPTION
Fix end-to-end integration test configuration for change to `prepare_config.py` CLI in #1008 