### PR TITLE
Fix: use PodSpecPatch to set prognostic_diags memory parameters

### DIFF
--- a/workflows/argo/prognostic_run_diags.yaml
+++ b/workflows/argo/prognostic_run_diags.yaml
@@ -138,13 +138,16 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret
-      resources:
-        requests:
-            memory: "{{inputs.parameters.memory}}"
-            cpu: "1000m"
-        limits:
-            memory: "{{inputs.parameters.memory}}"
-            cpu: "1000m"
+    podSpecPatch: |
+      containers:
+        - name: main
+          resources:
+            limits:
+              cpu: "1000m"
+              memory: "{{inputs.parameters.memory}}"
+            requests:
+              cpu: "1000m"
+              memory: "{{inputs.parameters.memory}}"
   - name: movie
     inputs:
       parameters:
@@ -173,10 +176,13 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret
-      resources:
-        requests:
-            memory: "{{inputs.parameters.memory}}"
-            cpu: "8000m"
-        limits:
-            memory: "{{inputs.parameters.memory}}"
-            cpu: "8000m"
+    podSpecPatch: |
+      containers:
+        - name: main
+          resources:
+            limits:
+              cpu: "8000m"
+              memory: "{{inputs.parameters.memory}}"
+            requests:
+              cpu: "8000m"
+              memory: "{{inputs.parameters.memory}}"


### PR DESCRIPTION
Fixes the breaking change in the previous PR #1014 where the string for the memory parameters was unable to be parsed. I don't really understand why `"{{inputs.parameter.*}}"` works for passing parameters in some argo fields but not others, but I changed it to set the memory and cpu with a `podSpecPatch` instead, which is what other workflows with those parameters use.