### PR TITLE
Update catalog for two-year C384 runs

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -550,7 +550,7 @@ sources:
       urlpath: "gs://vcm-ml-code-testing-data/c8-grids-regression-testing/landseamask.zarr/"
       consolidated: true
 
-   free_minus_4K_ssts_c384_fv3gfs_20170801_20190801_physics_output:
+  free_minus_4K_ssts_c384_fv3gfs_20170801_20190801_physics_output:
     description: 2D physics diagnostics variables from two-year free-running C384 FV3GFS simulation with minus 4K SSTs (January 9, 2021)
     driver: zarr
     args:


### PR DESCRIPTION
This PR adds catalog entries for data from the two-year C384 FV3GFS simulations run on Gaea.

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

