### PR TITLE
Fix image pushing on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build_image_prognostic_run:
 		-f docker/prognostic_run/Dockerfile -t $(REGISTRY)/notebook:$(VERSION) \
 		--target notebook .
 
-push_image_prognostic_run:
+push_image_prognostic_run: build_image_prognostic_run
 	docker push $(REGISTRY)/prognostic_run:$(VERSION)
 	docker push $(REGISTRY)/notebook:$(VERSION)
 


### PR DESCRIPTION
The docker images for the prognostic run were not being correctly tagged
before pushing after ce08917. This commit restores this dependency in
the makefile.