### PR TITLE
Specify catalog tag for C384 grid data

### DIFF
--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/load_diagnostic_data.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/load_diagnostic_data.py
@@ -25,7 +25,7 @@ DIM_RENAME_INVERSE_MAP = {
 VARNAME_SUFFIX_TO_REMOVE = ["_coarse"]
 _DIAG_OUTPUT_LOADERS = []
 MASK_VARNAME = "SLMSKsfc"
-GRID_ENTRIES = {48: "grid/c48", 96: "grid/c96"}
+GRID_ENTRIES = {48: "grid/c48", 96: "grid/c96", 384: "grid/c384"}
 
 
 def _adjust_tile_range(ds: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
#1059 added the C384 grid data to the catalog. But I forgot to add the relevant catalog tag to the `GRID_ENTRIES` variable. This PR fixes that issue, so that diagnostics can be computed for C384 runs.