### PR TITLE
Decouple fv3net docker images from fv3gfs-fortran

### DIFF
--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -1,17 +1,96 @@
 # syntax=docker/dockerfile:experimental
-FROM us.gcr.io/vcm-ml/fms-build@sha256:6ac3fee7bbea8213804abd70c15d100b2b81c81c8247990b368d1047aa40289b AS bld
+FROM ubuntu:18.04 as bld
 
-ENV FMS_DIR=/FMS
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
+    apt-get install -y  --no-install-recommends \
+    autoconf \
+    bats \
+    curl \
+    cython3 \
+    g++ \
+    gcc \
+    gfortran \
+    git \
+    libblas-dev \
+    libffi-dev \
+    liblapack-dev \
+    libnetcdf-dev \
+    libnetcdff-dev \
+    libpython3-dev \
+    libtool \
+    libtool-bin \
+    m4 \
+    make  \
+    openssl \
+    perl \
+    pkg-config \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    rsync \
+    wget
+
+RUN wget -q http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz && \
+    tar xzf mpich-3.1.4.tar.gz && \
+    cd mpich-3.1.4 && \
+    ./configure --enable-fortran --enable-cxx --prefix=/usr --enable-fast=all,O3 && \
+    make -j24
+
+
+RUN cd /mpich-3.1.4 && make install && ldconfig
+
+# Install ESMF
+ENV ESMF_DIR=/esmf \
+    ESMF_INSTALL_PREFIX=/usr/local/esmf \
+    ESMF_INSTALL_MODDIR=/usr/local/esmf/include \
+    ESMF_INSTALL_HEADERDIR=/usr/local/esmf/include \
+    ESMF_INSTALL_LIBDIR=/usr/local/esmf/lib \
+    ESMF_INSTALL_BINDIR=/usr/local/esmf/bin \
+    ESMF_NETCDF_INCLUDE=/usr/include \
+    ESMF_NETCDF_LIBS="-lnetcdf -lnetcdff" \
+    ESMF_BOPT=O3
+
+RUN git clone -b ESMF_8_0_0 --depth 1 https://git.code.sf.net/p/esmf/esmf $ESMF_DIR && \
+    cd $ESMF_DIR && \
+    make lib -j24 && \
+    make install && \
+    make installcheck
+
+
+# INSTALL FMS
+ENV CC=/usr/bin/mpicc \
+    FC=/usr/bin/mpif90 \
+    LDFLAGS="-L/usr/lib" \
+    LOG_DRIVER_FLAGS="--comments" \
+    CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500 -DGFS_PHYS" \
+    FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check -fdefault-real-8 -fdefault-double-8 -fopenmp"
+
+COPY external/fv3gfs-fortran/FMS /FMS
+RUN apt-get install -y automake
+RUN cd /FMS && autoreconf --install && ./configure && \
+    cd /FMS && make -j8 && \
+    mv /FMS/*/*.mod /FMS/*/*.o /FMS/*/*.h /FMS/
+
+
+# download and install NCEP libraries
+RUN git config --global http.sslverify false && \
+    git clone https://github.com/NCAR/NCEPlibs.git && \
+    mkdir /opt/NCEPlibs && \
+    cd NCEPlibs && \
+    git checkout 3da51e139d5cd731c9fc27f39d88cb4e1328212b && \
+    echo "y" | ./make_ncep_libs.sh -s linux -c gnu -d /opt/NCEPlibs -o 1
+
+
 ENV ESMF_DIR=/usr/local/esmf
+ENV FMS_DIR=/FMS
 ENV FV3GFS_FORTRAN_DIR=/external/fv3gfs-fortran
 ENV ESMF_INC="-I${ESMF_DIR}/include -I${ESMF_DIR}/mod/modO3/Linux.gfortran.64.mpiuni.default/"
 
 ENV FMS_LIB=${FMS_DIR}/libFMS/.libs/
 ENV ESMF_LIB=${ESMF_DIR}/lib
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ESMF_LIB}:${FMS_LIB}
-
-COPY --from=us.gcr.io/vcm-ml/esmf-build@sha256:981815d85ca19999a585fe3e6430c8cd4fd9efd898ad7b9fa3b391e5ede63cf5 /esmf ${ESMF_DIR}
-COPY --from=us.gcr.io/vcm-ml/esmf-build@sha256:981815d85ca19999a585fe3e6430c8cd4fd9efd898ad7b9fa3b391e5ede63cf5 /esmf/lib/libO3/Linux.gfortran.64.mpiuni.default/*.so* ${ESMF_LIB}/
 
 # build/install the fortran model
 COPY external/fv3gfs-fortran/ /tmp/fortran-build
@@ -23,16 +102,6 @@ RUN cd /tmp/fortran-build/FV3 && \
 #
 # Python Stuff Here
 #
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
-    apt-get install -y  --no-install-recommends \
-    python3 \
-    libpython3-dev \
-    python3-dev \
-    python3-setuptools \
-    python3-pip \
-    cython3
 
 # Python components here
 COPY docker/prognostic_run/requirements/base.txt /tmp/requirements.txt
@@ -48,15 +117,12 @@ RUN pip3 install wheel && \
     ln -s /bin/python3 /bin/python && \
     ln -s /bin/pip3 /bin/pip
 
-# Build the wrapper
-RUN apt-get install -y pkg-config
-COPY /external/fv3gfs-wrapper /fv3gfs-wrapper
-RUN pip3 install jinja2 && make -C /fv3gfs-wrapper/lib
-
-# copy dependency packages
+# fv3gfs-util
 COPY /external/fv3gfs-util /external/fv3gfs-util
 RUN pip3 install /external/fv3gfs-util 
 
+COPY /external/fv3gfs-wrapper /fv3gfs-wrapper
+RUN pip3 install jinja2 && make -C /fv3gfs-wrapper/lib
 
 # cache external package installation
 RUN mkdir -p /fv3net/external /fv3net/workflows && \

--- a/docker/prognostic_run/Dockerfile
+++ b/docker/prognostic_run/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
     apt-get install -y  --no-install-recommends \
     autoconf \
+    automake \
     bats \
     curl \
     cython3 \
@@ -32,55 +33,18 @@ RUN apt-get update && \
     rsync \
     wget
 
-RUN wget -q http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz && \
-    tar xzf mpich-3.1.4.tar.gz && \
-    cd mpich-3.1.4 && \
-    ./configure --enable-fortran --enable-cxx --prefix=/usr --enable-fast=all,O3 && \
-    make -j24
+COPY docker/prognostic_run/scripts/install_mpi.sh install_mpi.sh
+RUN bash install_mpi.sh
 
+COPY docker/prognostic_run/scripts/install_esmf.sh install_esmf.sh
+RUN bash install_esmf.sh /usr/local/esmf
 
-RUN cd /mpich-3.1.4 && make install && ldconfig
-
-# Install ESMF
-ENV ESMF_DIR=/esmf \
-    ESMF_INSTALL_PREFIX=/usr/local/esmf \
-    ESMF_INSTALL_MODDIR=/usr/local/esmf/include \
-    ESMF_INSTALL_HEADERDIR=/usr/local/esmf/include \
-    ESMF_INSTALL_LIBDIR=/usr/local/esmf/lib \
-    ESMF_INSTALL_BINDIR=/usr/local/esmf/bin \
-    ESMF_NETCDF_INCLUDE=/usr/include \
-    ESMF_NETCDF_LIBS="-lnetcdf -lnetcdff" \
-    ESMF_BOPT=O3
-
-RUN git clone -b ESMF_8_0_0 --depth 1 https://git.code.sf.net/p/esmf/esmf $ESMF_DIR && \
-    cd $ESMF_DIR && \
-    make lib -j24 && \
-    make install && \
-    make installcheck
-
-
-# INSTALL FMS
-ENV CC=/usr/bin/mpicc \
-    FC=/usr/bin/mpif90 \
-    LDFLAGS="-L/usr/lib" \
-    LOG_DRIVER_FLAGS="--comments" \
-    CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500 -DGFS_PHYS" \
-    FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check -fdefault-real-8 -fdefault-double-8 -fopenmp"
-
+COPY docker/prognostic_run/scripts/install_fms.sh install_fms.sh
 COPY external/fv3gfs-fortran/FMS /FMS
-RUN apt-get install -y automake
-RUN cd /FMS && autoreconf --install && ./configure && \
-    cd /FMS && make -j8 && \
-    mv /FMS/*/*.mod /FMS/*/*.o /FMS/*/*.h /FMS/
+RUN bash install_fms.sh /FMS
 
-
-# download and install NCEP libraries
-RUN git config --global http.sslverify false && \
-    git clone https://github.com/NCAR/NCEPlibs.git && \
-    mkdir /opt/NCEPlibs && \
-    cd NCEPlibs && \
-    git checkout 3da51e139d5cd731c9fc27f39d88cb4e1328212b && \
-    echo "y" | ./make_ncep_libs.sh -s linux -c gnu -d /opt/NCEPlibs -o 1
+COPY docker/prognostic_run/scripts/install_nceplibs.sh .
+RUN bash install_nceplibs.sh /opt/NCEPlibs
 
 
 ENV ESMF_DIR=/usr/local/esmf

--- a/docker/prognostic_run/scripts/install_esmf.sh
+++ b/docker/prognostic_run/scripts/install_esmf.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+PREFIX="$1"
+
+export ESMF_DIR=/esmf
+export ESMF_INSTALL_PREFIX=$PREFIX
+export ESMF_INSTALL_MODDIR=$PREFIX/include
+export ESMF_INSTALL_HEADERDIR=$PREFIX/include
+export ESMF_INSTALL_LIBDIR=$PREFIX/lib
+export ESMF_INSTALL_BINDIR=$PREFIX/bin
+export ESMF_NETCDF_INCLUDE=/usr/include
+export ESMF_NETCDF_LIBS="-lnetcdf -lnetcdff"
+export ESMF_BOPT=O3
+
+git clone -b ESMF_8_0_0 --depth 1 https://git.code.sf.net/p/esmf/esmf $ESMF_DIR
+cd $ESMF_DIR
+make lib -j24
+make install
+make installcheck

--- a/docker/prognostic_run/scripts/install_fms.sh
+++ b/docker/prognostic_run/scripts/install_fms.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+src="$1"
+
+export CC=/usr/bin/mpicc
+export FC=/usr/bin/mpif90
+export LDFLAGS="-L/usr/lib"
+export LOG_DRIVER_FLAGS="--comments"
+export CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500 -DGFS_PHYS"
+export FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check -fdefault-real-8 -fdefault-double-8 -fopenmp"
+
+cd $src
+autoreconf --install
+./configure
+make -j8
+mv $src/*/*.mod $src/*/*.o $src/*/*.h $src/

--- a/docker/prognostic_run/scripts/install_mpi.sh
+++ b/docker/prognostic_run/scripts/install_mpi.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+wget -q http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz
+tar xzf mpich-3.1.4.tar.gz
+cd mpich-3.1.4
+./configure --enable-fortran --enable-cxx --prefix=/usr --enable-fast=all,O3
+make -j24
+make install && ldconfig

--- a/docker/prognostic_run/scripts/install_nceplibs.sh
+++ b/docker/prognostic_run/scripts/install_nceplibs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+PREFIX="$1"
+
+curl -L https://github.com/NCAR/NCEPlibs/archive/3da51e139d5cd731c9fc27f39d88cb4e1328212b.tar.gz | tar xz
+mkdir -p "$PREFIX"
+cd NCEPlibs-*
+echo "y" | ./make_ncep_libs.sh -s linux -c gnu -d "$PREFIX" -o 1


### PR DESCRIPTION
The prognostic run dockerfile depends on ESMF and MPI from images pushed
from the fv3gfs-fortran repo. This effectively coupled the build systems
of fv3net to fv3gfs-fortran, but this repo has different concerns.
fv3net emphasize modern tools to support experimental ML, while
fv3gfs-fortran empahsize stability in bit-for-bit checksums. As a
consequence, this coupling effectively pinned this repo to ubuntu
version supported by fv3gfs-fortran (18.04), preventing fv3net from
updating to a more recent OS and software like python 3.7 (See #1083).

Building esmf, mpi, and fms in the prognostic run dockerfile effectively
decouples these repos.

The checksums remain unaltered.