### PR TITLE
Online emulator stable encoder

### DIFF
--- a/external/fv3fit/fv3fit/emulation/layers/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/layers/__init__.py
@@ -6,3 +6,5 @@ from .normalization import (
     MeanFeatureStdNormLayer,
     MeanFeatureStdDenormLayer,
 )
+
+from .stable_encoder import mlp, StableDynamics, StableEncoder

--- a/external/fv3fit/fv3fit/emulation/layers/stable_encoder.py
+++ b/external/fv3fit/fv3fit/emulation/layers/stable_encoder.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from math import pi
 from fv3fit.emulation.layers import (
     MeanFeatureStdNormLayer,
     MeanFeatureStdDenormLayer,
@@ -25,9 +24,8 @@ class StableDynamics(tf.keras.layers.Layer):
         )
 
     def call(self, z):
-        phase = tf.minimum(tf.maximum(self.phase, 0.0), 1.0) * 2 * pi
         scale = -tf.nn.relu(self.growth_rate)
-        exponent = tf.complex(scale, phase)
+        exponent = tf.complex(scale, self.phase)
         return tf.exp(exponent) * z
 
 

--- a/external/fv3fit/fv3fit/emulation/layers/stable_encoder.py
+++ b/external/fv3fit/fv3fit/emulation/layers/stable_encoder.py
@@ -1,0 +1,79 @@
+import tensorflow as tf
+from math import pi
+
+
+def mlp(num_hidden, num_layers, num_output):
+    return tf.keras.Sequential(
+        [tf.keras.layers.Dense(num_hidden, activation="relu")] * (num_layers - 1)
+        + [tf.keras.layers.Dense(num_output, activation=None)]
+    )
+
+
+class StableDynamics(tf.keras.layers.Layer):
+    def __init__(self, n: int):
+        super(StableDynamics, self).__init__()
+        self.phase = self.add_weight(
+            "phase", shape=[n], dtype=tf.float32, trainable=True
+        )
+        self.growth_rate = self.add_weight(
+            "growth_rate", shape=[n], dtype=tf.float32, trainable=True
+        )
+
+    def call(self, z):
+        phase = tf.minimum(tf.maximum(self.phase, 0.0), 1.0) * 2 * pi
+        scale = -tf.nn.relu(self.growth_rate)
+        exponent = tf.complex(scale, phase)
+        return tf.exp(exponent) * z
+
+
+class StableEncoder(tf.keras.layers.Layer):
+    """A next-time-step predictor enforcing stable dynamics
+
+    Stability is enforced by assuming that the dynamics are a described by
+    damped oscillators in complex-valued latent space.
+
+    Let x be the prognostic variables, and y the auxiliary variables.
+    
+    Then the next timestep prediction is given by ::
+
+        x_next = g^{-1}(exp(i * phase - growth) g(x, y), y)
+
+
+    """
+
+    def __init__(self):
+        super(StableEncoder, self).__init__()
+        self.num_hidden = 128
+        self.num_layers = 2
+
+    def build(self, input_shape):
+        prog_shape, _ = input_shape
+        num_prognostic = prog_shape[-1]
+
+        # encoder
+        self.encoder_real = mlp(self.num_hidden, self.num_layers, self.num_hidden)
+        self.encoder_complex = mlp(self.num_hidden, self.num_layers, self.num_hidden)
+
+        # dynamics
+        self.dynamics = StableDynamics(self.num_hidden)
+
+        # decoder
+        self.decoder = mlp(self.num_hidden, self.num_layers, num_prognostic)
+
+    def _decode(self, z, auxiliary):
+        stacked = tf.concat([tf.math.real(z), tf.math.imag(z), auxiliary], axis=-1)
+        return self.decoder(stacked)
+
+    def call(self, in_):
+
+        prognostic, auxiliary = in_
+        stacked = tf.concat([prognostic, auxiliary], axis=-1)
+        z = tf.complex(self.encoder_real(stacked), self.encoder_complex(stacked))
+        z_next = self.dynamics(z)
+        prognostic_decoded = self._decode(z, auxiliary)
+        y_prediction = self._decode(z_next, auxiliary)
+
+        # add auto-encoding loss
+        self.add_loss(tf.reduce_mean((prognostic_decoded - prognostic) ** 2))
+
+        return y_prediction

--- a/external/fv3fit/tests/emulation/test_emulator.py
+++ b/external/fv3fit/tests/emulation/test_emulator.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from fv3fit.emulation.thermobasis.batch import to_dict
 from fv3fit.emulation.thermobasis.emulator import (
     Config as Config,
-    Emulator,
+    Trainer as Emulator,
 )
 from fv3fit.emulation.thermobasis.xarray import get_xarray_emulator
 from fv3fit.emulation.thermobasis.xarray import XarrayEmulator

--- a/external/fv3fit/tests/emulation/test_emulator.py
+++ b/external/fv3fit/tests/emulation/test_emulator.py
@@ -5,7 +5,10 @@ from fv3fit.emulation.thermobasis.batch import to_dict
 from fv3fit.emulation.thermobasis.emulator import (
     Config as Config,
     Trainer as Emulator,
+    get_model,
 )
+from fv3fit.emulation.layers import StableEncoder
+from fv3fit.emulation.thermobasis.models import VectorModelAdapter
 from fv3fit.emulation.thermobasis.xarray import get_xarray_emulator
 from fv3fit.emulation.thermobasis.xarray import XarrayEmulator
 
@@ -90,6 +93,18 @@ def test_OnlineEmulator_batch_fit(config, with_validation):
         emulator.batch_fit(dataset, validation_data=dataset)
     else:
         emulator.batch_fit(dataset)
+
+
+def test_get_stable_encoder():
+    config = Config(stable_encoder=True)
+    model = get_model(config)
+    assert isinstance(model, VectorModelAdapter)
+    assert isinstance(model.vector_layer, StableEncoder)
+
+
+def test_args_stable_encoder():
+    config = Config.from_argv(["--stable-encoder", "--multi-output"])
+    assert config.stable_encoder
 
 
 def test_top_level():

--- a/external/fv3fit/tests/emulation/test_layers_stable.py
+++ b/external/fv3fit/tests/emulation/test_layers_stable.py
@@ -1,0 +1,46 @@
+import tensorflow as tf
+from math import pi
+from fv3fit.emulation.layers import StableDynamics, StableEncoder
+import pytest
+
+
+def test_complex_multiplication():
+    out = tf.complex(0.0, pi / 2)
+
+    y = tf.exp(out)
+    assert pytest.approx(0.0, abs=1e-7) == tf.math.real(y).numpy()
+    assert pytest.approx(1.0, abs=1e-7) == tf.math.imag(y).numpy()
+
+
+def to_float(x):
+    return x.numpy().item()
+
+
+def test_StableDynamics_is_contracting():
+    z = tf.ones([1, 10], dtype=tf.dtypes.complex64)
+    dyn = StableDynamics(10)
+
+    def norm(z):
+        return to_float(tf.math.real(tf.reduce_sum(tf.math.conj(z) * z)))
+
+    assert norm(dyn(z)) <= norm(z)
+
+
+def test_StableEncoder_encoder_loss_has_reasonable_magnitude():
+    n = 23
+    x = tf.ones([n, 10])
+    auxiliary = tf.ones([n, 3])
+
+    encoder = StableEncoder()
+    encoder([x, auxiliary])
+    assert 0.1 < sum(encoder.losses) < 10
+
+
+def test_StableEncoder_prediction_has_same_size():
+    n = 23
+    x = tf.ones([n, 10])
+    auxiliary = tf.ones([n, 3])
+
+    encoder = StableEncoder()
+    y = encoder([x, auxiliary])
+    assert x.shape == y.shape

--- a/external/fv3fit/tests/emulation/thermobasis/test_models.py
+++ b/external/fv3fit/tests/emulation/thermobasis/test_models.py
@@ -2,6 +2,7 @@ from fv3fit.emulation.thermobasis.thermo import ThermoBasis
 import numpy as np
 import pytest
 import tensorflow as tf
+from fv3fit.emulation.layers import StableEncoder
 from fv3fit.emulation.thermobasis.loss import QVLossSingleLevel, RHLossSingleLevel
 from fv3fit.emulation.thermobasis.models import (
     RHScalarMLP,
@@ -175,3 +176,10 @@ def test_VectorModelAdapter_output_matches_expected():
     expected = expected_output(x)
     out = model(x)
     assert_relative_humidity_basis_almost_equal(out, expected, rtol=1e-7)
+
+
+def test_VectorModelAdapter_StableEncoder_integration():
+    x = _get_argsin(levels=10, n=3)
+    model = VectorModelAdapter(StableEncoder())
+    model.fit_scalers(x, x)
+    model(x)


### PR DESCRIPTION
Experimenting with stable NN architectures similar to spectral norm, but hopefully not as constricting.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
