### PR TITLE
experiment: add the loss function weighting option to precip model

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -275,8 +275,7 @@ class PrecipitativeModel:
         self._residual_regularizer = (
             hyperparameters.residual_regularizer_config.instance
         )
-        if hyperparameters.weights is None:
-            self.weights: Mapping[str, Union[int, float, np.ndarray]] = {}
+        self.weights = hyperparameters.weights if hyperparameters.weights else {}
 
     def fit_statistics(self, X: xr.Dataset):
         """


### PR DESCRIPTION
Adds the loss function weighting option as implemented in DenseModel to the precip model, which previously had equal weights for dQ1/dQ2/total_precipitation hard coded.