### PR TITLE
Check for existence of wind diags before using them

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_diagnostics.py
@@ -37,9 +37,9 @@ def psi_bias(diags: xr.Dataset) -> xr.DataArray:
 
 @derived_registry.register("mass_streamfunction_300_700_zonal_and_time_mean")
 def psi_value_mid_troposphere(diags: xr.Dataset) -> xr.DataArray:
-    northward_wind = diags["northward_wind_pressure_level_zonal_time_mean"]
     if "northward_wind_pressure_level_zonal_time_mean" not in diags:
         return xr.DataArray()
+    northward_wind = diags["northward_wind_pressure_level_zonal_time_mean"]
     psi = vcm.mass_streamfunction(northward_wind).sel(pressure=slice(30000, 70000))
     psi_mid_trop = psi.weighted(psi.pressure).mean("pressure")
     return psi_mid_trop.assign_attrs(
@@ -49,9 +49,9 @@ def psi_value_mid_troposphere(diags: xr.Dataset) -> xr.DataArray:
 
 @derived_registry.register("mass_streamfunction_300_700_zonal_bias")
 def psi_bias_mid_troposphere(diags: xr.Dataset) -> xr.DataArray:
-    northward_wind_bias = diags["northward_wind_pressure_level_zonal_bias"]
     if "northward_wind_pressure_level_zonal_bias" not in diags:
         return xr.DataArray()
+    northward_wind_bias = diags["northward_wind_pressure_level_zonal_bias"]
     psi = vcm.mass_streamfunction(northward_wind_bias).sel(pressure=slice(30000, 70000))
     psi_mid_trop = psi.weighted(psi.pressure).mean("pressure")
     return psi_mid_trop.assign_attrs(


### PR DESCRIPTION
Fixes bug in `fv3net.diagnostics.prognostic_run.derived_diagnostics` that prevents computing metrics or generating report from diagnostics that do not include time- and zonal-mean northward wind.
