### PR TITLE
emulation: Add L2 regularization to multi-level models

### DIFF
--- a/external/fv3fit/fv3fit/emulation/thermobasis/emulator.py
+++ b/external/fv3fit/fv3fit/emulation/thermobasis/emulator.py
@@ -382,6 +382,7 @@ def get_model(config: Config) -> tf.keras.Model:
             var_level=config.target.level,
             num_hidden=config.num_hidden,
             num_hidden_layers=config.num_hidden_layers,
+            regularizer=regularizer,
         )
     elif isinstance(config.target, RHLossSingleLevel):
         logging.info("Using RHScaler")
@@ -389,6 +390,7 @@ def get_model(config: Config) -> tf.keras.Model:
             var_level=config.target.level,
             num_hidden=config.num_hidden,
             num_hidden_layers=config.num_hidden_layers,
+            regularizer=regularizer,
         )
     else:
         raise NotImplementedError(f"{config}")

--- a/external/fv3fit/fv3fit/emulation/thermobasis/models.py
+++ b/external/fv3fit/fv3fit/emulation/thermobasis/models.py
@@ -22,7 +22,13 @@ def atleast_2d(x: tf.Variable) -> tf.Variable:
 
 
 class ScalarMLP(tf.keras.layers.Layer):
-    def __init__(self, num_hidden=256, num_hidden_layers=1, var_level=0):
+    def __init__(
+        self,
+        num_hidden: int = 256,
+        num_hidden_layers: int = 1,
+        var_level: int = 0,
+        regularizer: Optional[tf.keras.regularizers.Regularizer] = None,
+    ):
         super(ScalarMLP, self).__init__()
         self.scalers_fitted = False
         self.sequential = tf.keras.Sequential()
@@ -38,9 +44,15 @@ class ScalarMLP(tf.keras.layers.Layer):
         self.sequential.add(self.norm)
 
         for _ in range(num_hidden_layers):
-            self.sequential.add(tf.keras.layers.Dense(num_hidden, activation="relu"))
+            self.sequential.add(
+                tf.keras.layers.Dense(
+                    num_hidden, activation="relu", kernel_regularizer=regularizer
+                )
+            )
 
-        self.sequential.add(tf.keras.layers.Dense(1, name="out"))
+        self.sequential.add(
+            tf.keras.layers.Dense(1, name="out", kernel_regularizer=regularizer)
+        )
         self.sequential.add(self.output_scaler)
 
     def call(self, in_: ThermoBasis):


### PR DESCRIPTION
This may help online stability

(cherry picked from commit a59f9b51498afc5ffa9f1bc9bc3f3c09d59adcdf)

- `--l2` flag to `fv3fit.train_emulator` CLI