### PR TITLE
fv3fit: clean up sample dim arg

### DIFF
--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -36,8 +36,6 @@ class DerivedModel(Predictor):
             derived_output_variables
         )
 
-        sample_dim_name = base_model.sample_dim_name
-
         full_input_variables = sorted(
             list(
                 set(
@@ -55,7 +53,7 @@ class DerivedModel(Predictor):
         # DerivedModel.input_variables (what the prognostic run uses to grab
         # necessary state for input to .predict()) is the set of
         # base_model_input_variables arg and hyperparameters.additional_inputs.
-        super().__init__(sample_dim_name, full_input_variables, full_output_variables)
+        super().__init__(full_input_variables, full_output_variables)
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
         self._check_additional_inputs_present(X)
@@ -127,14 +125,8 @@ class EnsembleModel(Predictor):
         self._reduction = reduction
         input_variables: Set[Hashable] = set()
         output_variables: Set[Hashable] = set()
-        sample_dim_name = self._models[0].sample_dim_name
         outputs = set(self._models[0].output_variables)
         for model in self._models:
-            if model.sample_dim_name != sample_dim_name:
-                raise ValueError(
-                    "all models in ensemble must have same sample_dim_name, "
-                    f"got {sample_dim_name} and {model.sample_dim_name}"
-                )
             if set(model.output_variables) != outputs:
                 raise ValueError(
                     "all models in ensemble must have same outputs, "
@@ -143,7 +135,6 @@ class EnsembleModel(Predictor):
             input_variables.update(model.input_variables)
             output_variables.update(model.output_variables)
         super().__init__(
-            sample_dim_name,
             input_variables=tuple(sorted(input_variables)),
             output_variables=tuple(sorted(output_variables)),
         )

--- a/external/fv3fit/fv3fit/_shared/predictor.py
+++ b/external/fv3fit/fv3fit/_shared/predictor.py
@@ -12,8 +12,8 @@ class Predictor(abc.ABC):
     """
     Abstract base class for a predictor object, which has a `predict` method
     that takes in a stacked xarray dataset containing variables defined the class's
-    `input_variables` attribute with the first dimension being the `sample_dim_name`
-    attribute, and returns predictions for the class's `output_variables` attribute.
+    `input_variables` attribute with the first dimension being the sample
+    dimension, and returns predictions for the class's `output_variables` attribute.
     Also implements `load` method. Base class for model classes which implement a
     `fit` method as well, but allows creation of predictor classes to be used in
     (non-training) diagnostic and prognostic settings.
@@ -21,7 +21,6 @@ class Predictor(abc.ABC):
 
     def __init__(
         self,
-        sample_dim_name: str,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
         **kwargs,
@@ -29,7 +28,6 @@ class Predictor(abc.ABC):
         """Initialize the predictor.
         
         Args:
-            sample_dim_name: name of sample dimension
             input_variables: names of input variables
             output_variables: names of output variables
         """
@@ -38,7 +36,6 @@ class Predictor(abc.ABC):
             raise TypeError(
                 f"received unexpected keyword arguments: {tuple(kwargs.keys())}"
             )
-        self.sample_dim_name = sample_dim_name
         self.input_variables = input_variables
         self.output_variables = output_variables
 

--- a/external/fv3fit/fv3fit/_shared/stacking.py
+++ b/external/fv3fit/fv3fit/_shared/stacking.py
@@ -10,13 +10,6 @@ SAMPLE_DIM_NAME = "_fv3fit_sample"
 DATASET_DIM_NAME = "dataset"
 Z_DIM_NAMES = ["z", "pfull"]
 
-"""
-TODO: Remove the optional sample_dim_name arg from functions once the
-stacking sample dim is hard coded and removed as a training function arg.
-The presence in the functions below is temporary and done to allow use
-of an internal stacking dim (allows inputs to be prestacked in "sample" dim)
-"""
-
 
 class StackedBatches(Sequence[xr.Dataset]):
     def __init__(self, batches: Sequence[xr.Dataset], random_state: RandomState):

--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -104,7 +104,6 @@ def train_dense_model(
     validation_batches: Sequence[xr.Dataset],
 ):
     model = DenseModel(
-        "sample",
         hyperparameters.input_variables,
         hyperparameters.output_variables,
         hyperparameters,
@@ -138,7 +137,6 @@ class DenseModel(Predictor):
 
     def __init__(
         self,
-        sample_dim_name: str,
         input_variables: Iterable[str],
         output_variables: Iterable[str],
         hyperparameters: DenseHyperparameters,
@@ -152,8 +150,6 @@ class DenseModel(Predictor):
         of features that are orders of magnitude larger than other features.
 
         Args:
-            sample_dim_name: name of the sample dimension in datasets used as
-                inputs and outputs.
             input_variables: names of input variables
             output_variables: names of output variables
             hyperparameters: configuration of the dense model training
@@ -162,7 +158,7 @@ class DenseModel(Predictor):
         self._hyperparameters = hyperparameters
         self._nonnegative_outputs = hyperparameters.nonnegative_outputs
         # TODO: remove internal sample dim name once sample dim is hardcoded everywhere
-        super().__init__(sample_dim_name, input_variables, output_variables)
+        super().__init__(input_variables, output_variables)
         self._model = None
         self.X_packer = ArrayPacker(
             sample_dim_name=SAMPLE_DIM_NAME, pack_names=input_variables
@@ -375,12 +371,7 @@ class DenseModel(Predictor):
                 config=dacite.Config(strict=True),
             )
 
-            obj = cls(
-                X_packer.sample_dim_name,
-                X_packer.pack_names,
-                y_packer.pack_names,
-                hyperparameters,
-            )
+            obj = cls(X_packer.pack_names, y_packer.pack_names, hyperparameters,)
             obj.X_packer = X_packer
             obj.y_packer = y_packer
             obj.X_scaler = X_scaler

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -251,14 +251,13 @@ class PrecipitativeModel:
         self._loss_type = hyperparameters.loss
         self.output_variables = (T_TENDENCY_NAME, Q_TENDENCY_NAME, PRECIP_NAME)
         self._couple_precip_to_dQ1_dQ2 = hyperparameters.couple_precip_to_dQ1_dQ2
-        self.sample_dim_name = SAMPLE_DIM_NAME
         self.input_variables = input_variables
-        self.input_packer = ArrayPacker(self.sample_dim_name, input_variables)
-        self.humidity_packer = ArrayPacker(self.sample_dim_name, [Q_TENDENCY_NAME])
-        self.output_packer = ArrayPacker(self.sample_dim_name, self.output_variables)
+        self.input_packer = ArrayPacker(SAMPLE_DIM_NAME, input_variables)
+        self.humidity_packer = ArrayPacker(SAMPLE_DIM_NAME, [Q_TENDENCY_NAME])
+        self.output_packer = ArrayPacker(SAMPLE_DIM_NAME, self.output_variables)
         output_without_precip = (T_TENDENCY_NAME, Q_TENDENCY_NAME)
         self.output_without_precip_packer = ArrayPacker(
-            self.sample_dim_name, output_without_precip
+            SAMPLE_DIM_NAME, output_without_precip
         )
         self.input_scaler = LayerStandardScaler()
         self.output_scaler = LayerStandardScaler()
@@ -401,10 +400,9 @@ class PrecipitativeModel:
     @property
     def predictor(self) -> PureKerasModel:
         return PureKerasModel(
-            self.sample_dim_name,
             self.input_variables,
             # predictor has additional diagnostic outputs which were indirectly trained
             list(self.output_variables),
-            get_output_metadata(self.output_packer, self.sample_dim_name),
+            get_output_metadata(self.output_packer, SAMPLE_DIM_NAME),
             self._predict_model,
         )

--- a/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
@@ -23,7 +23,6 @@ class PureKerasModel(Predictor):
 
     def __init__(
         self,
-        sample_dim_name: str,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
         output_metadata: Iterable[Dict[str, Any]],
@@ -32,14 +31,12 @@ class PureKerasModel(Predictor):
         """Initialize the predictor
         
         Args:
-            sample_dim_name: name of sample dimension
             input_variables: names of input variables
             output_variables: names of output variables
             output_metadata: attributes and stacked dimension order for each variable
                 in output_variables
         """
-        super().__init__(sample_dim_name, input_variables, output_variables)
-        self.sample_dim_name = sample_dim_name
+        super().__init__(input_variables, output_variables)
         self.input_variables = input_variables
         self.output_variables = output_variables
         self._output_metadata = output_metadata
@@ -56,7 +53,6 @@ class PureKerasModel(Predictor):
             with open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
                 config = yaml.load(f, Loader=yaml.Loader)
             obj = cls(
-                config["sample_dim_name"],
                 config["input_variables"],
                 config["output_variables"],
                 config.get("output_metadata", None),
@@ -131,7 +127,6 @@ class PureKerasModel(Predictor):
                 f.write(
                     yaml.dump(
                         {
-                            "sample_dim_name": self.sample_dim_name,
                             "input_variables": self.input_variables,
                             "output_variables": self.output_variables,
                             "output_metadata": self._output_metadata,

--- a/external/fv3fit/fv3fit/testing.py
+++ b/external/fv3fit/fv3fit/testing.py
@@ -21,23 +21,17 @@ class ConstantOutputPredictor(Predictor):
     """
 
     def __init__(
-        self,
-        sample_dim_name: str,
-        input_variables: Iterable[Hashable],
-        output_variables: Iterable[Hashable],
+        self, input_variables: Iterable[Hashable], output_variables: Iterable[Hashable],
     ):
         """Initialize the predictor
         
         Args:
-            sample_dim_name: name of sample dimension
             input_variables: names of input variables
             output_variables: names of output variables
         
         """
         super().__init__(
-            sample_dim_name=sample_dim_name,
-            input_variables=input_variables,
-            output_variables=output_variables,
+            input_variables=input_variables, output_variables=output_variables,
         )
         self._outputs: Dict[Hashable, Union[np.ndarray, float]] = {}
 
@@ -83,7 +77,6 @@ class ConstantOutputPredictor(Predictor):
         with open(os.path.join(path, "attrs.yaml"), "w") as f:
             yaml.safe_dump(
                 {
-                    "sample_dim_name": self.sample_dim_name,
                     "input_variables": self.input_variables,
                     "output_variables": self.output_variables,
                 },

--- a/external/fv3fit/tests/test__shared.py
+++ b/external/fv3fit/tests/test__shared.py
@@ -26,7 +26,7 @@ class InOutPredictor(Predictor):
 
     @classmethod
     def create(cls):
-        return cls("sample", cls.input_variables, cls.output_variables)
+        return cls(cls.input_variables, cls.output_variables)
 
     def predict(self, x):
         return x.rename({"in": "out"})
@@ -40,9 +40,8 @@ class InOutPredictor(Predictor):
 
 
 @pytest.mark.parametrize("sample_dims", [("x", "y"), ("y", "x")])
-@pytest.mark.parametrize("sample_dim_name", ["sample", "asdf"])
-def test__Predictor_predict_columnwise_dims_same_order(sample_dims, sample_dim_name):
-    model = IdentityPredictor2D(sample_dim_name, ["a"], ["a"])
+def test__Predictor_predict_columnwise_dims_same_order(sample_dims):
+    model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((3, 4, 5)))})
     ans = model.predict_columnwise(X, sample_dims=sample_dims)
     assert ans.a.dims == ("x", "y", "z")
@@ -58,7 +57,7 @@ def test__Predictor_predict_columnwise_dims_same_order_InOutPredictor(sample_dim
 
 
 def test__Predictor_predict_columnwise_dims_same_order_2d_output():
-    model = IdentityPredictor2D("sample", ["a", "b"], ["b"])
+    model = IdentityPredictor2D(["a", "b"], ["b"])
     X = xr.Dataset(
         {"a": (["x", "y", "z"], np.ones((3, 4, 5))), "b": (["x", "y"], np.ones((3, 4)))}
     )
@@ -67,7 +66,7 @@ def test__Predictor_predict_columnwise_dims_same_order_2d_output():
 
 
 def test__Predictor_predict_columnwise_dims_infers_feature_dim():
-    model = IdentityPredictor2D("sample", ["a"], ["a"])
+    model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((3, 4, 5)))})
     ans = model.predict_columnwise(X, feature_dim=["z"])
     assert ans.a.dims == X.a.dims
@@ -85,7 +84,7 @@ nx, ny, nz = 3, 4, 5
     ],
 )
 def test__Predictor_predict_columnwise_coordinates_same(coords,):
-    model = IdentityPredictor2D("sample", ["a"], ["a"])
+    model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((nx, ny, nz)))}, coords=coords)
     ans = model.predict_columnwise(X, sample_dims=["x", "y"])
     for coord in ans.coords:
@@ -93,7 +92,7 @@ def test__Predictor_predict_columnwise_coordinates_same(coords,):
 
 
 def test__Predictor_predict_columnwise_broadcast_dataset_dim_in_input():
-    model = IdentityPredictor2D("sample", ["a", "b"], ["a"])
+    model = IdentityPredictor2D(["a", "b"], ["a"])
     sample_dims = ("x", "y", DATASET_DIM_NAME)
     X = xr.Dataset(
         {

--- a/external/fv3fit/tests/test_bptt.py
+++ b/external/fv3fit/tests/test_bptt.py
@@ -402,7 +402,6 @@ def test_pure_keras_predict_works_on_format(da):
     input_vars, output_vars = ["input"], ["output"]
     dummy_predictor = DummyPredictor("sample", input_vars, output_vars)
     model = PureKerasModel(
-        "sample",
         input_vars,
         output_vars,
         output_metadata=[

--- a/external/fv3fit/tests/test_constant_predictor.py
+++ b/external/fv3fit/tests/test_constant_predictor.py
@@ -32,9 +32,7 @@ def get_gridded_dataset(nz):
 
 def get_predictor(input_variables, output_variables, outputs):
     predictor = fv3fit.testing.ConstantOutputPredictor(
-        sample_dim_name=SAMPLE_DIM_NAME,
-        input_variables=input_variables,
-        output_variables=output_variables,
+        input_variables=input_variables, output_variables=output_variables,
     )
     predictor.set_outputs(**outputs)
     return predictor

--- a/external/fv3fit/tests/test_ensemble.py
+++ b/external/fv3fit/tests/test_ensemble.py
@@ -3,7 +3,6 @@ import xarray as xr
 import numpy as np
 import pytest
 from fv3fit._shared.models import EnsembleModel
-from fv3fit._shared import SAMPLE_DIM_NAME
 
 
 @pytest.mark.parametrize(
@@ -11,13 +10,10 @@ from fv3fit._shared import SAMPLE_DIM_NAME
     [((0.0, 3.0, 5.0), "median", 3.0), ((0.0, 3.0, 5.0), "mean", 8.0 / 3)],
 )
 def test_ensemble_model_median(values, reduction, output):
-    sample_dim_name = SAMPLE_DIM_NAME
     input_variables = ["input"]
     output_variables = ["output"]
     models = tuple(
-        fv3fit.testing.ConstantOutputPredictor(
-            sample_dim_name, input_variables, output_variables
-        )
+        fv3fit.testing.ConstantOutputPredictor(input_variables, output_variables)
         for _ in values
     )
     for i, m in enumerate(models):

--- a/external/fv3fit/tests/test_models.py
+++ b/external/fv3fit/tests/test_models.py
@@ -34,7 +34,7 @@ def test_DenseModel_jacobian(base_state):
             "b": (["x", "z"], np.arange(10).reshape(2, 5)),
         }
     )
-    model = IdentityModel("sample", ["a"], ["b"], DenseHyperparameters(["a"], ["b"]))
+    model = IdentityModel(["a"], ["b"], DenseHyperparameters(["a"], ["b"]))
     model.fit([batch])
     if base_state == "manual":
         jacobian = model.jacobian(batch[["a"]].isel(x=0))
@@ -65,7 +65,7 @@ def test_nonnegative_model_outputs():
     hyperparameters = DenseHyperparameters(
         ["input"], ["output"], nonnegative_outputs=True
     )
-    model = DenseModel("sample", ["input"], ["output"], hyperparameters,)
+    model = DenseModel(["input"], ["output"], hyperparameters,)
     batch = xr.Dataset(
         {
             "input": (["x"], np.arange(100)),

--- a/external/fv3fit/tests/test_sklearn_wrapper.py
+++ b/external/fv3fit/tests/test_sklearn_wrapper.py
@@ -89,10 +89,7 @@ def _get_sklearn_wrapper(scale_factor=None, dumps_returns: bytes = b"HEY!"):
         scaler = None
 
     wrapper = SklearnWrapper(
-        sample_dim_name="sample",
-        input_variables=["x"],
-        output_variables=["y"],
-        model=model,
+        input_variables=["x"], output_variables=["y"], model=model,
     )
     wrapper.target_scaler = scaler
     return wrapper
@@ -118,10 +115,7 @@ def test_fitting_SklearnWrapper_does_not_fit_scaler():
     scaler = unittest.mock.Mock()
 
     wrapper = SklearnWrapper(
-        sample_dim_name="sample",
-        input_variables=["x"],
-        output_variables=["y"],
-        model=model,
+        input_variables=["x"], output_variables=["y"], model=model,
     )
     wrapper.target_scaler = scaler
 
@@ -143,10 +137,7 @@ def test_SklearnWrapper_serialize_predicts_the_same(tmpdir, scale_factor):
         scaler = None
     model = _RegressorEnsemble(base_regressor=LinearRegression(), n_jobs=1)
     wrapper = SklearnWrapper(
-        sample_dim_name="sample",
-        input_variables=["x"],
-        output_variables=["y"],
-        model=model,
+        input_variables=["x"], output_variables=["y"], model=model,
     )
     wrapper.target_scaler = scaler
 
@@ -166,10 +157,7 @@ def test_SklearnWrapper_serialize_predicts_the_same(tmpdir, scale_factor):
 def test_SklearnWrapper_serialize_fit_after_load(tmpdir):
     model = _RegressorEnsemble(base_regressor=LinearRegression(), n_jobs=1)
     wrapper = SklearnWrapper(
-        sample_dim_name="sample",
-        input_variables=["x"],
-        output_variables=["y"],
-        model=model,
+        input_variables=["x"], output_variables=["y"], model=model,
     )
 
     # setup input data
@@ -195,10 +183,7 @@ def fit_wrapper_with_columnar_data():
         n_jobs=1,
     )
     wrapper = SklearnWrapper(
-        sample_dim_name="sample",
-        input_variables=["a"],
-        output_variables=["b"],
-        model=model,
+        input_variables=["a"], output_variables=["b"], model=model,
     )
 
     dims = ["x", "y", "z"]


### PR DESCRIPTION
This removes the `sample_dim_name` arg from the initialization of most of the models where it was just an internal implementation detail used to stack and unstack data. The one exception to this is in the BPTT `StepwiseModel` where dataset input to `integrate_stepwise` already has a sample dimension which might not match the `fv3fit._shared.SAMPLE_DIM_NAME` used in other models.
