### PR TITLE
Fix doc deployment

### DIFF
--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -18,7 +18,7 @@ if [[ "$CIRCLE_BRANCH" == "master" ]]
 then
     echo "pushing untagged images as 'latest'"
     make push_image_$IMAGE VERSION=latest
-    make deploy_docs_$IMAGE
+    make deploy_docs_$IMAGE VERSION=latest
 fi
 
 if [[ -n "$CIRCLE_TAG" ]]


### PR DESCRIPTION
f3a49e6833df3ac53b0a1efbc84528f1cec39e5c broke the documentation deployment.

This was previously relying the image build invoked at the beginning of the build_and_push_image.sh script.