### PR TITLE
Try to improve caching

### DIFF
--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -12,13 +12,15 @@ then
 fi
 
 apt-get install -y make jq
+make build_image_$IMAGE
+make image_test_$IMAGE
 
 
 if [[ "$CIRCLE_BRANCH" == "master" ]]
 then
     echo "pushing untagged images as 'latest'"
     make push_image_$IMAGE VERSION=latest
-    make deploy_docs_$IMAGE VERSION=latest
+    make deploy_docs_$IMAGE
 fi
 
 if [[ -n "$CIRCLE_TAG" ]]


### PR DESCRIPTION
f3a49e6833df3ac53b0a1efbc84528f1cec39e5c appears to have broken caching on all the docker builds.

Because all the docker builds fail it is probably not the changes to the prognostic run dockerfile. The commit also changed the makefile and circle builds. This suggests the order of tagging/building/pushing docker images is somehow important for cache performance.

After a few hours, I still don't understand what the issues is. This PR reverts most of the makefile and circle ci changes back to feadec25df0b855d1d21a6915c25568f1678f8cb, and then makes a more minimal change to call the prog run tests. I suggest reviewing commit-by-commit.