### PR TITLE
Improve cache use

### DIFF
--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -13,6 +13,7 @@ fi
 
 apt-get install -y make jq
 make build_image_$IMAGE
+make image_test_$IMAGE
 
 
 if [[ "$CIRCLE_BRANCH" == "master" ]]

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,17 @@ push_image_prognostic_run: build_image_prognostic_run
 	docker push $(REGISTRY)/prognostic_run:$(VERSION)
 	docker push $(REGISTRY)/notebook:$(VERSION)
 
+image_test_prognostic_run:
+	docker run \
+		--rm \
+		-v ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/key.json \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/tmp/key.json \
+		-w /fv3net/workflows/prognostic_c48_run \
+		$(REGISTRY)/prognostic_run:$(VERSION) pytest
+
+image_test_%:
+	echo "No tests specified"
+
 push_image_%: build_image_%
 	docker push $(REGISTRY)/$*:$(VERSION)
 


### PR DESCRIPTION
f3a49e6 appears to have broken caching on the fv3net and prognostic run images. The other images (e.g. artifacts) have not had any code updated since f3a49e6, so their caches still work.

Because the issue affects the fv3net image too it is probably not the changes to the prognostic run dockerfile. The commit also changed the makefile and circle builds. This suggests the order of tagging/building/pushing docker images is somehow important for cache performance.

After a few hours, I still don't understand what the issue is so I am shooting from the hip. This PR reverts most of the makefile and circle ci changes back to feadec2, and then makes a more minimal change to call the prog run tests that should be less likely to break things. I suggest reviewing commit-by-commit.

We won't know if this works until this is merged to master.