### PR TITLE
Restore prepare-config CLI

### DIFF
--- a/workflows/prognostic_c48_run/setup.py
+++ b/workflows/prognostic_c48_run/setup.py
@@ -30,5 +30,10 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     extras_require={"docs": ["sphinx >=3.2", "sphinx-rtd-theme>=0.5.0"]},
-    entry_points={"console_scripts": ["runfv3=runtime.segmented_run.cli:cli"]},
+    entry_points={
+        "console_scripts": [
+            "runfv3=runtime.segmented_run.cli:cli",
+            "prepare-config=runtime.segmented_run.prepare_config:main",
+        ]
+    },
 )


### PR DESCRIPTION
I accidentally removed this in 1b14cdee842859ed69ffd59ad3fd4c77a5501323, causing the integration tests to fail.