### PR TITLE
fix integration test

### DIFF
--- a/external/vcm/tests/test_cloud_fsspec.py
+++ b/external/vcm/tests/test_cloud_fsspec.py
@@ -32,7 +32,11 @@ def test_copy(tmpdir, content_type):
 
 @pytest.mark.parametrize(
     "protocol,path,expected",
-    [("gs", "some-path", "gcs://some-path"), ("file", "some-path", "file://some-path")],
+    [
+        ("gs", "some-path", "gs://some-path"),
+        ("file", "some-path", "file://some-path"),
+        ("http", "some-path", "http://some-path"),
+    ],
 )
 def test_to_url(protocol, path, expected):
     assert expected == to_url(fsspec.filesystem(protocol), path)

--- a/external/vcm/vcm/cloud/fsspec.py
+++ b/external/vcm/vcm/cloud/fsspec.py
@@ -40,6 +40,8 @@ def to_url(fs: fsspec.AbstractFileSystem, path: str):
     """
     if isinstance(fs.protocol, str):
         protocol = fs.protocol
+    elif "gs" in fs.protocol:
+        protocol = "gs"
     else:
         protocol = fs.protocol[0]
 


### PR DESCRIPTION
vcm.to_url uses the gcs:// prefix for GCSfs paths, but fv3config requires "gs://".
