### PR TITLE
Add mypy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,28 @@ repos:
       files: "__init__.py"
       # ignore unused import error in __init__.py files
       args: ["--ignore=F401,E203", --config, setup.cfg]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.770
+    hooks:
+    - id: mypy
+      args: [
+          --no-strict-optional,
+          --ignore-missing-imports,
+          --follow-imports, silent  # needed so we only test enabled files
+        ]
+      files: |
+        (?x)^(
+        external/vcm/vcm/.+ |
+        workflows/dataflow/fv3net/pipelines/restarts_to_zarr/.+ |
+        workflows/prognostic_c48_run/.+ |
+        workflows/prognostic_c48_run/tests/.+ |
+        external/fv3fit/fv3fit/.+ |
+        external/loaders/loaders/.+ |
+        workflows/diagnostics/fv3net/diagnostics/offline/.+
+        )$
+      exclude: |
+        (?x)^(
+        .+/conf.py |
+        .+/setup.py |
+        .+/conftest.py
+        )$


### PR DESCRIPTION
I frequently find my PRs fail type checking only after I push them, since mypy checks are currently run outside of pre-commit. We planned a while back to enable this in pre-commit. This PR accomplishes that, with minimal changes to mypy configuration.

Significant internal changes:
- Mypy checks now run as part of pre-commit hooks

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
