### PR TITLE
offline diags: use first timestep from test dataset, not full mapper, in snapshots

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -359,7 +359,8 @@ def main(args):
     mapper = _get_data_mapper_if_exists(config)
     if mapper is not None:
         snapshot_time = (
-            args.snapshot_time or config.kwargs.get("timesteps", list(mapper.keys()))[0]
+            args.snapshot_time
+            or sorted(config.kwargs.get("timesteps", list(mapper.keys())))[0]
         )
         snapshot_key = nearest_time(snapshot_time, list(mapper.keys()))
         ds_snapshot = predict_function(mapper[snapshot_key])


### PR DESCRIPTION
Recent changes inadvertently made the snapshot diagnostics use the first timestep in the available data, instead of the first timestep in the test dataset as specified by the `config.kwargs["timesteps"]`. This PR fixes the snapshots to use the latter.