### PR TITLE
diagnostics manager: only save data the first time `.flush()` called on a timestep

### DIFF
--- a/workflows/prognostic_c48_run/tests/test_diagnostics.py
+++ b/workflows/prognostic_c48_run/tests/test_diagnostics.py
@@ -99,6 +99,24 @@ def test_DiagnosticFile_time_selection():
     sink.sink.assert_called_once()
 
 
+def test_DiagnosticFile_does_not_write_twice():
+    # mock the input data
+    t1 = datetime(year=2016, month=8, day=1, hour=0, minute=15)
+
+    sink = Mock()
+    diag_file = DiagnosticFile(times=TimeContainer([t1]), variables=[], sink=sink)
+    diag_file.observe(t1, {})
+
+    # force flush to disk
+    diag_file.flush()
+    diag_file.flush()
+    sink.sink.assert_called_once()
+
+    # check that garbage collection does not write last time again
+    del diag_file
+    sink.sink.assert_called_once()
+
+
 def test_DiagnosticFile_variable_selection():
 
     data_vars = {"a": (["x"], [1.0]), "b": (["x"], [2.0])}


### PR DESCRIPTION
See issue https://github.com/ai2cm/fv3net/issues/1442

This adds a check to see if `.flush` was already called on a timestep so that it only saves data the first time called.