### PR TITLE
Simplify-prepare-config

### DIFF
--- a/docs/quickstarts.rst
+++ b/docs/quickstarts.rst
@@ -89,6 +89,9 @@ This example submits a "baseline" run of our fv3gfs model run to the Kubernetes 
 
   cat <<"EOF" > test_fv3config.yaml
   base_version: v0.5
+  initial_conditions:
+    base_url: gs://vcm-ml-experiments/2020-06-02-fine-res/coarsen_restarts
+    timestep: "20160805.000000"
   namelist:
     coupler_nml:
       days: 0
@@ -108,8 +111,6 @@ This example submits a "baseline" run of our fv3gfs model run to the Kubernetes 
   argo submit \
       --from workflowtemplate/prognostic-run \
       -p output=gs://vcm-ml-scratch/test-prognostic-run-example \
-      -p reference-restarts=gs://vcm-ml-experiments/2020-06-02-fine-res/coarsen_restarts \
-      -p initial-condition="20160805.000000" \
       -p config="$(cat ./test_fv3config.yaml)"
 
 After the job submits, there will be a read out of the job::
@@ -121,8 +122,6 @@ After the job submits, there will be a read out of the job::
     Created:             Tue Feb 23 00:12:20 +0000 (now)
     Parameters:          
       output:            gs://vcm-ml-scratch/test-prognostic-run-example
-      reference-restarts: gs://vcm-ml-experiments/2020-06-02-fine-res/coarsen_restarts
-      initial-condition: 20160805.000000
       config:            base_version: v0.5
     namelist:
       coupler_nml:

--- a/projects/microphysics/scripts/fv3config.yml
+++ b/projects/microphysics/scripts/fv3config.yml
@@ -106,7 +106,6 @@ namelist:
     days: 10
     dt_atmos: 900
     dt_ocean: 900
-    force_date_from_namelist: true
     hours: 6
     memuse_verbose: true
     minutes: 0

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -2,13 +2,10 @@ import argparse
 import logging
 import os
 import uuid
-from datetime import timedelta
 from pathlib import Path
 from typing import Any
 import dacite
 
-import fv3config
-import pandas as pd
 import wandb
 import yaml
 from runtime.segmented_run import api
@@ -22,7 +19,7 @@ PROJECT = "2021-10-14-microphsyics-emulation-paper"
 BUCKET = "vcm-ml-scratch"
 
 
-def prepare_config(user_config: Any, duration: timedelta, initial_condition: str):
+def prepare_config(user_config: Any, duration: str, initial_condition: str):
     """Create an fv3config object from a ``user_config``
     
     Args:
@@ -30,10 +27,7 @@ def prepare_config(user_config: Any, duration: timedelta, initial_condition: str
         duration: the length of the run
         initial_condition: the path to the initial condition
     """
-    user_config = dacite.from_dict(HighLevelConfig, user_config)
-    user_config.initial_conditions = initial_condition
-    config = user_config.to_fv3config()
-    return fv3config.set_run_duration(config, duration)
+    return user_config.to_fv3config()
 
 
 def get_env(args):
@@ -71,12 +65,9 @@ job = wandb.init(job_type="prognostic_run", project="crapcrap", entity="ai2cm")
 with CONFIG_PATH.open() as f:
     config = yaml.safe_load(f)
 
-config = prepare_config(
-    config,
-    duration=pd.to_timedelta(args.duration).to_pytimedelta(),
-    initial_condition=args.initial_condition,
-)
-
+config = dacite.from_dict(HighLevelConfig, config)
+config.initial_conditions = args.initial_condition
+config.duration = args.duration
 
 url = resolve_url(BUCKET, PROJECT, args.tag)
 env = get_env(args)

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -5,13 +5,14 @@ import uuid
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+import dacite
 
 import fv3config
 import pandas as pd
 import wandb
 import yaml
 from runtime.segmented_run import api
-from runtime.segmented_run.prepare_config import to_fv3config
+from runtime.segmented_run.prepare_config import HighLevelConfig
 
 from fv3net.artifacts.resolve_url import resolve_url
 
@@ -29,9 +30,10 @@ def prepare_config(user_config: Any, duration: timedelta, initial_condition: str
         duration: the length of the run
         initial_condition: the path to the initial condition
     """
-    config = to_fv3config(user_config, nudging_url="")
-    config = fv3config.set_run_duration(config, duration)
-    return fv3config.enable_restart(config, initial_condition)
+    user_config = dacite.from_dict(HighLevelConfig, user_config)
+    user_config.initial_conditions = initial_condition
+    config = user_config.to_fv3config()
+    return fv3config.set_run_duration(config, duration)
 
 
 def get_env(args):

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -19,6 +19,7 @@ spec:
               x_wind: 3
               y_wind: 3
               pressure_thickness_of_atmospheric_layer: 3
+            restarts_path: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
           namelist:
             coupler_nml:
               current_date:

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -5,14 +5,13 @@ metadata:
 spec:
   arguments:
     parameters:
-      - name: initial-condition
-        value: "20160801.001500"
-      - name: reference-restarts
-        value: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
       - name: nudge-to-fine-config
         value: | 
           base_version: v0.6
           forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+          initial_conditions:
+            base_url: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
+            timestep: "20160801.001500"
           nudging:
             timescale_hours:
               air_temperature: 3
@@ -199,6 +198,9 @@ spec:
       - name: prognostic-run-config
         value: |
           base_version: v0.6
+          initial_conditions:
+            base_url: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
+            timestep: "20160801.001500"
           namelist:
             coupler_nml:
               hours: 8
@@ -337,10 +339,6 @@ spec:
           template: prognostic-run
         arguments:
           parameters:
-          - name: reference-restarts
-            value: "{{workflow.parameters.reference-restarts}}"
-          - name: initial-condition
-            value: "{{workflow.parameters.initial-condition}}"
           - name: bucket
             value: "{{workflow.parameters.bucket}}"
           - name: project
@@ -376,12 +374,8 @@ spec:
             value: "{{workflow.parameters.training-data-config}}"
           - name: validation-data-config
             value: "{{workflow.parameters.validation-data-config}}"
-          - name: initial-condition
-            value: "{{workflow.parameters.initial-condition}}"
           - name: prognostic-run-config
             value: "{{workflow.parameters.prognostic-run-config}}"
-          - name: reference-restarts
-            value: "{{workflow.parameters.reference-restarts}}"
           - name: public-report-output
             value: "{{tasks.resolve-output-url.outputs.result}}/offline-report"
           - name: cpu-prog

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -61,9 +61,7 @@ sequential segments.
 
 | Parameter            | Description                                                                   |
 |----------------------|-------------------------------------------------------------------------------|
-| `initial-condition`  | Timestamp string for time at which to begin the prognostic run                |
 | `config`             | String representation of base config YAML file; supplied to prepare-config |
-| `reference-restarts` | Location of restart data for initializing the prognostic run                  |
 | `tag`                | Tag which describes the run and is used in its storage location               | 
 | `flags`              | (optional) Extra command line flags for prepare-config                    |
 | `bucket`             | (optional) Bucket to save run output data; default 'vcm-ml-experiments'       |
@@ -87,8 +85,6 @@ And then calls:
 prepare-config \
         {{inputs.parameters.flags}} \
         {{inputs.parameters.config}} \
-        {{inputs.parameters.reference-restarts}} \
-        {{inputs.parameters.initial-condition}} \
         > /tmp/fv3config.yaml
 ```
 And then
@@ -254,9 +250,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `train-times`           | `times` for `training` workflow                                       |
 | `test-times`            | `times` for `offline-diags` workflow                                  |
 | `public-report-output`  | `report-output` for `offline-diags` workflow                          |
-| `initial-condition`     | `initial-condition` for `prognostic-run` workflow                     |
 | `prognostic-run-config` | `config` for `prognostic-run` workflow                                |
-| `reference-restarts`    | `reference-restarts` for `prognostic-run` workflow                    |
 | `bucket`                | (optional) Bucket to save output data; default 'vcm-ml-experiments'   |
 | `project`               | (optional) Project directory to save output data; default 'default'   |
 | `flags`                 | (optional) `flags` for `prognostic-run` workflow                      |

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -91,7 +91,6 @@ spec:
     - name: prepare-config
       inputs:
         parameters:
-          - name: initial-condition
           - name: config
           - name: flags
       outputs:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -19,9 +19,7 @@ spec:
     - name: prognostic-run
       inputs:
         parameters:
-          - {name: initial-condition}
           - {name: config}
-          - {name: reference-restarts}
           - {name: tag}
           - {name: flags, value: ""}
           - {name: bucket, value: "vcm-ml-experiments"}
@@ -45,9 +43,7 @@ spec:
           template: prepare-config
           arguments:
             parameters:
-              - {name: initial-condition, value: "{{inputs.parameters.initial-condition}}"}
               - {name: config, value: "{{inputs.parameters.config}}"}
-              - {name: reference-restarts, value: "{{inputs.parameters.reference-restarts}}"}
               - {name: flags, value: "{{inputs.parameters.flags}}"}
       - - name: run-model
           continueOn:
@@ -97,7 +93,6 @@ spec:
         parameters:
           - name: initial-condition
           - name: config
-          - name: reference-restarts
           - name: flags
       outputs:
         artifacts:
@@ -118,6 +113,4 @@ spec:
             prepare-config \
               {{inputs.parameters.flags}} \
               config.yaml \
-              {{inputs.parameters.reference-restarts}} \
-              {{inputs.parameters.initial-condition}} \
               > /tmp/fv3config.yaml

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -23,9 +23,7 @@ spec:
       - name: training-configs  # used in withParam
       - name: training-data-config
       - name: validation-data-config
-      - name: initial-condition
       - name: prognostic-run-config
-      - name: reference-restarts
       - name: flags
         value: " "
       - name: public-report-output
@@ -114,12 +112,8 @@ spec:
         dependencies: [train-model, construct-full-flags]
         arguments:
           parameters:
-              - name: initial-condition
-                value: "{{inputs.parameters.initial-condition}}"
               - name: config
                 value: "{{inputs.parameters.prognostic-run-config}}"
-              - name: reference-restarts
-                value: "{{inputs.parameters.reference-restarts}}"
               - name: bucket
                 value: "{{inputs.parameters.bucket}}"
               - name: project

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -56,11 +56,11 @@ class NudgingConfig:
         )
     """
 
+    restarts_path: str
     timescale_hours: Dict[str, float]
     # This should be required, but needs to be typed this way to preserve
     # backwards compatibility with existing yamls that don't specify it.
     # See https://github.com/ai2cm/fv3net/issues/1449
-    restarts_path: Optional[str] = None
     # optional arguments needed for time interpolation
     reference_initial_time: Optional[str] = None
     reference_frequency_seconds: float = 900

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/emulator.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/emulator.yml
@@ -1,4 +1,7 @@
 base_version: v0.5
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
 namelist:
   coupler_nml:
     days: 10 # total length

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -1,4 +1,7 @@
 base_version: v0.5
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
 namelist:
   coupler_nml:
     days: 10

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/nudge_to_fine_config.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/nudge_to_fine_config.yml
@@ -6,6 +6,10 @@ nudging:
     x_wind: 12
     y_wind: 12
     pressure_thickness_of_atmospheric_layer: 12
+  restarts_path: gs://ic-bucket
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
 namelist:
   coupler_nml:
     current_date:

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/nudge_to_obs_config.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/nudge_to_obs_config.yml
@@ -2,6 +2,9 @@ base_version: v0.6
 gfs_analysis_data:
   url: gs://vcm-ml-raw-flexible-retention/2019-12-02-year-2016-T85-nudging-data
   filename_pattern: "%Y%m%d_%HZ_T85LR.nc"
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
 namelist:
   coupler_nml:
     days: 10 

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/prognostic_config.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/prognostic_config.yml
@@ -1,4 +1,7 @@
 base_version: v0.5
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
 namelist:
   coupler_nml:
     days: 10 # total length

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -50,11 +50,11 @@ def test_get_user_config_is_valid():
         ],
     }
 
-    config = prepare_config.user_config_from_dict_and_args(
+    config = prepare_config.to_fv3config(
         dict_, model_url=[], diagnostic_ml=True, nudging_url="gs://some-url",
     )
     # validate using dacite.from_dict
-    dacite.from_dict(UserConfig, dataclasses.asdict(config))
+    dacite.from_dict(UserConfig, config)
 
 
 def test_to_fv3config_initial_conditions():

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -1,15 +1,14 @@
+import dataclasses
+
+import dacite
+import pytest
 from runtime.segmented_run.prepare_config import (
-    to_fv3config,
     HighLevelConfig,
+    UserConfig,
     instantiate_dataclass_from,
 )
-from runtime.segmented_run import prepare_config
-import dacite
-import dataclasses
-from runtime.config import UserConfig
-import pytest
-
 from runtime.diagnostics.fortran import FortranFileConfig
+from runtime.segmented_run import prepare_config
 
 TEST_DATA_DIR = "tests/prepare_config_test_data"
 
@@ -28,11 +27,8 @@ TEST_DATA_DIR = "tests/prepare_config_test_data"
     ],
 )
 def test_prepare_ml_config_regression(regtest, argv):
-    IC_URL = "gs://ic-bucket"
-    IC_TIMESTAMP = "20160805.000000"
-
     parser = prepare_config._create_arg_parser()
-    args = parser.parse_args(argv + [IC_URL, IC_TIMESTAMP])
+    args = parser.parse_args(argv)
     with regtest:
         prepare_config.prepare_config(args)
 
@@ -50,24 +46,9 @@ def test_get_user_config_is_valid():
         ],
     }
 
-    config = prepare_config.to_fv3config(
-        dict_, model_url=[], diagnostic_ml=True, nudging_url="gs://some-url",
-    )
+    config = prepare_config.to_fv3config(dict_, model_url=[], diagnostic_ml=True,)
     # validate using dacite.from_dict
     dacite.from_dict(UserConfig, config)
-
-
-def test_to_fv3config_initial_conditions():
-    my_ic = "my_ic"
-    final = to_fv3config(
-        {"initial_conditions": my_ic, "base_version": "v0.5"},
-        initial_condition=None,
-        model_url=[],
-        diagnostic_ml=True,
-        nudging_url="gs://some-url",
-    )
-
-    assert final["initial_conditions"] == my_ic
 
 
 def test_high_level_config_fortran_diagnostics():

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -77,3 +77,18 @@ def test_instantiate_dataclass_from():
     a = instantiate_dataclass_from(A, b)
     assert a.a == b.a
     assert isinstance(a, A)
+
+
+@pytest.mark.parametrize("duration, expected", [("3h", 10800), ("60s", 60)])
+def test_config_high_level_duration(duration, expected):
+    config = HighLevelConfig(duration=duration)
+    out = config.to_fv3config()
+    assert out["namelist"]["coupler_nml"]["seconds"] == expected
+
+
+def test_config_high_level_duration_respects_namelist():
+    """The high level config should use the namelist options if the duration is
+    not given"""
+    config = HighLevelConfig(namelist={"coupler_nml": {"seconds": 7}})
+    out = config.to_fv3config()
+    assert out["namelist"]["coupler_nml"]["seconds"] == 7


### PR DESCRIPTION
Improvements to the prepare config CLI and API. These are breaking changes

(Delete unused sections)
Added public API:
- config.duration, a more convenient way of specifying run durations.

Refactored public API:
- Removed initial condtions related arguments from `prepare-config` and the argo workflows.