### PR TITLE
fv3fit: dump and load packer config with ArrayPacker

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -279,16 +279,12 @@ class SliceConfig:
         return slice(self.start, self.stop, self.step)
 
 
-ClipConfig = Mapping[Hashable, Mapping[str, SliceConfig]]
-
-
-def _clip_config_factory() -> ClipConfig:
-    return {}
+ClipDims = Mapping[Hashable, Mapping[str, SliceConfig]]
 
 
 @dataclasses.dataclass(frozen=True)
 class PackerConfig:
-    clip: ClipConfig = dataclasses.field(default_factory=_clip_config_factory)
+    clip: ClipDims = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -282,9 +282,13 @@ class SliceConfig:
 ClipConfig = Mapping[Hashable, Mapping[str, SliceConfig]]
 
 
+def _clip_config_factory() -> ClipConfig:
+    return {}
+
+
 @dataclasses.dataclass(frozen=True)
 class PackerConfig:
-    clip: ClipConfig = dataclasses.field(default_factory=dict)
+    clip: ClipConfig = dataclasses.field(default_factory=_clip_config_factory)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -284,7 +284,7 @@ ClipConfig = Mapping[Hashable, Mapping[str, SliceConfig]]
 
 @dataclasses.dataclass(frozen=True)
 class PackerConfig:
-    clip: ClipConfig
+    clip: ClipConfig = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -12,7 +12,7 @@ from typing import (
     Mapping,
 )
 
-from .config import PackerConfig, ClipConfig
+from .config import PackerConfig, ClipDims
 import dacite
 import dataclasses
 import numpy as np
@@ -90,7 +90,7 @@ def tuple_to_multiindex(d: tuple) -> pd.MultiIndex:
 
 
 def clip(
-    data: Union[xr.Dataset, Mapping[Hashable, xr.DataArray]], config: ClipConfig,
+    data: Union[xr.Dataset, Mapping[Hashable, xr.DataArray]], config: ClipDims,
 ) -> Mapping[Hashable, xr.DataArray]:
     clipped_data = {}
     for variable in data:

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -217,7 +217,7 @@ class ArrayPacker:
     @classmethod
     def load(cls, f: TextIO):
         data = yaml.safe_load(f.read())
-        packer_config = dacite.from_dict(PackerConfig, data["packer_config"])
+        packer_config = dacite.from_dict(PackerConfig, data.get("packer_config", {}))
         packer = cls(data["sample_dim_name"], data["pack_names"], packer_config)
         packer._feature_index = tuple_to_multiindex(data["feature_index"])
         packer._n_features = count_features(packer._feature_index)

--- a/external/fv3fit/tests/test_models.py
+++ b/external/fv3fit/tests/test_models.py
@@ -122,10 +122,12 @@ def test_loaded_DenseModel_predicts_with_clipped_inputs(tmpdir):
     arr = np.arange(np.prod(shape)).reshape(shape).astype(float)
     input_data = xr.Dataset({"a": (dims, arr), "b": (dims, arr), "c": (dims, arr + 1)})
     model.fit([input_data])
+    prediction = model.predict(input_data)
     output_path = str(tmpdir.join("trained_model"))
     fv3fit.dump(model, output_path)
     model_loaded = fv3fit.load(output_path)
-    model_loaded.predict(input_data)
+    loaded_prediction = model_loaded.predict(input_data)
+    xr.testing.assert_allclose(prediction, loaded_prediction)
 
 
 def test_DenseModel_raises_not_implemented_error_with_clipped_output_data():

--- a/external/fv3fit/tests/test_models.py
+++ b/external/fv3fit/tests/test_models.py
@@ -7,6 +7,7 @@ import pytest
 from fv3fit.keras._models._sequences import _ThreadedSequencePreLoader
 from fv3fit.keras._models.models import DenseModel, _fill_default
 from fv3fit._shared import PackerConfig, SliceConfig
+import fv3fit
 import tensorflow.keras
 
 
@@ -105,6 +106,26 @@ def test_DenseModel_clipped_inputs():
     prediction_nan_filled = model.predict(slice_filled_input)
 
     xr.testing.assert_allclose(prediction_nan_filled, prediction_clipped, rtol=1e-3)
+
+
+def test_loaded_DenseModel_predicts_with_clipped_inputs(tmpdir):
+    hyperparameters = DenseHyperparameters(
+        ["a", "b"],
+        ["c"],
+        packer_config=PackerConfig({"a": {"z": SliceConfig(None, 3)}}),
+    )
+    model = DenseModel(["a", "b"], ["c"], hyperparameters)
+
+    nz = 5
+    dims = ["x", "y", "z"]
+    shape = (2, 2, nz)
+    arr = np.arange(np.prod(shape)).reshape(shape).astype(float)
+    input_data = xr.Dataset({"a": (dims, arr), "b": (dims, arr), "c": (dims, arr + 1)})
+    model.fit([input_data])
+    output_path = str(tmpdir.join("trained_model"))
+    fv3fit.dump(model, output_path)
+    model_loaded = fv3fit.load(output_path)
+    model_loaded.predict(input_data)
 
 
 def test_DenseModel_raises_not_implemented_error_with_clipped_output_data():

--- a/external/fv3fit/tests/test_packer.py
+++ b/external/fv3fit/tests/test_packer.py
@@ -259,14 +259,18 @@ def test_count_features():
     assert out["c"] == 5
 
 
-def test_array_packer_dump_and_load(tmpdir, dataset):
-    packer = ArrayPacker(SAMPLE_DIM, list(dataset.data_vars))
+def test_array_packer_dump_and_load(tmpdir):
+    dataset = get_dataset(["var1"], [[SAMPLE_DIM, FEATURE_DIM]])
+    packer_config = PackerConfig({"var1": {"z": SliceConfig(None, 2)}})
+    packer = ArrayPacker(SAMPLE_DIM, list(dataset.data_vars), packer_config)
     packer.to_array(dataset)
     with open(str(tmpdir.join("packer.yaml")), "w") as f:
         packer.dump(f)
     with open(str(tmpdir.join("packer.yaml"))) as f:
         loaded_packer = ArrayPacker.load(f)
-    packer._pack_names = loaded_packer._pack_names
-    packer._n_features = loaded_packer._n_features
-    packer._sample_dim_name = loaded_packer._sample_dim_name
-    packer._feature_index = loaded_packer._feature_index
+    assert packer._pack_names == loaded_packer._pack_names
+    assert packer._n_features == loaded_packer._n_features
+    assert packer._sample_dim_name == loaded_packer._sample_dim_name
+    assert packer._config == packer_config
+    for orig, loaded in zip(packer._feature_index, loaded_packer._feature_index):
+        assert orig == loaded


### PR DESCRIPTION
The previous PR #1463  to add the optional PackerConfig hyperparameter to the DenseModel did not test whether the input clipping worked with loaded models, so it missed a bug where loaded ArrayPackers did not clip inputs because they did not dump or load their configs. This PR addresses that issue and adds tests.

- [x] Tests added