### PR TITLE
fv3net: pin setuptools in vcm build

### DIFF
--- a/external/vcm/pyproject.toml
+++ b/external/vcm/pyproject.toml
@@ -1,4 +1,4 @@
 # credit: https://stackoverflow.com/questions/60045913/installing-numpy-before-using-numpy-distutils-core-setup
 [build-system]
 build-backend = "setuptools.build_meta"
-requires=["numpy==1.19.4", "setuptools"]
+requires=["numpy==1.19.4", "setuptools==49.6.0"]


### PR DESCRIPTION
Fixes an unpinned dependency on setuptools in installing vcm. The version used when pip installing vcm is specified in pyproject.toml, and previous unpinned nature allowed upstream failures such as [this](https://github.com/pypa/setuptools/issues/2849) to break the installation.

Requirement changes:
- setuptools pinned in external/vcm/pyoroject.toml to version already pinned in conda environment

