### PR TITLE
offline diags: add column drying versus PW

### DIFF
--- a/external/vcm/vcm/calc/histogram.py
+++ b/external/vcm/vcm/calc/histogram.py
@@ -25,6 +25,8 @@ def histogram(da: xr.DataArray, **kwargs) -> Tuple[xr.DataArray, xr.DataArray]:
         count_da[coord_name].attrs["units"] = da.units
         width_da[coord_name].attrs["units"] = da.units
         width_da.attrs["units"] = da.units
+    if "long_name" in da.attrs:
+        count_da[coord_name].attrs["long_name"] = da.long_name
     return count_da, width_da
 
 
@@ -60,4 +62,5 @@ def histogram2d(
     if "units" in y.attrs:
         ywidth_da[ycoord_name].attrs["units"] = y.units
         ywidth_da.attrs["units"] = y.units
+
     return count_da, xwidth_da, ywidth_da

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -1,9 +1,21 @@
 import xarray as xr
 from typing import Optional
 from dataclasses import dataclass
+import numpy as np
 
 HORIZONTAL_DIMS = ["x", "y", "tile"]
 VERTICAL_DIM = "z"
+PRECIP_RATE = "total_precip_to_surface"
+
+WVP = "water_vapor_path"
+COL_DRYING = "minus_column_integrated_q2"
+COL_MOISTENING = "column_integrated_q2"
+HISTOGRAM_BINS = {
+    PRECIP_RATE: np.logspace(-1, np.log10(500), 101),
+    WVP: np.linspace(-10, 90, 101),
+    COL_DRYING: np.linspace(-10, 90, 101),
+    COL_MOISTENING: np.linspace(-10, 90, 101),
+}
 
 # argument typehint for diags in save_prognostic_run_diags but used
 # by multiple modules split out to group operations and simplify

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
@@ -178,13 +178,13 @@ def _inner_join_time(
     """ Subset times within the prognostic data to be within the verification data,
     as necessary and vice versa, and return the subset datasets
     """
+
     inner_join_time = xr.merge(
         [
             prognostic.time.rename("prognostic_time"),
             verification.time.rename("verification_time"),
         ],
         join="inner",
-        compat="override",
     )
 
     return (

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
@@ -178,13 +178,13 @@ def _inner_join_time(
     """ Subset times within the prognostic data to be within the verification data,
     as necessary and vice versa, and return the subset datasets
     """
-
     inner_join_time = xr.merge(
         [
             prognostic.time.rename("prognostic_time"),
             verification.time.rename("verification_time"),
         ],
         join="inner",
+        compat="override",
     )
 
     return (

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -31,6 +31,8 @@ UNITS = {
     "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface": "[W/m2]",
     "net_shortwave_sfc_flux_derived": "[W/m2]",
     "total_precipitation_rate": "[kg/m2/s]",
+    "water_vapor_path": "[mm]",
+    "minus_column_integrated_q2": "[mm/day]",
 }
 UNITS = {**UNITS, **{f"error_in_{k}": v for k, v in UNITS.items()}}
 UNITS = {**UNITS, **{f"{k}_snapshot": v for k, v in UNITS.items()}}

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -1,13 +1,19 @@
 from fv3net.diagnostics._shared.registry import Registry
 import fv3net.diagnostics._shared.transform as transform
-from fv3net.diagnostics._shared.constants import DiagArg, HORIZONTAL_DIMS
+from fv3net.diagnostics._shared.constants import (
+    DiagArg,
+    HORIZONTAL_DIMS,
+    COL_DRYING,
+    WVP,
+    HISTOGRAM_BINS,
+)
 import logging
 import numpy as np
 import pandas as pd
 from typing import Sequence, Tuple, Dict, Union, Mapping, Optional
 import xarray as xr
 
-from vcm import thermo, safe, weighted_average, local_time
+from vcm import thermo, safe, weighted_average, local_time, histogram, histogram2d
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +27,7 @@ DOMAINS = (
 SURFACE_TYPE = "land_sea_mask"
 SURFACE_TYPE_ENUMERATION = {0.0: "sea", 1.0: "land", 2.0: "sea"}
 DERIVATION_DIM = "derivation"
+COL_MOISTENING = "column_integrated_Q2"
 
 
 def _prepare_diag_dict(suffix: str, ds: xr.Dataset) -> Dict[str, xr.DataArray]:
@@ -245,6 +252,33 @@ def zonal_mean(
         )
     latitude_midpoints = [x.item().mid for x in zm["latitude"]]
     return zm.assign_coords(latitude=latitude_midpoints)
+
+
+def _compute_wvp_vs_q2_histogram(ds: xr.Dataset) -> xr.Dataset:
+    counts = xr.Dataset()
+    col_drying = -ds[COL_MOISTENING].rename(COL_DRYING)
+    col_drying.attrs["units"] = ds[COL_MOISTENING].attrs.get("units")
+    bins = [HISTOGRAM_BINS[WVP], np.linspace(-50, 150, 101)]
+
+    counts, wvp_bins, q2_bins = histogram2d(ds[WVP], col_drying, bins=bins)
+    return xr.Dataset(
+        {
+            f"{WVP}_versus_{COL_DRYING}": counts,
+            f"{WVP}_bin_width": wvp_bins,
+            f"{COL_DRYING}_bin_width": q2_bins,
+        }
+    )
+
+
+def _assign_source_attrs(
+    diagnostics_ds: xr.Dataset, source_ds: xr.Dataset
+) -> xr.Dataset:
+    """Get attrs for each variable in diagnostics_ds from corresponding in source_ds."""
+    for variable in diagnostics_ds:
+        if variable in source_ds:
+            attrs = source_ds[variable].attrs
+            diagnostics_ds[variable] = diagnostics_ds[variable].assign_attrs(attrs)
+    return diagnostics_ds
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -528,3 +562,54 @@ def time_mean(diag_arg):
             dim=pd.Index(["predict", "target"], name=DERIVATION_DIM),
         )
         return ds.mean("time")
+
+
+@diagnostics_registry.register("hist_2d")
+@transform.apply(transform.resample_time, "3H")
+@transform.apply(transform.mask_to_sfc_type, "sea")
+@transform.apply(transform.mask_to_sfc_type, "tropics20")
+def compute_hist_2d(diag_arg: DiagArg):
+    if COL_MOISTENING in diag_arg.prediction and WVP in diag_arg.prediction:
+        logger.info("Computing joint histogram of water vapor path versus Q2")
+        hist = _compute_wvp_vs_q2_histogram(diag_arg.prediction).squeeze()
+        return _assign_source_attrs(hist, diag_arg.prediction)
+    else:
+        return xr.Dataset()
+
+
+@diagnostics_registry.register("hist2d_bias")
+@transform.apply(transform.resample_time, "3H", inner_join=True)
+@transform.apply(transform.mask_to_sfc_type, "sea")
+@transform.apply(transform.mask_to_sfc_type, "tropics20")
+def compute_hist_2d_bias(diag_arg: DiagArg):
+    if COL_MOISTENING in diag_arg.prediction and WVP in diag_arg.prediction:
+        logger.info("Computing bias of joint histogram of water vapor path versus Q2")
+        hist2d_prog = _compute_wvp_vs_q2_histogram(diag_arg.prediction)
+        hist2d_verif = _compute_wvp_vs_q2_histogram(diag_arg.verification)
+        name = f"{WVP}_versus_{COL_DRYING}"
+        error = hist2d_prog[name] - hist2d_verif[name]
+        hist2d_prog.update({name: error})
+        hist = _compute_wvp_vs_q2_histogram(diag_arg.prediction).squeeze()
+        return _assign_source_attrs(hist, diag_arg.prediction)
+    else:
+        return xr.Dataset()
+
+
+@diagnostics_registry.register("histogram")
+@transform.apply(transform.resample_time, "3H", inner_join=True, method="mean")
+@transform.apply(transform.subset_variables, [WVP, COL_MOISTENING])
+def compute_histogram(diag_arg: DiagArg):
+    logger.info("Computing histograms for physics diagnostics")
+    prediction = diag_arg.prediction
+    prediction[COL_DRYING] = -diag_arg.prediction[COL_MOISTENING]
+    prediction[COL_DRYING].attrs["units"] = getattr(
+        diag_arg.prediction[COL_MOISTENING], "units", "mm/day"
+    )
+    counts = xr.Dataset()
+    for varname in prediction.data_vars:
+        count, width = histogram(
+            prediction[varname], bins=HISTOGRAM_BINS[varname.lower()], density=True
+        )
+        counts[varname] = count
+        counts[f"{varname}_bin_width"] = width
+    return _assign_source_attrs(counts, prediction)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -565,7 +565,6 @@ def time_mean(diag_arg):
 
 
 @diagnostics_registry.register("hist_2d")
-@transform.apply(transform.resample_time, "3H")
 @transform.apply(transform.mask_to_sfc_type, "sea")
 @transform.apply(transform.mask_to_sfc_type, "tropics20")
 def compute_hist_2d(diag_arg: DiagArg):
@@ -578,7 +577,6 @@ def compute_hist_2d(diag_arg: DiagArg):
 
 
 @diagnostics_registry.register("hist2d_bias")
-@transform.apply(transform.resample_time, "3H", inner_join=True)
 @transform.apply(transform.mask_to_sfc_type, "sea")
 @transform.apply(transform.mask_to_sfc_type, "tropics20")
 def compute_hist_2d_bias(diag_arg: DiagArg):

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -594,7 +594,6 @@ def compute_hist_2d_bias(diag_arg: DiagArg):
 
 
 @diagnostics_registry.register("histogram")
-@transform.apply(transform.resample_time, "3H", inner_join=True, method="mean")
 @transform.apply(transform.subset_variables, [WVP, COL_MOISTENING])
 def compute_histogram(diag_arg: DiagArg):
     logger.info("Computing histograms for physics diagnostics")

--- a/workflows/diagnostics/fv3net/diagnostics/offline/derived_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/derived_diagnostics.py
@@ -1,0 +1,37 @@
+from typing import Sequence, Tuple
+
+import xarray as xr
+
+import vcm
+
+from fv3net.diagnostics._shared.registry import Registry
+from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
+
+
+def merge_derived(diags: Sequence[Tuple[str, xr.DataArray]]) -> xr.Dataset:
+    out = xr.Dataset()
+    for name, da in diags:
+        if len(da.dims) != 0:
+            # don't add empty DataArrays, which are returned in case of missing inputs
+            out[name] = da
+    return out
+
+
+# all functions added to this registry must take a single xarray Dataset as
+# input and return a single xarray DataArray
+derived_registry = Registry(merge_derived)
+
+
+@derived_registry.register(f"conditional_average_of_{COL_DRYING}_on_{WVP}")
+def conditional_average(diags: xr.Dataset) -> xr.DataArray:
+    count_name = f"{WVP}_versus_{COL_DRYING}_hist_2d"
+    q2_bin_name = f"{COL_DRYING}_bins"
+    q2_bin_widths_name = f"{COL_DRYING}_bin_width_hist_2d"
+    if count_name not in diags:
+        return xr.DataArray()
+    count = diags[count_name]
+    q2_bin_centers = diags[q2_bin_name] + 0.5 * diags[q2_bin_widths_name]
+    average = vcm.weighted_average(q2_bin_centers, count, dims=[q2_bin_name])
+    return average.assign_attrs(
+        long_name="Conditional average of -<Q2> on water vapor path", units="mm/day"
+    )

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -31,13 +31,15 @@ from fv3net.diagnostics.offline.compute import (
 )
 from .plot import (
     get_plot_dataset,
+    plot_histogram,
     plot_profile_var,
     plot_diurnal_cycles,
     plot_zonal_average,
     plot_column_integrated_var,
     plot_generic_data_array,
+    plot_histogram2d,
 )
-
+from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
 
 DOMAIN_DIM = "domain"
 
@@ -296,6 +298,33 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
         }
         metrics_formatted.append((var_r2.replace("_r2", ""), values))
 
+    if "water_vapor_path_versus_minus_column_integrated_q2_hist_2d" in ds_diags:
+        hist2d_wvp_vs_q2 = plot_histogram2d(
+            ds_diags, "water_vapor_path", "minus_column_integrated_q2"
+        )
+        report.insert_report_figure(
+            report_sections,
+            hist2d_wvp_vs_q2,
+            filename=f"hist2d_wvp_vs_q2.png",
+            section_name=f"Water vapor path versus column integrated drying",
+            output_dir=output_dir,
+        )
+        hist_wvp = plot_histogram(ds_diags, f"{WVP}_histogram")
+        report.insert_report_figure(
+            report_sections,
+            hist_wvp,
+            filename=f"hist_wvp.png",
+            section_name=f"Water vapor path versus column integrated drying",
+            output_dir=output_dir,
+        )
+        hist_col_drying = plot_histogram(ds_diags, f"{COL_DRYING}_histogram")
+        report.insert_report_figure(
+            report_sections,
+            hist_col_drying,
+            filename=f"hist_col_drying.png",
+            section_name=f"Water vapor path versus column integrated drying",
+            output_dir=output_dir,
+        )
     return report.create_html(
         sections=report_sections,
         title="ML offline diagnostics",

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -218,7 +218,7 @@ def plot_histogram2d(ds, xname: str, yname: str):
     y_bin_name = f"{yname}_bins"
     x_bin_widths_name = f"{xname.lower()}_bin_width_hist_2d"
     y_bin_widths_name = f"{yname.lower()}_bin_width_hist_2d"
-    fig = plt.figure(figsize=(8, 4))
+    fig = plt.figure(figsize=(12, 6))
 
     for i, source in enumerate(["target", "predict"]):
         ds_ = ds.sel({DERIVATION_DIM_NAME: source})

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -193,7 +193,6 @@ def plot_histogram(ds, varname: str, xscale="linear", yscale="linear"):
     bin_name = varname.replace("histogram", "bins")
     v = ds[varname]
     units = units_from_name(varname.replace("_histogram", ""))
-    print(units, varname.replace("_histogram", ""))
     ax.step(v[bin_name], v, where="post", linewidth=1)
     ax.set_xlabel(f"{getattr(v, 'long_name', v.name)} {units}")
     ax.set_ylabel(f"Frequency {units}^-1")
@@ -233,12 +232,6 @@ def plot_histogram2d(ds, xname: str, yname: str):
 
     x_units = units_from_name(x_bin_widths.name.replace("_bin_width_hist_2d", ""))
     y_units = units_from_name(y_bin_widths.name.replace("_bin_width_hist_2d", ""))
-    print(
-        x_units,
-        y_units,
-        x_bin_widths.name.replace("_bin_width_hist_2d", ""),
-        y_bin_widths.name.replace("_bin_width_hist_2d", ""),
-    )
     ax.set_xlabel(f"{xname} {x_units}")
     ax.set_ylabel(f"{yname} {y_units}")
     ax.set_xlim([xedges[0], xedges[-1]])

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -204,7 +204,6 @@ def plot_histogram(ds, varname: str, xscale="linear", yscale="linear"):
     ax.set_yscale(yscale)
     ax.set_ylim([0, None])
     ax.legend()
-    ax.set_title(source)
     fig.tight_layout()
     return fig
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -30,17 +30,20 @@ import vcm
 
 from fv3net.diagnostics.prognostic_run import load_run_data as load_diags
 from fv3net.diagnostics.prognostic_run import diurnal_cycle
-from fv3net.diagnostics._shared.constants import DiagArg, HORIZONTAL_DIMS
-from .constants import (
+from fv3net.diagnostics._shared.constants import (
+    DiagArg,
+    HORIZONTAL_DIMS,
+    COL_DRYING,
+    WVP,
     HISTOGRAM_BINS,
+)
+from .constants import (
     GLOBAL_AVERAGE_VARS,
     GLOBAL_BIAS_VARS,
     DIURNAL_CYCLE_VARS,
     TIME_MEAN_VARS,
     RMSE_VARS,
     PRESSURE_INTERPOLATED_VARS,
-    COL_DRYING,
-    WVP,
 )
 from fv3net.diagnostics._shared.registry import Registry
 from fv3net.diagnostics._shared import transform

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -1,4 +1,3 @@
-import numpy as np
 from typing import Mapping, Sequence
 
 
@@ -140,12 +139,7 @@ PRESSURE_INTERPOLATED_VARS = [
 
 PRECIP_RATE = "total_precip_to_surface"
 MASS_STREAMFUNCTION_MID_TROPOSPHERE = "mass_streamfunction_300_700_zonal_and_time_mean"
-WVP = "water_vapor_path"
-COL_DRYING = "minus_column_integrated_q2"
-HISTOGRAM_BINS = {
-    PRECIP_RATE: np.logspace(-1, np.log10(500), 101),
-    WVP: np.linspace(-10, 90, 101),
-}
+
 PERCENTILES = [25, 50, 75, 90, 99, 99.9]
 TOP_LEVEL_METRICS = {
     "rmse_5day": ["h500", "tmp850"],

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_diagnostics.py
@@ -5,7 +5,7 @@ import xarray as xr
 import vcm
 
 from fv3net.diagnostics._shared.registry import Registry
-from .constants import WVP, COL_DRYING
+from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
 
 
 def merge_derived(diags: Sequence[Tuple[str, xr.DataArray]]) -> xr.Dataset:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -27,9 +27,8 @@ from fv3net.diagnostics.prognostic_run.constants import (
     PRECIP_RATE,
     TOP_LEVEL_METRICS,
     MovieUrls,
-    WVP,
-    COL_DRYING,
 )
+from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
 
 import logging
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -12,6 +12,7 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     RunDiagnostics,
     RunMetrics,
 )
+
 import vcm
 from report import create_html, Link, OrderedList, RawHTML
 from report.holoviews import HVPlot, get_html_header
@@ -64,11 +65,15 @@ def upload(html: str, url: str, content_type: str = "text/html"):
 
 class PlotManager:
     """An object for managing lists of plots in an extensible way
+
     New plotting functions can be registered using the ``register`` method.
+
     All plotting functions registered by the object will be called in sequence on
     the data passed to `make_plots``.
+
     We could extend this class in the future to have even more features
     (e.g. parallel plot generation, exception handling, etc)
+
     """
 
     def __init__(self):
@@ -76,6 +81,7 @@ class PlotManager:
 
     def register(self, func):
         """Register a given function as a diagnostic
+
         This can be used to generate a new set of plots to appear the html reports
         """
         self._diags.append(func)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -12,7 +12,6 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     RunDiagnostics,
     RunMetrics,
 )
-
 import vcm
 from report import create_html, Link, OrderedList, RawHTML
 from report.holoviews import HVPlot, get_html_header
@@ -65,15 +64,11 @@ def upload(html: str, url: str, content_type: str = "text/html"):
 
 class PlotManager:
     """An object for managing lists of plots in an extensible way
-
     New plotting functions can be registered using the ``register`` method.
-
     All plotting functions registered by the object will be called in sequence on
     the data passed to `make_plots``.
-
     We could extend this class in the future to have even more features
     (e.g. parallel plot generation, exception handling, etc)
-
     """
 
     def __init__(self):
@@ -81,7 +76,6 @@ class PlotManager:
 
     def register(self, func):
         """Register a given function as a diagnostic
-
         This can be used to generate a new set of plots to appear the html reports
         """
         self._diags.append(func)


### PR DESCRIPTION
This adds histograms of water vapor path and column drying as well as their 2D histogram to the offline report.

I do recognize the `create_report` script is getting really long and needs a refactor to use a registry, which I'll do at a later time, but I wanted to get these figures into the report since they were added to the prognostic report recently.

The diagnostics functions and plotting functions are basically copies of the prognostic run versions that were added in PR #1452 , but with some small adjustments to account for the fact that current ML prediction data in the offline diags is often missing units that need to be filled in with the helper function.

example at bottom of index: https://storage.googleapis.com/vcm-ml-public/annak/2021-10-28/offline-diags-7/index.html
