### PR TITLE
Prognostic run: allow multiple prescribe sources

### DIFF
--- a/workflows/prognostic_c48_run/runtime/__init__.py
+++ b/workflows/prognostic_c48_run/runtime/__init__.py
@@ -21,7 +21,6 @@ from .nudging import (
     nudging_timescales_from_dict,
     setup_get_reference_state,
     get_nudging_tendency,
-    get_reference_surface_temperatures,
 )
 
 __version__ = "0.1.0"

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -31,8 +31,6 @@ FV3CONFIG_KEYS = {
     "gfs_analysis_data",
 }
 
-PrephysicsConfig = List[Union[PrescriberConfig, MachineLearningConfig]]
-
 
 @dataclasses.dataclass
 class UserConfig:
@@ -77,7 +75,6 @@ def get_config() -> UserConfig:
     """
     with open("fv3config.yml") as f:
         config = yaml.safe_load(f)
-    config = _standardize_prephysics_config(config)
 
     runtime_config = {key: config[key] for key in config if key not in FV3CONFIG_KEYS}
     return dacite.from_dict(UserConfig, runtime_config, dacite.Config(strict=True))
@@ -100,16 +97,3 @@ def write_chunks(config: UserConfig):
     chunks = get_chunks(diagnostic_file_configs)
     with open("chunks.yaml", "w") as f:
         yaml.safe_dump(chunks, f)
-
-
-def _standardize_prephysics_config(config) -> PrephysicsConfig:
-    # allows for backwards compatibility for old config format where
-    # only a single entry for prephysics was allowed
-    if "prephysics" not in config:
-        return config
-    elif isinstance(config["prephysics"], List):
-        return config
-    else:
-        raw_prephysics_config = config["prephysics"]
-        config["prephysics"] = [raw_prephysics_config]
-        return config

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -41,7 +41,10 @@ class UserConfig:
         fortran_diagnostics: list of Fortran diagnostic file configurations
         prephysics: optional configuration of computations prior to physics,
             specified by either a machine learning configuation or a prescriber
-            configuration
+            configuration. If quantity is in runtime.names.PREPHYSICS_OVERRIDES,
+            it will be applied during prephysics step, all others will be updated
+            postphysics (yes, this contradicts the name of the config class,
+            there is a github issue open to address this).
         scikit_learn: a machine learning configuration
         nudging: nudge2fine configuration. Cannot be used if any scikit_learn model
             urls are specified.

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -31,6 +31,8 @@ FV3CONFIG_KEYS = {
     "gfs_analysis_data",
 }
 
+PrephysicsConfig = List[Union[PrescriberConfig, MachineLearningConfig]]
+
 
 @dataclasses.dataclass
 class UserConfig:
@@ -52,7 +54,7 @@ class UserConfig:
     fortran_diagnostics: List[FortranFileConfig] = dataclasses.field(
         default_factory=list
     )
-    prephysics: Optional[Union[PrescriberConfig, MachineLearningConfig]] = None
+    prephysics: Optional[List[Union[PrescriberConfig, MachineLearningConfig]]] = None
     scikit_learn: Optional[MachineLearningConfig] = None
     nudging: Optional[NudgingConfig] = None
     tendency_prescriber: Optional[TendencyPrescriberConfig] = None
@@ -75,6 +77,8 @@ def get_config() -> UserConfig:
     """
     with open("fv3config.yml") as f:
         config = yaml.safe_load(f)
+    config = _standardize_prephysics_config(config)
+
     runtime_config = {key: config[key] for key in config if key not in FV3CONFIG_KEYS}
     return dacite.from_dict(UserConfig, runtime_config, dacite.Config(strict=True))
 
@@ -96,3 +100,16 @@ def write_chunks(config: UserConfig):
     chunks = get_chunks(diagnostic_file_configs)
     with open("chunks.yaml", "w") as f:
         yaml.safe_dump(chunks, f)
+
+
+def _standardize_prephysics_config(config) -> PrephysicsConfig:
+    # allows for backwards compatibility for old config format where
+    # only a single entry for prephysics was allowed
+    if "prephysics" not in config:
+        return config
+    elif isinstance(config["prephysics"], List):
+        return config
+    else:
+        raw_prephysics_config = config["prephysics"]
+        config["prephysics"] = [raw_prephysics_config]
+        return config

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -375,6 +375,7 @@ class TimeLoop(
             "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface",
             "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface",
             "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",
+            "ocean_surface_temperature",
         ]
         state_updates = {
             k: v for k, v in self._state_updates.items() if k in prephysics_overrides

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -456,7 +456,7 @@ class TimeLoop(
                     self._state[TOTAL_PRECIP], net_moistening, self._timestep,
                 )
                 self._state.update_mass_conserving(updated_state_from_tendency)
-                self._state.update_mass_conserving(self._state_updates)
+        self._state.update_mass_conserving(self._state_updates)
 
         diagnostics.update({name: self._state[name] for name in self._states_to_output})
         diagnostics.update(

--- a/workflows/prognostic_c48_run/runtime/names.py
+++ b/workflows/prognostic_c48_run/runtime/names.py
@@ -30,6 +30,12 @@ TENDENCY_TO_STATE_NAME: Mapping[Hashable, Hashable] = {
     "dQp": DELP,
 }
 STATE_NAME_TO_TENDENCY = {value: key for key, value in TENDENCY_TO_STATE_NAME.items()}
+PREPHYSICS_OVERRIDES = [
+    "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface",
+    "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface",
+    "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",
+    "ocean_surface_temperature",
+]
 
 
 def is_state_update_variable(key, state: State):

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -19,7 +19,7 @@ from typing import (
     Optional,
 )
 import logging
-from .names import SST, TSFC, MASK, STATE_NAME_TO_TENDENCY
+from .names import STATE_NAME_TO_TENDENCY
 
 logger = logging.getLogger(__name__)
 
@@ -236,28 +236,3 @@ def get_nudging_tendency(
         )
         return_dict[STATE_NAME_TO_TENDENCY[name]] = return_data
     return return_dict
-
-
-def get_reference_surface_temperatures(state: State, reference: State) -> State:
-    """
-    Set the sea surface and surface temperatures in a model state to values in
-    a reference state. Useful for maintaining consistency between a nudged run
-    and reference state.
-    """
-    state = {
-        SST: _sst_from_reference(reference[TSFC], state[SST], state[MASK]),
-        TSFC: _sst_from_reference(reference[TSFC], state[TSFC], state[MASK]),
-    }
-    return state
-
-
-def _sst_from_reference(
-    reference_surface_temperature: xr.DataArray,
-    surface_temperature: xr.DataArray,
-    land_sea_mask: xr.DataArray,
-) -> xr.DataArray:
-    return xr.where(
-        land_sea_mask.values.round().astype("int") == 0,
-        reference_surface_temperature,
-        surface_temperature,
-    ).assign_attrs(units=surface_temperature.units)

--- a/workflows/prognostic_c48_run/runtime/steppers/combine.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/combine.py
@@ -1,0 +1,53 @@
+from collections import Counter
+from typing import Optional, List, Union, MutableMapping, Hashable
+import xarray as xr
+
+from runtime.steppers.machine_learning import PureMLStepper
+from runtime.steppers.prescriber import Prescriber
+
+
+def _merge_outputs(
+    outputs: List[MutableMapping[Hashable, xr.DataArray]]
+) -> MutableMapping[Hashable, xr.DataArray]:
+    return {k: v for d in outputs for k, v in d.items()}
+
+
+class CombinedStepper:
+    def __init__(self, steppers: Optional[List[Union[Prescriber, PureMLStepper]]]):
+        self._steppers = steppers
+        # have to call the steppers first before checking if they collide
+        self._verified_no_collisions = False
+
+    def __call__(self, time, state):
+        tendencies, diagnostics, state_updates = [], [], []
+        for stepper in self._steppers:
+            t, d, s = stepper(time, state)
+            tendencies.append(t)
+            diagnostics.append(d)
+            state_updates.append(s)
+        if self._verified_no_collisions is False:
+            for outputs in [tendencies, diagnostics, state_updates]:
+                self._check_for_collisions(outputs)
+        return (
+            _merge_outputs(tendencies),
+            _merge_outputs(diagnostics),
+            _merge_outputs(state_updates),
+        )
+
+    def _check_for_collisions(
+        self, outputs: List[MutableMapping[Hashable, xr.DataArray]]
+    ):
+        output_keys = [list(output) for output in outputs]
+        all_keys: List = sum(output_keys, [])
+        key_counts = Counter(all_keys)
+        collisions = []
+        for key, count in key_counts.items():
+            if count > 1:
+                collisions.append(key)
+        if len(collisions) > 0:
+            raise ValueError(
+                "Steppers configured in prephysics state updates have overlapping "
+                f"update keys: {collisions}"
+            )
+        else:
+            self._verified_no_collisions = True

--- a/workflows/prognostic_c48_run/runtime/steppers/combine.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/combine.py
@@ -26,6 +26,8 @@ def _check_for_collisions(outputs: List[MutableMapping[Hashable, xr.DataArray]])
 
 
 class CombinedStepper:
+    label = "combined"
+
     def __init__(self, steppers: List[Union[Prescriber, PureMLStepper]]):
         if len(steppers) == 0:
             raise ValueError("No steppers provided to combine.")

--- a/workflows/prognostic_c48_run/runtime/steppers/combine.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/combine.py
@@ -1,9 +1,10 @@
 from collections import Counter
-from typing import Optional, List, Union, MutableMapping, Hashable
+from typing import List, Union, MutableMapping, Hashable, Tuple
 import xarray as xr
 
 from runtime.steppers.machine_learning import PureMLStepper
 from runtime.steppers.prescriber import Prescriber
+from runtime.types import Diagnostics
 
 
 def _merge_outputs(
@@ -12,8 +13,22 @@ def _merge_outputs(
     return {k: v for d in outputs for k, v in d.items()}
 
 
+def _check_for_collisions(outputs: List[MutableMapping[Hashable, xr.DataArray]]):
+    output_keys = [list(output) for output in outputs]
+    all_keys: List = sum(output_keys, [])
+    key_counts = Counter(all_keys)
+    collisions = []
+    for key, count in key_counts.items():
+        if count > 1:
+            collisions.append(key)
+    if len(collisions) > 0:
+        raise ValueError(f"Outputs have overlapping update keys: {collisions}")
+
+
 class CombinedStepper:
-    def __init__(self, steppers: Optional[List[Union[Prescriber, PureMLStepper]]]):
+    def __init__(self, steppers: List[Union[Prescriber, PureMLStepper]]):
+        if len(steppers) == 0:
+            raise ValueError("No steppers provided to combine.")
         self._steppers = steppers
         # have to call the steppers first before checking if they collide
         self._verified_no_collisions = False
@@ -27,27 +42,40 @@ class CombinedStepper:
             state_updates.append(s)
         if self._verified_no_collisions is False:
             for outputs in [tendencies, diagnostics, state_updates]:
-                self._check_for_collisions(outputs)
+                _check_for_collisions(outputs)
+                self._verified_no_collisions = True
         return (
             _merge_outputs(tendencies),
             _merge_outputs(diagnostics),
             _merge_outputs(state_updates),
         )
 
-    def _check_for_collisions(
-        self, outputs: List[MutableMapping[Hashable, xr.DataArray]]
-    ):
-        output_keys = [list(output) for output in outputs]
-        all_keys: List = sum(output_keys, [])
-        key_counts = Counter(all_keys)
-        collisions = []
-        for key, count in key_counts.items():
-            if count > 1:
-                collisions.append(key)
-        if len(collisions) > 0:
-            raise ValueError(
-                "Steppers configured in prephysics state updates have overlapping "
-                f"update keys: {collisions}"
+    def get_diagnostics(self, state, tendency) -> Tuple[Diagnostics, xr.DataArray]:
+        """Return diagnostics mapping and net moistening array."""
+        diags, net_moistening = [], []
+        for stepper in self._steppers:
+            stepper_diags, stepper_net_moistening = stepper.get_diagnostics(
+                state, tendency
             )
+            diags.append(stepper_diags)
+            if len(stepper_net_moistening.sizes) > 0:
+                net_moistening.append(stepper_net_moistening)
+        if len(net_moistening) == 0:
+            moistening_diag = xr.DataArray()
+        elif len(net_moistening) == 1:
+            moistening_diag = net_moistening[0]
         else:
-            self._verified_no_collisions = True
+            raise ValueError(
+                "More than one stepper outputs a net moistening diagnostic. "
+                "Only one stepper should be providing this diag."
+            )
+        _check_for_collisions(diags)
+        return _merge_outputs(diags), moistening_diag
+
+    def get_momentum_diagnostics(self, state, tendency) -> Diagnostics:
+        """Return diagnostics of momentum tendencies."""
+        momentum_diags = []
+        for stepper in self._steppers:
+            momentum_diags.append(stepper.get_momentum_diagnostics(state, tendency))
+        _check_for_collisions(momentum_diags)
+        return _merge_outputs(momentum_diags)

--- a/workflows/prognostic_c48_run/runtime/steppers/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/nudging.py
@@ -5,12 +5,12 @@ import fv3gfs.wrapper
 from runtime.nudging import (
     NudgingConfig,
     get_nudging_tendency,
-    get_reference_surface_temperatures,
     nudging_timescales_from_dict,
     setup_get_reference_state,
 )
 from runtime.diagnostics import compute_diagnostics
 from runtime.names import SST, TSFC
+from .prescriber import get_reference_surface_temperatures
 
 
 class PureNudger:

--- a/workflows/prognostic_c48_run/runtime/steppers/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/nudging.py
@@ -10,7 +10,7 @@ from runtime.nudging import (
 )
 from runtime.diagnostics import compute_diagnostics
 from runtime.names import SST, TSFC
-from .prescriber import get_reference_surface_temperatures
+from .prescriber import sst_update_from_reference
 
 
 class PureNudger:
@@ -47,13 +47,13 @@ class PureNudger:
     def __call__(self, time, state):
         reference = self._get_reference_state(time)
         tendencies = get_nudging_tendency(state, reference, self._nudging_timescales)
-        ssts = get_reference_surface_temperatures(state, reference)
+        state_updates = sst_update_from_reference(state, reference)
 
         reference = {
             f"{key}_reference": reference_state
             for key, reference_state in reference.items()
         }
-        return tendencies, reference, ssts
+        return tendencies, reference, state_updates
 
     def get_diagnostics(self, state, tendency):
         diags = compute_diagnostics(state, tendency, self.label, self.hydrostatic)

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -136,7 +136,7 @@ class Prescriber:
                 # "ocean_surface_temperature". If "surface_temperature" is
                 # the prescribed variable, all points will be updated.
                 state_updates.update(
-                    sst_update_from_reference(prescribed_timestep, state, SST)
+                    sst_update_from_reference(state, prescribed_timestep, SST)
                 )
             else:
                 state_updates[name] = prescribed_timestep[name]

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -133,8 +133,7 @@ class Prescriber:
             if name == SST:
                 # If just the sea surface temperature is to be updated
                 # (and not land as well), the prescribed dataarray should be
-                # "ocean_surface_temperature". If "surface_temperature" is
-                # the prescribed variable, all points will be updated.
+                # "ocean_surface_temperature".
                 state_updates.update(
                     sst_update_from_reference(state, prescribed_timestep, SST)
                 )

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -131,8 +131,8 @@ class Prescriber:
         state_updates: State = {}
         for name in prescribed_timestep.data_vars:
             if name == SST:
-                # this assumes that if only the sea surface temperature is to
-                # be updated and not land as well, the prescribed dataarray should be
+                # If just the sea surface temperature is to be updated
+                # (and not land as well), the prescribed dataarray should be
                 # "ocean_surface_temperature". If "surface_temperature" is
                 # the prescribed variable, all points will be updated.
                 state_updates.update(

--- a/workflows/prognostic_c48_run/tests/test_combined_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_combined_stepper.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+import xarray as xr
+from runtime.steppers.combine import CombinedStepper
+
+
+class MockStepper:
+    def __init__(self, output_tendencies, output_diags, output_state_updates):
+        self.output_tendencies = output_tendencies
+        self.output_diags = output_diags
+        self.output_state_updates = output_state_updates
+
+    def __call__(self, time, state):
+        return self.output_tendencies, self.output_diags, self.output_state_updates
+
+
+da = xr.DataArray(np.array([0.0, 1.0, 2.0]), dims=["x"], attrs={"units": None})
+
+
+@pytest.mark.parametrize(
+    "stepper0_outputs, stepper1_outputs, passes",
+    [
+        pytest.param(
+            ({"t0": da}, {"d0": da}, {}),
+            ({"t1": da}, {"d1": da}, {}),
+            True,
+            id="no_overlap",
+        ),
+        pytest.param(
+            ({}, {}, {}), ({"t1": da}, {"d1": da}, {}), True, id="one_empty_output"
+        ),
+        pytest.param(
+            ({"t0": da}, {"d1": da}, {}),
+            ({"t1": da}, {"d1": da}, {}),
+            False,
+            id="one_collision",
+        ),
+    ],
+)
+def test_CombinedStepper_raises_error_on_collision(
+    stepper0_outputs, stepper1_outputs, passes
+):
+    stepper0 = MockStepper(*stepper0_outputs)
+    stepper1 = MockStepper(*stepper1_outputs)
+    combined_stepper = CombinedStepper([stepper0, stepper1])
+    if passes:
+        assert combined_stepper._verified_no_collisions is False
+        combined_stepper(0, 0)
+        assert combined_stepper._verified_no_collisions is True
+    else:
+        with pytest.raises(ValueError):
+            combined_stepper(0, 0)
+
+
+@pytest.mark.parametrize(
+    "stepper_outputs, expected_outputs, passes",
+    [
+        pytest.param(
+            [
+                ({"t0": da}, {"d0": da}, {"s0": da}),
+                ({"t1": da + 1.0}, {"d1": da + 1.0}, {}),
+            ],
+            ({"t0": da, "t1": da + 1.0}, {"d0": da, "d1": da + 1.0}, {"s0": da}),
+            True,
+            id="combine_2",
+        ),
+        pytest.param(
+            [
+                ({"t0": da}, {"d0": da}, {"s0": da}),
+                ({"t1": da + 1.0}, {"d1": da + 1.0}, {}),
+                ({}, {}, {"s2": da + 2.0}),
+            ],
+            (
+                {"t0": da, "t1": da + 1.0},
+                {"d0": da, "d1": da + 1.0},
+                {"s0": da, "s2": da + 2.0},
+            ),
+            True,
+            id="combine_3",
+        ),
+        pytest.param(
+            [
+                ({"t0": da}, {"d0": da}, {"s0": da}),
+                ({"t1": da + 1.0}, {"d1": da + 1.0}, {}),
+                ({}, {}, {"s0": da + 2.0}),
+            ],
+            (),
+            False,
+            id="fail_on_collision",
+        ),
+    ],
+)
+def test_CombinedStepper_merged_output(stepper_outputs, expected_outputs, passes):
+    steppers = [MockStepper(*outputs) for outputs in stepper_outputs]
+    combined_stepper = CombinedStepper(steppers)
+    if passes:
+        combined_outputs = combined_stepper(0, 0)
+        for combined, expected in zip(combined_outputs, expected_outputs):
+            assert set(combined) == set(expected)
+            for k, v in combined.items():
+                xr.testing.assert_identical(expected[k], v)
+    else:
+        with pytest.raises(ValueError):
+            combined_stepper(0, 0)

--- a/workflows/prognostic_c48_run/tests/test_nudging.py
+++ b/workflows/prognostic_c48_run/tests/test_nudging.py
@@ -1,6 +1,5 @@
 from runtime.names import STATE_NAME_TO_TENDENCY, TENDENCY_TO_STATE_NAME
 from runtime.nudging import (
-    _sst_from_reference,
     _time_interpolate_func,
     _time_to_label,
     _label_to_time,
@@ -12,22 +11,6 @@ import pytest
 import numpy as np
 import cftime
 import copy
-
-
-def test__sst_from_reference():
-    land_sea_mask = xr.DataArray(
-        np.array([0.0, 1.0, 2.0]), dims=["x"], attrs={"units": None}
-    )
-    reference_sfc_temp = xr.DataArray(
-        np.array([1.0, 1.0, 1.0]), dims=["x"], attrs={"units": "degK"}
-    )
-    model_sfc_temp = xr.DataArray(
-        np.array([-1.0, -1.0, -1.0]), dims=["x"], attrs={"units": "degK"}
-    )
-    assert np.allclose(
-        _sst_from_reference(reference_sfc_temp, model_sfc_temp, land_sea_mask),
-        [1.0, -1.0, -1.0],
-    )
 
 
 @pytest.mark.parametrize("fraction", [0, 0.25, 0.5, 0.75, 1])

--- a/workflows/prognostic_c48_run/tests/test_prescriber.py
+++ b/workflows/prognostic_c48_run/tests/test_prescriber.py
@@ -1,4 +1,9 @@
-from runtime.steppers.prescriber import PrescriberConfig, Prescriber, get_timesteps
+from runtime.steppers.prescriber import (
+    PrescriberConfig,
+    Prescriber,
+    get_timesteps,
+    _sst_from_reference,
+)
 from fv3gfs.util.testing import DummyComm
 import fv3gfs.util
 import numpy as np
@@ -154,3 +159,19 @@ def test_no_tendencies(prescriber_output):
     tendencies_list = prescriber_output[1]
     for tendencies in tendencies_list:
         assert not tendencies
+
+
+def test__sst_from_reference():
+    land_sea_mask = xr.DataArray(
+        np.array([0.0, 1.0, 2.0]), dims=["x"], attrs={"units": None}
+    )
+    reference_sfc_temp = xr.DataArray(
+        np.array([1.0, 1.0, 1.0]), dims=["x"], attrs={"units": "degK"}
+    )
+    model_sfc_temp = xr.DataArray(
+        np.array([-1.0, -1.0, -1.0]), dims=["x"], attrs={"units": "degK"}
+    )
+    assert np.allclose(
+        _sst_from_reference(reference_sfc_temp, model_sfc_temp, land_sea_mask),
+        [1.0, -1.0, -1.0],
+    )


### PR DESCRIPTION
This PR allows the prognostic run to use >1 source for prescribed quantities. The immediate use for this feature would be to allow prognostic runs using both a surface radiative flux model as well as SSTs from the fine res data.

I tested this in a local prognostic run using separate prescribers for surface radiative fluxes and SST. I verified that the SST is being set correctly to the reference (figure shows the surface temperature difference between prognostic run and reference for a single timestep)
![image](https://user-images.githubusercontent.com/16710132/140843062-c5f61454-3890-4803-ac65-620d4868cd8e.png)


Added public API:
- The prognostic run config `prephysics` section can now accept a list of sources. It is still backwards compatible to allow a single non-list formatted source. ex. 
```
prephysics:
  -
    dataset_key: gs://vcm-ml-intermediate/2021-08-03-PIRE-c48-diags-post-spinup/fine-res-surface-radiative-fluxes-precip.zarr
    variables:
      - override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface
      - override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface
      - override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface
      - total_precipitation
  -
    dataset_key: gs://vcm-ml-intermediate/2021-08-03-PIRE-c48-diags-post-spinup/sst-time-centered.zarr
    variables:
      - ocean_surface_temperature 
 ```

Significant internal changes:
- Added a `CombinedStepper`, which takes a list of `Prescriber` and/or `PureMLStepper` steppers and combines their outputs.
- I moved the function `sst_update_from_reference` out of `runtime.nudging` and into `runtime.steppers.prescriber` since that seemed like the more natural home for it (since it prescribes SSTs). 
- Special treatment for variable `ocean_surface_temperature` if set in the `Prescriber` such that it only prescribes reference temperatures over ocean, and keeps land surface temperature from the state.

- [x] Tests added