### PR TITLE
fv3fit convolutional model: Allow 2D inputs

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -144,7 +144,7 @@ def _ensure_5d(array: np.ndarray) -> np.ndarray:
     elif len(array.shape) == 3:
         return array[:, :, :, None, None]
     else:
-        raise ValueError(f"expected 4d or 5d array, got shape {array.shape}")
+        raise ValueError(f"expected 3d, 4d or 5d array, got shape {array.shape}")
 
 
 def _get_input_layer_shapes(X: Sequence[np.ndarray]) -> List[Tuple[int]]:

--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -83,7 +83,7 @@ def train_convolutional_model(
     validation_batches: Optional[Sequence[xr.Dataset]] = None,
 ):
     n_halo = hyperparameters.convolutional_network.halos_required
-    if validation_batches is not None:
+    if validation_batches is not None and len(validation_batches) > 0:
         validation_data: Optional[Tuple[np.ndarray, np.ndarray]] = XyMultiArraySequence(
             X_names=hyperparameters.input_variables,
             y_names=hyperparameters.output_variables,

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -200,8 +200,8 @@ def test_default_convolutional_model_is_transpose_invariant():
     sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
     result = train_identity_model("convolutional", sample_func=sample_func)
     transpose_input = result.test_dataset.copy(deep=True)
-    transpose_input["var_in"].values[:] = np.transpose(
-        transpose_input["var_in"].values, axes=(0, 1, 3, 2, 4)
+    transpose_input["var_in_3d"].values[:] = np.transpose(
+        transpose_input["var_in_3d"].values, axes=(0, 1, 3, 2, 4)
     )
     transpose_output = result.model.predict(result.test_dataset)
     transpose_output["var_out"].values[:] = np.transpose(

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -106,7 +106,7 @@ def get_dataset(model_type, sample_func):
         ]
         output_variables = ["dQ1", "dQ2", "total_precipitation_rate"]
     else:
-        input_variables = ["var_in"]
+        input_variables = ["var_in_2d", "var_in_3d"]  # 2d var will be clipped below
         output_variables = ["var_out"]
     input_values = list(sample_func() for _ in input_variables)
     if model_type == "precipitative":
@@ -122,10 +122,10 @@ def get_dataset(model_type, sample_func):
             ),  # total_precipitation_rate is integration of dQ2
         )
     else:
-        output_values = input_values
-        # add an input with feature dim size 1
-        input_variables.append("var_in_2d")
-        input_values.append(input_values[0].isel(z=0) * 0.0)
+        i_2d_input = input_variables.index("var_in_2d")
+        input_values[i_2d_input] = input_values[i_2d_input].isel(z=0) * 0.0
+        i_3d_input = input_variables.index("var_in_3d")
+        output_values = [input_values[i_3d_input]]
 
     data_vars = {name: value for name, value in zip(input_variables, input_values)}
     data_vars.update(

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -123,6 +123,10 @@ def get_dataset(model_type, sample_func):
         )
     else:
         output_values = input_values
+        # add an input with feature dim size 1
+        input_variables.append("var_in_2d")
+        input_values.append(input_values[0].isel(z=0) * 0.0)
+
     data_vars = {name: value for name, value in zip(input_variables, input_values)}
     data_vars.update(
         {name: value for name, value in zip(output_variables, output_values)}


### PR DESCRIPTION
I ran into a couple issues while trying out the convolutional model with 2D input fields (ex. surface geopotential). This PR modifies some of the dimension checking and input layer concatenation to allow these types of inputs to be used.

Significant internal changes:
- change `_ensure_5d` to `ensure_4d` and allow 3d shape in the `_ensure_4d` check
- add a z dim of size 1 to the input layer shape for 2D inputs
- minor fix for the check on whether validation batches are present; the training script passes an empty list, not `None` as assumed in the convolutional training function


- [x] Tests added
