### PR TITLE
Add microphysics emulation training configs

### DIFF
--- a/projects/microphysics/train/Makefile
+++ b/projects/microphysics/train/Makefile
@@ -1,0 +1,21 @@
+
+
+
+all-tendency-no-limit:
+	./run_arch.sh all-tendency-no-limit.yaml linear all-tends-nolimit
+	./run_arch.sh all-tendency-no-limit.yaml dense all-tends-nolimit
+	./run_arch.sh all-tendency-no-limit.yaml rnn all-tends-nolimit
+
+all-tendency-limited:
+	./run_arch.sh all-tendency-limited.yaml linear all-tends-limited
+	./run_arch.sh all-tendency-limited.yaml dense all-tends-limited
+	./run_arch.sh all-tendency-limited.yaml rnn all-tends-limited
+
+direct-cloud-limited:
+	./run_arch.sh direct-cloud-limited.yaml linear direct-qc-limited
+	./run_arch.sh direct-cloud-limited.yaml dense direct-qc-limited
+	./run_arch.sh direct-cloud-limited.yaml rnn direct-qc-limited
+
+all: all-tendency-no-limit all-tendency-limited direct-cloud-limited
+
+.PHONY: all-tendency-no-limit all-tendency-limited direct-cloud-limited

--- a/projects/microphysics/train/all-tendency-limited.yaml
+++ b/projects/microphysics/train/all-tendency-limited.yaml
@@ -1,0 +1,72 @@
+use_wandb: true
+wandb_project: microphysics-emulation-k8s
+batch_size: 128
+epochs: 50
+nfiles_valid: 100
+valid_freq: 2
+out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
+test_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/validation_netcdfs/
+train_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/training_netcdfs/
+optimizer:
+  kwargs:
+    learning_rate: 0.0001
+  name: Adam
+loss_variables:
+- air_temperature_output
+- specific_humidity_output
+- cloud_water_mixing_ratio_output
+- total_precipitation
+weights:
+  air_temperature_output: 500000.0
+  specific_humidity_output: 500000.0
+  cloud_water_mixing_ratio_output: 1.0
+  total_precipitation: .04
+metric_variables:
+- tendency_of_air_temperature_due_to_microphysics
+- tendency_of_specific_humidity_due_to_microphysics
+- tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+model:
+  architecture:
+    kwargs: {}
+    name: dense
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  direct_out_variables:
+  - total_precipitation
+  residual_out_variables:
+    air_temperature_output: air_temperature_input
+    specific_humidity_output: specific_humidity_input
+    cloud_water_mixing_ratio_output: cloud_water_mixing_ratio_input
+  tendency_outputs:
+    air_temperature_output: tendency_of_air_temperature_due_to_microphysics
+    specific_humidity_output: tendency_of_specific_humidity_due_to_microphysics
+    cloud_water_mixing_ratio_output: tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  normalize_key: mean_std
+  enforce_positive: true
+  selection_map:
+    air_temperature_input: [null, -10]
+    cloud_water_mixing_ratio_input: [null, -10]
+    pressure_thickness_of_atmospheric_layer: [null, -10]
+    specific_humidity_input: [null, -10]
+  timestep_increment_sec: 900
+transform:
+  antarctic_only: false
+  derived_microphys_timestep: 900
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  output_variables:
+  - total_precipitation
+  - air_temperature_output
+  - specific_humidity_output
+  - cloud_water_mixing_ratio_output
+  - tendency_of_air_temperature_due_to_microphysics
+  - tendency_of_specific_humidity_due_to_microphysics
+  - tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  use_tensors: true
+  vertical_subselections: null

--- a/projects/microphysics/train/all-tendency-limited.yaml
+++ b/projects/microphysics/train/all-tendency-limited.yaml
@@ -1,5 +1,5 @@
 use_wandb: true
-wandb_project: microphysics-emulation-k8s
+wandb_project: microphysics-emulation
 batch_size: 128
 epochs: 50
 nfiles_valid: 100

--- a/projects/microphysics/train/all-tendency-no-limit.yaml
+++ b/projects/microphysics/train/all-tendency-no-limit.yaml
@@ -1,0 +1,72 @@
+use_wandb: true
+wandb_project: microphysics-emulation-k8s
+batch_size: 128
+epochs: 50
+nfiles_valid: 100
+valid_freq: 2
+out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
+test_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/validation_netcdfs/
+train_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/training_netcdfs/
+optimizer:
+  kwargs:
+    learning_rate: 0.0001
+  name: Adam
+loss_variables:
+- air_temperature_output
+- specific_humidity_output
+- cloud_water_mixing_ratio_output
+- total_precipitation
+weights:
+  air_temperature_output: 500000.0
+  specific_humidity_output: 500000.0
+  cloud_water_mixing_ratio_output: 1.0
+  total_precipitation: .04
+metric_variables:
+- tendency_of_air_temperature_due_to_microphysics
+- tendency_of_specific_humidity_due_to_microphysics
+- tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+model:
+  architecture:
+    kwargs: {}
+    name: dense
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  direct_out_variables:
+  - total_precipitation
+  residual_out_variables:
+    air_temperature_output: air_temperature_input
+    specific_humidity_output: specific_humidity_input
+    cloud_water_mixing_ratio_output: cloud_water_mixing_ratio_input
+  tendency_outputs:
+    air_temperature_output: tendency_of_air_temperature_due_to_microphysics
+    specific_humidity_output: tendency_of_specific_humidity_due_to_microphysics
+    cloud_water_mixing_ratio_output: tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  normalize_key: mean_std
+  enforce_positive: false
+  selection_map:
+    air_temperature_input: [null, -10]
+    cloud_water_mixing_ratio_input: [null, -10]
+    pressure_thickness_of_atmospheric_layer: [null, -10]
+    specific_humidity_input: [null, -10]
+  timestep_increment_sec: 900
+transform:
+  antarctic_only: false
+  derived_microphys_timestep: 900
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  output_variables:
+  - total_precipitation
+  - air_temperature_output
+  - specific_humidity_output
+  - cloud_water_mixing_ratio_output
+  - tendency_of_air_temperature_due_to_microphysics
+  - tendency_of_specific_humidity_due_to_microphysics
+  - tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  use_tensors: true
+  vertical_subselections: null

--- a/projects/microphysics/train/all-tendency-no-limit.yaml
+++ b/projects/microphysics/train/all-tendency-no-limit.yaml
@@ -1,5 +1,5 @@
 use_wandb: true
-wandb_project: microphysics-emulation-k8s
+wandb_project: microphysics-emulation
 batch_size: 128
 epochs: 50
 nfiles_valid: 100

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -9,10 +9,6 @@ spec:
       secret:
         defaultMode: 420
         secretName: gcp-key
-    - name: wandb-key
-      secret:
-        defaultMode: 420
-        secretName: wandb-andrep
   templates:
     - name: training
       inputs:
@@ -23,18 +19,17 @@ spec:
       container:
         image: us.gcr.io/vcm-ml/prognostic_run:94fe4d44f231d0a91e90008a4916cfa342d50339
         command: ["bash", "-c", "-x"]
+        envFrom:
+        - secretRef:
+            name: wandb-andrep
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /secret/gcp-credentials/key.json
           - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
             value: /secret/gcp-credentials/key.json
-          - name: WANDB_KEYFILE
-            value: /secret/wandb-api/apikey
         volumeMounts:
           - mountPath: /secret/gcp-credentials
             name: gcp-key-secret
-          - mountPath: /secret/wandb-api
-            name: wandb-key
         resources:
           limits:
             cpu: "7"
@@ -46,8 +41,6 @@ spec:
           # The use of the API key here is a security problem
           # It's logged by argo...
           - |
-            export WANDB_API_KEY=$(cat $WANDB_KEYFILE)
-
             cat <<EOF >training_config.yaml
             {{inputs.parameters.training-config}}
             EOF

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -38,8 +38,6 @@ spec:
             cpu: "4"
             memory: "8Gi"
         args:
-          # The use of the API key here is a security problem
-          # It's logged by argo...
           - |
             cat <<EOF >training_config.yaml
             {{inputs.parameters.training-config}}

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -1,0 +1,62 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: train-microphysics-
+spec:
+  entrypoint: training
+  volumes:
+    - name: gcp-key-secret
+      secret:
+        defaultMode: 420
+        secretName: gcp-key
+    - name: wandb-key
+      secret:
+        defaultMode: 420
+        secretName: wandb-andrep
+  templates:
+    - name: training
+      inputs:
+        parameters:
+          - name: training-config
+          - {name: flags, value: " "}
+          # - {name: memory, value: "8Gi"}
+      container:
+        image: us.gcr.io/vcm-ml/prognostic_run:94fe4d44f231d0a91e90008a4916cfa342d50339
+        command: ["bash", "-c", "-x"]
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/gcp-credentials/key.json
+          - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+            value: /secret/gcp-credentials/key.json
+          - name: WANDB_KEYFILE
+            value: /secret/wandb-api/apikey
+        volumeMounts:
+          - mountPath: /secret/gcp-credentials
+            name: gcp-key-secret
+          - mountPath: /secret/wandb-api
+            name: wandb-key
+        resources:
+          limits:
+            cpu: "7"
+            memory: "8Gi"
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+        args:
+          # The use of the API key here is a security problem
+          # It's logged by argo...
+          - |
+            export WANDB_API_KEY=$(cat $WANDB_KEYFILE)
+
+            cat <<EOF >training_config.yaml
+            {{inputs.parameters.training-config}}
+            EOF
+
+            python3 -m fv3fit.train_microphysics \
+              --config-path training_config.yaml \
+              {{inputs.parameters.flags}}
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "med-sim-pool"
+        effect: "NoSchedule"  

--- a/projects/microphysics/train/direct-cloud-limited.yaml
+++ b/projects/microphysics/train/direct-cloud-limited.yaml
@@ -1,0 +1,69 @@
+use_wandb: true
+wandb_project: microphysics-emulation-k8s
+batch_size: 128
+epochs: 50
+nfiles_valid: 100
+valid_freq: 2
+out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
+test_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/validation_netcdfs/
+train_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/training_netcdfs/
+optimizer:
+  kwargs:
+    learning_rate: 0.0001
+  name: Adam
+loss_variables:
+- air_temperature_output
+- specific_humidity_output
+- cloud_water_mixing_ratio_output
+- total_precipitation
+weights:
+  air_temperature_output: 500000.0
+  specific_humidity_output: 500000.0
+  cloud_water_mixing_ratio_output: 1.0
+  total_precipitation: .04
+metric_variables:
+- tendency_of_air_temperature_due_to_microphysics
+- tendency_of_specific_humidity_due_to_microphysics
+model:
+  architecture:
+    kwargs: {}
+    name: dense
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  direct_out_variables:
+  - cloud_water_mixing_ratio_output
+  - total_precipitation
+  residual_out_variables:
+    air_temperature_output: air_temperature_input
+    specific_humidity_output: specific_humidity_input
+  tendency_outputs:
+    air_temperature_output: tendency_of_air_temperature_due_to_microphysics
+    specific_humidity_output: tendency_of_specific_humidity_due_to_microphysics
+  normalize_key: mean_std
+  enforce_positive: true
+  selection_map:
+    air_temperature_input: [null, -10]
+    cloud_water_mixing_ratio_input: [null, -10]
+    pressure_thickness_of_atmospheric_layer: [null, -10]
+    specific_humidity_input: [null, -10]
+  timestep_increment_sec: 900
+transform:
+  antarctic_only: false
+  derived_microphys_timestep: 900
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  output_variables:
+  - cloud_water_mixing_ratio_output
+  - total_precipitation
+  - air_temperature_output
+  - specific_humidity_output
+  - tendency_of_air_temperature_due_to_microphysics
+  - tendency_of_specific_humidity_due_to_microphysics
+  use_tensors: true
+  vertical_subselections: null

--- a/projects/microphysics/train/direct-cloud-limited.yaml
+++ b/projects/microphysics/train/direct-cloud-limited.yaml
@@ -1,5 +1,5 @@
 use_wandb: true
-wandb_project: microphysics-emulation-k8s
+wandb_project: microphysics-emulation
 batch_size: 128
 epochs: 50
 nfiles_valid: 100

--- a/projects/microphysics/train/rnn_w_rain_input.yaml
+++ b/projects/microphysics/train/rnn_w_rain_input.yaml
@@ -1,0 +1,69 @@
+use_wandb: true
+wandb_project: microphysics-emulation-k8s
+batch_size: 128
+epochs: 50
+nfiles_valid: 100
+valid_freq: 2
+out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/rnn_tendency_w_rain
+wandb_model_name: microphysics-rnn-tendency-w-rain
+test_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/validation_netcdfs/
+train_url: gs://vcm-ml-experiments/microphysics-emu-data/2021-07-29/training_netcdfs/
+optimizer:
+  kwargs:
+    learning_rate: 0.0001
+  name: Adam
+loss_variables:
+- tendency_of_air_temperature_due_to_microphysics
+- tendency_of_specific_humidity_due_to_microphysics
+- tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+- total_precipitation
+weights:
+  total_precipitation: .04
+metric_variables:
+- air_temperature_output
+- specific_humidity_output
+- cloud_water_mixing_ratio_output
+model:
+  architecture:
+    kwargs: {}
+    name: rnn
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  direct_out_variables:
+  - total_precipitation
+  residual_out_variables:
+    air_temperature_output: air_temperature_input
+    specific_humidity_output: specific_humidity_input
+    cloud_water_mixing_ratio_output: cloud_water_mixing_ratio_input
+  tendency_outputs:
+    air_temperature_output: tendency_of_air_temperature_due_to_microphysics
+    specific_humidity_output: tendency_of_specific_humidity_due_to_microphysics
+    cloud_water_mixing_ratio_output: tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  normalize_key: mean_std
+  selection_map:
+    air_temperature_input: [null, -10]
+    cloud_water_mixing_ratio_input: [null, -10]
+    pressure_thickness_of_atmospheric_layer: [null, -10]
+    specific_humidity_input: [null, -10]
+  timestep_increment_sec: 900
+transform:
+  antarctic_only: false
+  derived_microphys_timestep: 900
+  input_variables:
+  - air_temperature_input
+  - specific_humidity_input
+  - cloud_water_mixing_ratio_input
+  - pressure_thickness_of_atmospheric_layer
+  output_variables:
+  - total_precipitation
+  - air_temperature_output
+  - specific_humidity_output
+  - cloud_water_mixing_ratio_output
+  - tendency_of_air_temperature_due_to_microphysics
+  - tendency_of_specific_humidity_due_to_microphysics
+  - tendency_of_cloud_water_mixing_ratio_due_to_microphysics
+  use_tensors: true
+  vertical_subselections: null

--- a/projects/microphysics/train/rnn_w_rain_input.yaml
+++ b/projects/microphysics/train/rnn_w_rain_input.yaml
@@ -1,5 +1,5 @@
 use_wandb: true
-wandb_project: microphysics-emulation-k8s
+wandb_project: microphysics-emulation
 batch_size: 128
 epochs: 50
 nfiles_valid: 100

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+config_file=$1
+
+argo submit argo.yaml \
+    -p training-config="$(< $config_file)"

--- a/projects/microphysics/train/run_arch.sh
+++ b/projects/microphysics/train/run_arch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+config_file=$1
+model_type=$2
+model_prefix=$3
+
+model_name=${model_prefix}-${model_type}
+out_url=gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/${model_prefix}/${model_name}
+
+argo submit argo.yaml \
+    -p training-config="$(< $config_file)" \
+    -p flags="--model.architecture.name ${model_type} --wandb_model_name ${model_name} --out_url ${out_url}"

--- a/projects/microphysics/train/run_arch.sh
+++ b/projects/microphysics/train/run_arch.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 config_file=$1
 model_type=$2
 model_prefix=$3
 
 model_name=${model_prefix}-${model_type}
-out_url=gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/${model_prefix}/${model_name}
+out_url=$(artifacts resolve-url vcm-ml-experiments microphysics-emulation ${model_name})
 
 argo submit argo.yaml \
     -p training-config="$(< $config_file)" \


### PR DESCRIPTION
These previously lived in a draft PR here: https://github.com/ai2cm/vcm-workflow-control/pull/118.

I moved these into this repo and made some minimal changes to the configs/argo to allow submitting them locally.

The argo workflows still reference an old fv3net commit. The yamls and CLI options uses in the argo workflows are not current though, so we should figure out which yamls we want to base future experiments off and then update them in a future PR.