### PR TITLE
Zonal mean nudging tendencies in prog run report

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -135,6 +135,8 @@ PRESSURE_INTERPOLATED_VARS = [
     "dQv",
     "tendency_of_air_temperature_due_to_machine_learning",
     "tendency_of_specific_humidity_due_to_machine_learning",
+    "air_temperature_tendency_due_to_nudging",
+    "specific_humidity_tendency_due_to_nudging",
 ]
 
 PRECIP_RATE = "total_precip_to_surface"

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -79,7 +79,7 @@ def _coarsen_to_target_resolution(
 
 def _load_3d(url: str, catalog: intake.catalog.Catalog) -> xr.Dataset:
     logger.info(f"Processing 3d data from run directory at {url}")
-    files_3d = ["diags_3d.zarr", "state_after_timestep.zarr"]
+    files_3d = ["diags_3d.zarr", "state_after_timestep.zarr", "nudging_tendencies.zarr"]
     ds = xr.merge(
         [
             load_coarse_data(os.path.join(url, filename), catalog)


### PR DESCRIPTION
Open nudging tendency zarr and plot zonal mean tendencies for
temperature and specific humidity nudging. Useful for evaluating
nudged runs with the prognostic run report.
