### PR TITLE
Offline diags: include WVP scatterplot for predicted Q2

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -154,7 +154,7 @@ def _compute_diagnostics(
         ds = ds.pipe(insert_column_integrated_vars, diagnostic_vars_3d).load()
 
         full_predicted_vars = [var for var in ds if DERIVATION_DIM_NAME in ds[var].dims]
-        if "dQ2" in full_predicted_vars:
+        if "dQ2" in full_predicted_vars or "Q2" in full_predicted_vars:
             full_predicted_vars.append("water_vapor_path")
         prediction = safe.get_variables(
             ds.sel({DERIVATION_DIM_NAME: PREDICT_COORD}), full_predicted_vars


### PR DESCRIPTION
Fixes a bug where the Q2 vs water vapor path was only calculated if the model predicted dQ2 (but not Q2).

ex . works for the fine res apparent sources: https://storage.googleapis.com/vcm-ml-public/annak/2021-11-22/offline-diags/index.html