### PR TITLE
Dynamics difference method for estimating eddy term

### DIFF
--- a/external/loaders/loaders/mappers/_fine_res.py
+++ b/external/loaders/loaders/mappers/_fine_res.py
@@ -70,7 +70,6 @@ def _open_merged_dataset(
 class Approach(Enum):
     apparent_sources_only = 1
     apparent_sources_plus_nudging_tendencies = 2
-    apparent_sources_plus_dynamics_differences = 3
     apparent_sources_extend_lower = 4
     dynamics_difference = 5
 
@@ -109,8 +108,6 @@ def compute_budget(
 
     if approach == Approach.apparent_sources_plus_nudging_tendencies:
         merged["Q1"], merged["Q2"] = _add_nudging_tendencies(merged)
-    elif approach == Approach.apparent_sources_plus_dynamics_differences:
-        merged["Q1"], merged["Q2"] = _add_dynamics_differences(merged)
     elif approach == Approach.apparent_sources_extend_lower:
         merged["Q1"] = _extend_lower(merged["Q1"])
         merged["Q2"] = _extend_lower(merged["Q2"])
@@ -144,33 +141,6 @@ def _add_nudging_tendencies(merged: xr.Dataset):
             + " plus dynamics nudging tendency",
             "description": merged.Q2.attrs.get("description")
             + " + dynamics nudging tendency",
-        }
-    )
-    return Q1, Q2
-
-
-def _add_dynamics_differences(merged: xr.Dataset):
-    with xr.set_options(keep_attrs=True):
-        Q1 = (
-            merged.Q1
-            + merged.fine_minus_coarse_tendency_of_air_temperature_due_to_dynamics
-        )
-        Q2 = (
-            merged.Q2
-            + merged.fine_minus_coarse_tendency_of_specific_humidity_due_to_dynamics
-        )
-    Q1.attrs.update(
-        {
-            "long_name": merged.Q1.attrs.get("long_name") + " plus dynamics difference",
-            "description": merged.Q1.attrs.get("description")
-            + " + dynamics difference",
-        }
-    )
-    Q2.attrs.update(
-        {
-            "long_name": merged.Q2.attrs.get("long_name") + " plus dynamics difference",
-            "description": merged.Q2.attrs.get("description")
-            + " + dynamics difference",
         }
     )
     return Q1, Q2

--- a/external/loaders/loaders/mappers/_fine_res.py
+++ b/external/loaders/loaders/mappers/_fine_res.py
@@ -67,10 +67,8 @@ class Approach(Enum):
 def _compute_budget(
     merged: xr.Dataset, approach: Approach, include_temperature_nudging: bool
 ) -> MLTendencies:
-
-    merged["Q1"], merged["Q2"] = compute_fine_res_sources(
-        merged, include_temperature_nudging
-    )
+    sources = compute_fine_res_sources(merged, include_temperature_nudging)
+    merged = xr.merge([merged] + list(sources))
 
     if approach == Approach.apparent_sources_plus_nudging_tendencies:
         merged["Q1"], merged["Q2"] = _add_nudging_tendencies(merged)

--- a/external/loaders/loaders/mappers/_fine_res.py
+++ b/external/loaders/loaders/mappers/_fine_res.py
@@ -21,8 +21,8 @@ class MLTendencies(Protocol):
 
 
 class NudgedRun(Protocol):
-    tendency_of_air_temperature_due_to_dynamics: xr.Dataset
-    tendency_of_specific_humidity_due_to_dynamics: xr.Dataset
+    tendency_of_air_temperature_due_to_dynamics: xr.DataArray
+    tendency_of_specific_humidity_due_to_dynamics: xr.DataArray
 
 
 class MergedData(NudgedRun, FineResBudget):

--- a/external/loaders/loaders/mappers/_fine_res_budget.py
+++ b/external/loaders/loaders/mappers/_fine_res_budget.py
@@ -76,6 +76,7 @@ class FineResBudget(Protocol):
     t_dt_phys_coarse: xarray.DataArray
     vulcan_omega_coarse: xarray.DataArray
     T_vulcan_omega_coarse: xarray.DataArray
+    T_storage: xarray.DataArray
 
 
 def apparent_heating(data: FineResBudget, include_temperature_nudging: bool = False):

--- a/external/loaders/tests/test__fine_resolution.py
+++ b/external/loaders/tests/test__fine_resolution.py
@@ -1,7 +1,11 @@
-import xarray as xr
 import numpy as np
 import pytest
-from loaders.mappers._fine_res import _extend_lower
+import xarray as xr
+from loaders.mappers._fine_res import (
+    Approach,
+    _extend_lower,
+    compute_budget,
+)
 
 
 @pytest.mark.parametrize(
@@ -29,3 +33,51 @@ def test__extend_lower(nz, nx, vertical_dim, n_levels, error):
             )
             for i in range(n_levels)
         ]
+
+
+@pytest.mark.parametrize("include_temperature_nudging", [True, False])
+@pytest.mark.parametrize("approach", list(Approach))
+def test_compute_budget(approach, include_temperature_nudging):
+
+    if approach == Approach.apparent_sources_plus_dynamics_differences:
+        pytest.skip()
+
+    one = xr.DataArray(np.ones((5, 1, 1)), dims=["z", "y", "x"])
+    ds = xr.Dataset()
+    for name in [
+        "delp",
+        "T",
+        "dq3dt_deep_conv_coarse",
+        "dq3dt_mp_coarse",
+        "dq3dt_pbl_coarse",
+        "dq3dt_shal_conv_coarse",
+        "dt3dt_deep_conv_coarse",
+        "dt3dt_lw_coarse",
+        "dt3dt_mp_coarse",
+        "dt3dt_ogwd_coarse",
+        "dt3dt_pbl_coarse",
+        "dt3dt_shal_conv_coarse",
+        "dt3dt_sw_coarse",
+        "eddy_flux_vulcan_omega_sphum",
+        "eddy_flux_vulcan_omega_temp",
+        "exposed_area",
+        "qv_dt_fv_sat_adj_coarse",
+        "qv_dt_phys_coarse",
+        "sphum",
+        "sphum_storage",
+        "sphum_vulcan_omega_coarse",
+        "t_dt_fv_sat_adj_coarse",
+        "t_dt_nudge_coarse",
+        "t_dt_phys_coarse",
+        "vulcan_omega_coarse",
+        "T_vulcan_omega_coarse",
+        "T_storage",
+        "air_temperature_tendency_due_to_nudging",
+        "specific_humidity_tendency_due_to_nudging",
+        "tendency_of_air_temperature_due_to_dynamics",
+        "tendency_of_specific_humidity_due_to_dynamics",
+    ]:
+        ds[name] = one
+
+    out = compute_budget(ds, approach, include_temperature_nudging)
+    assert {"dQ1", "dQ2"} <= set(out)

--- a/external/loaders/tests/test__fine_resolution.py
+++ b/external/loaders/tests/test__fine_resolution.py
@@ -38,10 +38,6 @@ def test__extend_lower(nz, nx, vertical_dim, n_levels, error):
 @pytest.mark.parametrize("include_temperature_nudging", [True, False])
 @pytest.mark.parametrize("approach", list(Approach))
 def test_compute_budget(approach, include_temperature_nudging):
-
-    if approach == Approach.apparent_sources_plus_dynamics_differences:
-        pytest.skip()
-
     one = xr.DataArray(np.ones((5, 1, 1)), dims=["z", "y", "x"])
     ds = xr.Dataset()
     for name in [


### PR DESCRIPTION
Implement the dynamics difference method for estimating the eddy flux term. This method computes the apparent source like this:

    Q = (high_res dyn - coarse dyn) + high_res physics 
        = high res storage - coarse dyn tendency 

This is different from the `apparent_sources_plus_dynamics_difference` method, which is not what I had in mind when originally proposing it. This approach doesn't directly use the eddy flux, so should be less susceptible to numerical discretization errors. 

I deleted the `apparent_sources_plus_dynamics_difference` method. @brianhenn I can revert the last commit if you were independently interested in that method.