### PR TITLE
Fix dynamics difference temperature nudging

### DIFF
--- a/external/loaders/loaders/mappers/_fine_res.py
+++ b/external/loaders/loaders/mappers/_fine_res.py
@@ -86,13 +86,13 @@ class DynamicsDifferenceApparentSource:
 
     def temperature_source(self, merged: MergedData):
         if self.include_temperature_nudging:
+            return merged.T_storage - merged.tendency_of_air_temperature_due_to_dynamics
+        else:
             return (
                 merged.T_storage
                 - merged.t_dt_nudge_coarse
                 - merged.tendency_of_air_temperature_due_to_dynamics
             )
-        else:
-            return merged.T_storage - merged.tendency_of_air_temperature_due_to_dynamics
 
     def moisture_source(self, merged: MergedData):
         return (


### PR DESCRIPTION
I mixed up the clause of the boolean `include_temperature_nudging` mixed up.

The returned temperature source should be larger when including the temperature nudging.