### PR TITLE
Fix rnn-v1 model reload after save

### DIFF
--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -372,6 +372,15 @@ class RNNOutput(tf.keras.layers.Layer):
         return fields
 
 
+_ARCHITECTURE_KEYS = (
+    "rnn-v1-shared-weights",
+    "rnn-v1",
+    "rnn",
+    "dense",
+    "linear",
+)
+
+
 def _get_output_layer(key, feature_lengths):
     if key == "rnn-v1":
         return RNNOutput(feature_lengths)
@@ -400,8 +409,6 @@ def _get_arch_layer(key, kwargs):
         if kwargs:
             raise TypeError("No keyword arguments accepted for linear model")
         return MLPBlock(depth=0)
-    else:
-        raise KeyError(f"Unrecognized architecture provided: {key}")
 
 
 class _HiddenArchitecture(tf.keras.layers.Layer):
@@ -441,6 +448,10 @@ class ArchitectureConfig:
 
     name: str
     kwargs: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.name not in _ARCHITECTURE_KEYS:
+            raise KeyError(f"Unrecognized architecture key: {self.name}")
 
     def build(self, feature_lengths: Mapping[str, int]) -> tf.keras.layers.Layer:
         """

--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -118,7 +118,7 @@ class HybridRNN(tf.keras.layers.Layer):
         return config
 
 
-class RNN(tf.keras.layers.Layer):
+class RNNBlock(tf.keras.layers.Layer):
     """
     RNN for prediction that preserves vertical information so
     directional dependence is possible
@@ -400,7 +400,7 @@ def _get_combine_layer(key):
 def _get_arch_layer(key, kwargs):
 
     if key == "rnn-v1" or key == "rnn-v1-shared-weights":
-        return RNN(**kwargs)
+        return RNNBlock(**kwargs)
     elif key == "rnn":
         return HybridRNN(**kwargs)
     elif key == "dense":

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -137,7 +137,7 @@ def test_OutputConnectors(connector_cls, hidden_out):
 def test_get_architecture_unrecognized():
 
     with pytest.raises(KeyError):
-        _HiddenArchitecture("not_an_arch", {}, {})
+        ArchitectureConfig(name="not_an_arch")
 
 
 @pytest.mark.parametrize("key", ["rnn-v1", "rnn", "dense", "linear"])

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -12,7 +12,7 @@ from fv3fit.emulation.layers.architecture import (
     RNNOutput,
     StandardOutput,
     ArchitectureConfig,
-    _ARCHITECTURE_KEYS
+    _ARCHITECTURE_KEYS,
 )
 
 

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from fv3fit.emulation.layers.architecture import (
-    RNN,
+    RNNBlock,
     _HiddenArchitecture,
     MLPBlock,
     HybridRNN,
@@ -12,6 +12,7 @@ from fv3fit.emulation.layers.architecture import (
     RNNOutput,
     StandardOutput,
     ArchitectureConfig,
+    _ARCHITECTURE_KEYS
 )
 
 
@@ -57,7 +58,7 @@ def test_HybridRNN(depth, expected_shp):
 
 def test_RNN():
 
-    rnn = RNN(channels=64, depth=2)
+    rnn = RNNBlock(channels=64, depth=2)
     tensor = _get_tensor((20, 10, 2))
     result = rnn(tensor)
     assert result.shape == (20, 10, 64)
@@ -104,7 +105,7 @@ def test_no_weight_sharing_num_weights():
     assert num_weights_expected == total
 
 
-@pytest.mark.parametrize("layer_cls", [CombineInputs, MLPBlock, HybridRNN, RNN])
+@pytest.mark.parametrize("layer_cls", [CombineInputs, MLPBlock, HybridRNN, RNNBlock])
 def test_from_config(layer_cls):
 
     layer = layer_cls()
@@ -146,7 +147,7 @@ def test_ArchParams_bad_kwargs(key):
 
 
 @pytest.mark.parametrize(
-    "arch_key", ["rnn-v1-shared-weights", "rnn-v1", "rnn", "dense", "linear"],
+    "arch_key", _ARCHITECTURE_KEYS,
 )
 def test_ArchitectureConfig(arch_key):
 

--- a/external/fv3fit/tests/emulation/models/test_microphysics_config.py
+++ b/external/fv3fit/tests/emulation/models/test_microphysics_config.py
@@ -1,4 +1,5 @@
 import numpy as np
+from os.path import join
 import pytest
 import tempfile
 import tensorflow as tf
@@ -147,9 +148,9 @@ def test_MicrophysicConfig_saveable(arch):
     expected = model(sample)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        model_path = tmpdir.join("model.tf")
+        model_path = join(tmpdir, "model.tf")
         model.save(model_path, save_format="tf")
-        reloaded = tf.keras.models.load_model(model_path)
+        reloaded = tf.keras.models.load_model(model_path, compile=False)
 
     result = reloaded(sample)
     np.testing.assert_array_equal(expected["field_output"], result["field_output"])

--- a/external/fv3fit/tests/emulation/models/test_microphysics_config.py
+++ b/external/fv3fit/tests/emulation/models/test_microphysics_config.py
@@ -131,7 +131,7 @@ def test_precip_conserving_extra_inputs():
 
 
 @pytest.mark.parametrize("arch", _ARCHITECTURE_KEYS)
-def test_MicrophysicConfig_saveable(arch):
+def test_MicrophysicConfig_model_save_reload(arch):
 
     config = MicrophysicsConfig(
         input_variables=["field_input"],

--- a/external/fv3fit/tests/emulation/models/test_microphysics_config.py
+++ b/external/fv3fit/tests/emulation/models/test_microphysics_config.py
@@ -1,10 +1,13 @@
 import numpy as np
+import pytest
+import tempfile
 import tensorflow as tf
 
 import fv3fit.emulation.models
 from fv3fit._shared import SliceConfig
 from fv3fit.emulation.models import MicrophysicsConfig
 from fv3fit.emulation.layers import ArchitectureConfig
+from fv3fit.emulation.layers.architecture import _ARCHITECTURE_KEYS
 
 
 def _get_data(shape):
@@ -124,6 +127,32 @@ def test_precip_conserving_extra_inputs():
         extra_input_variables=extras
     )
     assert set(extra_names) < set(factory.input_variables)
+
+
+@pytest.mark.parametrize("arch", _ARCHITECTURE_KEYS)
+def test_MicrophysicConfig_saveable(arch):
+
+    config = MicrophysicsConfig(
+        input_variables=["field_input"],
+        direct_out_variables=["field_output"],
+        architecture=ArchitectureConfig(name=arch),
+    )
+
+    nlev = 15
+    data = tf.random.normal((10, nlev))
+    sample = {"field_input": data, "field_output": data}
+
+    model = config.build(sample)
+
+    expected = model(sample)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = tmpdir.join("model.tf")
+        model.save(model_path, save_format="tf")
+        reloaded = tf.keras.models.load_model(model_path)
+
+    result = reloaded(sample)
+    np.testing.assert_array_equal(expected["field_output"], result["field_output"])
 
 
 def test_RNN_downward_dependence():


### PR DESCRIPTION
Resolves #1535 

The new `RNN` classes could not be reloaded after saving.  This was due to a bug where an architecture layer (`RNN`) overlapped with a standard name of a keras layer (`RNN`).  During the load of the saved model, keras would try to instantiate the standard layer instead of our custom one.

[Notebook](https://github.com/ai2cm/explore/blob/master/andrep/microphysics/KerasRNNLoadError.ipynb) showing the error.

Moral of the story, use custom names.