### PR TITLE
Fix incorrect timestep bug when computing fine res budgets

### DIFF
--- a/workflows/fine_res_budget/budget/config.py
+++ b/workflows/fine_res_budget/budget/config.py
@@ -43,3 +43,4 @@ VARIABLES_TO_AVERAGE = set(
 ) - {"area_coarse", "delp"}
 # coarsening factor. C384 to C48 is a factor of 8
 factor = 8
+dt = 15 * 60  # timestep in seconds

--- a/workflows/fine_res_budget/budget/pipeline.py
+++ b/workflows/fine_res_budget/budget/pipeline.py
@@ -35,7 +35,10 @@ def as_one_chunk(ds):
 def func(iData):
     dims = ["time", "tile", "pfull", "grid_yt", "grid_xt"]
     ds = budgets.compute_recoarsened_budget_inputs(
-        iData, config.factor, first_moments=config.VARIABLES_TO_AVERAGE
+        iData,
+        dt=config.dt,
+        factor=config.factor,
+        first_moments=config.VARIABLES_TO_AVERAGE,
     )
     return ds.drop(["step"]).transpose(*dims).pipe(as_one_chunk)
 


### PR DESCRIPTION
In the fine_res_budget workflow, we were passing `factor` (8) as the timestep in seconds, giving storage terms that were 112.5 times too large. This PR fixes that bug.

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Fixed bug where 8 seconds was used in place of the timestep when computing fine-res storage terms

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
