### PR TITLE
Emulation enhance performance

### DIFF
--- a/external/fv3fit/fv3fit/__init__.py
+++ b/external/fv3fit/fv3fit/__init__.py
@@ -26,5 +26,6 @@ from .keras._models.precipitative import PrecipitativeHyperparameters
 from .keras._models.convolutional import ConvolutionalHyperparameters
 from .keras._models.dense import DenseHyperparameters
 from . import keras, sklearn, testing
+from fv3fit._py_function import py_function_dict_output
 
 __version__ = "0.1.0"

--- a/external/fv3fit/fv3fit/_py_function.py
+++ b/external/fv3fit/fv3fit/_py_function.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable, Mapping
+
+import tensorflow as tf
+
+
+def py_function_dict_output(
+    transform: Callable[..., Mapping[str, tf.Tensor]],
+    inp: Any,
+    signature: Mapping[str, tf.TensorSpec],
+) -> Mapping[str, tf.Tensor]:
+    """Wrap a user python function returning a dictionary of tensors for use in the
+    tensorflow graph
+
+    tf.data.Dataset.map only works with user functions that have been wrapped
+    with tf.py_function, unfortunately, tf.py_function is not compatible with
+    dictionary outputs or outputs with shapes.
+
+    Args:
+        transform: python function to embed in tensorflow graph
+        inp: input tensors (see ``tf.py_function`` docs)
+        signature: description of outputs of transform
+    """
+
+    keys = list(signature)
+
+    def transform_values(*args):
+        return tuple([transform(*args)[v] for v in keys])
+
+    # py_function only works with tuple outputs, and no shapes
+    out = tf.py_function(transform_values, inp, Tout=[signature[v].dtype for v in keys])
+    return {
+        v: tf.ensure_shape(out_i, signature[v].shape) for v, out_i in zip(keys, out)
+    }

--- a/external/fv3fit/fv3fit/emulation/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/__init__.py
@@ -1,1 +1,1 @@
-from .trainer import Trainer, ModelCheckpointCallback
+from .trainer import train, ModelCheckpointCallback

--- a/external/fv3fit/fv3fit/emulation/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/__init__.py
@@ -1,0 +1,1 @@
+from .trainer import Trainer, ModelCheckpointCallback

--- a/external/fv3fit/fv3fit/emulation/keras.py
+++ b/external/fv3fit/fv3fit/emulation/keras.py
@@ -30,6 +30,7 @@ def save_model(model: tf.keras.Model, destination: str):
     # clear all the weights and optimizers settings
     model.compile()
     model_path = os.path.join(destination, "model.tf")
+    logging.getLogger(__name__).debug(f"saving model to {model_path}")
     model.save(model_path, save_format="tf")
     return model_path
 

--- a/external/fv3fit/fv3fit/emulation/models/microphysics.py
+++ b/external/fv3fit/fv3fit/emulation/models/microphysics.py
@@ -323,16 +323,14 @@ def _assoc_conservative_precipitation(
     )
 
     out = model(inputs)
-    out[
-        fields.surface_precipitation.output_name
-    ] = thermo.conservative_precipitation_zhao_carr(
+    precip_scalar = thermo.conservative_precipitation_zhao_carr(
         specific_humidity_before=inputs[fields.specific_humidity.input_name],
         specific_humidity_after=out[fields.specific_humidity.output_name],
         cloud_before=inputs[fields.cloud_water.input_name],
         cloud_after=out[fields.cloud_water.output_name],
         mass=thermo.layer_mass(inputs[fields.pressure_thickness.input_name]),
     )
-
+    out[fields.surface_precipitation.output_name] = precip_scalar[:, None]
     # convert_to_dict_output ensures that output names are consistent
     new_model = ensure_dict_output(tf.keras.Model(inputs=inputs, outputs=out))
     new_model(inputs)

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -44,7 +44,7 @@ def train(
  
     Returns:
         The keras training history
-    
+
     Note:
         all other arguments have the same interpretation as ``tf.keras.Model.fit
 
@@ -52,7 +52,18 @@ def train(
     wrapped_model = _ModelWrapper(model)
 
     train_set = next(iter(dataset))
-    output_names = set(wrapped_model(train_set))
+    outputs = wrapped_model(train_set)
+    for name in outputs:
+        if name in train_set:
+            shape_in_data = tuple(train_set[name].shape)
+            shape_in_output = tuple(outputs[name].shape)
+            if shape_in_data != shape_in_output:
+                raise ValueError(
+                    f"{model} produced unexpected shape for {name}. "
+                    f"Expected {shape_in_data} got {shape_in_output}."
+                )
+
+    output_names = set(outputs)
 
     def split_in_out(m):
         return (

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -1,22 +1,47 @@
+from typing import Any, Sequence, Union
 import tensorflow as tf
+from fv3fit.emulation.keras import StandardLoss, CustomLoss
 
 
-class Trainer(tf.keras.Model):
-    """An object used for training another keras model
-    
-    This is used to separate training related serialization (e.g. loss
-    functions, optimizers) from parameters needed for inference (e.g. weights
-    and biases).
-    """
-
+class _ModelWrapper(tf.keras.Model):
     def __init__(self, model: tf.keras.Model):
         super().__init__()
         self.model = model
 
     def call(self, x):
-        # non public any more...please don't use
-        # needed for Trainer.fit to work
         return self.model(x)
+
+
+def train(
+    model: tf.keras.layers.Layer,
+    dataset: Any,
+    loss: Union[StandardLoss, CustomLoss],
+    callbacks: Sequence[tf.keras.callbacks.Callback] = (),
+    epochs: int = 1,
+    validation_data: Any = None,
+    validation_freq: Any = None,
+    verbose: int = 0,
+) -> Any:
+    """Train a keras model with a specified loss function
+
+    This is used to separate training related serialization (e.g. loss
+    functions, optimizers) from parameters needed for inference (e.g. weights
+    and biases).
+    """
+    wrapped_model = _ModelWrapper(model)
+    loss.compile(wrapped_model)
+    # explicitly handling all arguments makes it difficult to further expand
+    # the surface area of this function
+    # This minimizes our contact points to keras APIs...which are often
+    # poorly documented
+    return wrapped_model.fit(
+        dataset,
+        epochs=epochs,
+        validation_data=validation_data,
+        validation_freq=validation_freq,
+        verbose=verbose,
+        callbacks=callbacks,
+    )
 
 
 class ModelCheckpointCallback(tf.keras.callbacks.Callback):
@@ -27,7 +52,7 @@ class ModelCheckpointCallback(tf.keras.callbacks.Callback):
         super().__init__()
         self.filepath = filepath
 
-    def set_model(self, model: Trainer):
+    def set_model(self, model: _ModelWrapper):
         self.model = model.model
 
     def on_epoch_end(self, epoch, logs=None):

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -1,0 +1,34 @@
+import tensorflow as tf
+
+
+class Trainer(tf.keras.Model):
+    """An object used for training another keras model
+    
+    This is used to separate training related serialization (e.g. loss
+    functions, optimizers) from parameters needed for inference (e.g. weights
+    and biases).
+    """
+
+    def __init__(self, model: tf.keras.Model):
+        super().__init__()
+        self.model = model
+
+    def call(self, x):
+        # non public any more...please don't use
+        # needed for Trainer.fit to work
+        return self.model(x)
+
+
+class ModelCheckpointCallback(tf.keras.callbacks.Callback):
+    """the built in one doesn't work with ``Trainer`` since it saves the full
+    trainer object rather than the inner model"""
+
+    def __init__(self, filepath: str):
+        super().__init__()
+        self.filepath = filepath
+
+    def set_model(self, model: Trainer):
+        self.model = model.model
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.model.save(self.filepath.format(epoch=epoch), save_format="tf")

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -49,10 +49,6 @@ class TrainConfig:
     """
     Configuration for training a microphysics emulator
 
-    Note:
-        set ``score_model`` to false if you run out of memory near the end of
-        training.
-
     Args:
         train_url: Path to training netcdfs (already in [sample x feature] format)
         test_url: Path to validation netcdfs (already in [sample x feature] format)
@@ -72,11 +68,7 @@ class TrainConfig:
         shuffle_buffer_size: How many samples to keep in the keras shuffle buffer
             during training
         checkpoint_model: if true, save a checkpoint after each epoch
-        log_level: what python logging level to use
-        score_model: run the scoring and evaluation routines if true. These can
-            be memory intensive.
-
-
+        log_level: what logging level to use
     """
 
     train_url: str
@@ -97,7 +89,6 @@ class TrainConfig:
     shuffle_buffer_size: Optional[int] = 100_000
     checkpoint_model: bool = True
     log_level: str = "INFO"
-    score_model: bool = True
 
     @property
     def _model(
@@ -265,32 +256,29 @@ def main(config: TrainConfig, seed: int = 0):
                 callbacks=callbacks,
             )
     logger.debug("Training complete")
+    train_scores, train_profiles = score_model(model, train_set)
+    test_scores, test_profiles = score_model(model, test_set)
+    logger.debug("Scoring Complete")
 
-    if config.score_model:
-        logger.info("Begin Scoring")
-        train_scores, train_profiles = score_model(model, train_set)
-        test_scores, test_profiles = score_model(model, test_set)
-        logger.info("Scoring Complete")
-        if config.use_wandb:
-            pred_sample = model.predict(test_set)
-            log_profile_plots(test_set, pred_sample)
+    if config.use_wandb:
+        pred_sample = model.predict(test_set)
+        log_profile_plots(test_set, pred_sample)
 
-            # add level for dataframe index, assumes equivalent feature dims
-            sample_profile = next(iter(train_profiles.values()))
-            train_profiles["level"] = np.arange(len(sample_profile))
-            test_profiles["level"] = np.arange(len(sample_profile))
+        # add level for dataframe index, assumes equivalent feature dims
+        sample_profile = next(iter(train_profiles.values()))
+        train_profiles["level"] = np.arange(len(sample_profile))
+        test_profiles["level"] = np.arange(len(sample_profile))
 
-            log_to_table("score/train", train_scores, index=[config.wandb.job.name])
-            log_to_table("score/test", test_scores, index=[config.wandb.job.name])
-            log_to_table("profiles/train", train_profiles)
-            log_to_table("profiles/test", test_profiles)
-
-        with put_dir(config.out_url) as tmpdir:
-            # TODO: need to convert ot np.float to serialize
-            with open(os.path.join(tmpdir, "scores.json"), "w") as f:
-                json.dump({"train": train_scores, "test": test_scores}, f)
+        log_to_table("score/train", train_scores, index=[config.wandb.job.name])
+        log_to_table("score/test", test_scores, index=[config.wandb.job.name])
+        log_to_table("profiles/train", train_profiles)
+        log_to_table("profiles/test", test_profiles)
 
     with put_dir(config.out_url) as tmpdir:
+        # TODO: need to convert ot np.float to serialize
+        with open(os.path.join(tmpdir, "scores.json"), "w") as f:
+            json.dump({"train": train_scores, "test": test_scores}, f)
+
         with open(os.path.join(tmpdir, "history.json"), "w") as f:
             json.dump(history.params, f)
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -215,16 +215,9 @@ def main(config: TrainConfig, seed: int = 0):
     test_set = next(iter(test_ds.shuffle(160_000).batch(80_000)))
 
     model = config.build(train_set)
-    output_names = set(model(train_set))
 
     if config.shuffle_buffer_size is not None:
         train_ds = train_ds.shuffle(config.shuffle_buffer_size)
-
-    def split_in_out(m):
-        return (
-            {key: m[key] for key in model.input_names if key in m},
-            {key: m[key] for key in output_names if key in m},
-        )
 
     if config.checkpoint_model:
         callbacks.append(
@@ -236,9 +229,6 @@ def main(config: TrainConfig, seed: int = 0):
         )
 
     config.loss.prepare(output_samples=train_set)
-
-    train_ds = train_ds.map(split_in_out)
-    test_ds = test_ds.map(split_in_out)
 
     with tempfile.TemporaryDirectory() as train_temp:
         with tempfile.TemporaryDirectory() as test_temp:

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -19,7 +19,7 @@ from fv3fit._shared.config import (
     get_arg_updated_config_dict,
     to_nested_dict,
 )
-from fv3fit.emulation import models, Trainer, ModelCheckpointCallback
+from fv3fit.emulation import models, train, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
 from fv3fit.emulation.data.config import SliceConfig
 from fv3fit.emulation.keras import CustomLoss, StandardLoss, save_model, score_model
@@ -226,10 +226,6 @@ def main(config: TrainConfig, seed: int = 0):
             {key: m[key] for key in output_names if key in m},
         )
 
-    trainer = Trainer(model)
-    config.loss.prepare(output_samples=train_set)
-    config.loss.compile(trainer)
-
     if config.checkpoint_model:
         callbacks.append(
             ModelCheckpointCallback(
@@ -238,6 +234,9 @@ def main(config: TrainConfig, seed: int = 0):
                 )
             )
         )
+
+    config.loss.prepare(output_samples=train_set)
+
     train_ds = train_ds.map(split_in_out)
     test_ds = test_ds.map(split_in_out)
 
@@ -247,14 +246,17 @@ def main(config: TrainConfig, seed: int = 0):
             train_ds_cached = train_ds.batch(config.batch_size).cache(train_temp)
             test_ds_cached = test_ds.batch(config.batch_size).cache(test_temp)
 
-            history = trainer.fit(
+            history = train(
+                model,
                 train_ds_cached,
+                config.loss,
                 epochs=config.epochs,
                 validation_data=test_ds_cached,
                 validation_freq=config.valid_freq,
                 verbose=config.verbose,
                 callbacks=callbacks,
             )
+
     logger.debug("Training complete")
     train_scores, train_profiles = score_model(model, train_set)
     test_scores, test_profiles = score_model(model, test_set)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import os
 import tempfile
 import warnings
@@ -28,6 +29,8 @@ from fv3fit.wandb import (
     log_to_table,
     store_model_artifact,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def load_config_yaml(path: str) -> Dict[str, Any]:
@@ -65,6 +68,7 @@ class TrainConfig:
         shuffle_buffer_size: How many samples to keep in the keras shuffle buffer
             during training
         checkpoint_model: if true, save a checkpoint after each epoch
+        log_level: what logging level to use
     """
 
     train_url: str
@@ -84,6 +88,7 @@ class TrainConfig:
     verbose: int = 2
     shuffle_buffer_size: Optional[int] = 100_000
     checkpoint_model: bool = True
+    log_level: str = "INFO"
 
     @property
     def _model(
@@ -191,6 +196,7 @@ class TrainConfig:
 
 
 def main(config: TrainConfig, seed: int = 0):
+    logging.basicConfig(level=getattr(logging, config.log_level))
     set_random_seed(seed)
 
     callbacks = []
@@ -249,9 +255,10 @@ def main(config: TrainConfig, seed: int = 0):
                 verbose=config.verbose,
                 callbacks=callbacks,
             )
-
+    logger.debug("Training complete")
     train_scores, train_profiles = score_model(model, train_set)
     test_scores, test_profiles = score_model(model, test_set)
+    logger.debug("Scoring Complete")
 
     if config.use_wandb:
         pred_sample = model.predict(test_set)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -18,7 +18,7 @@ from fv3fit._shared.config import (
     get_arg_updated_config_dict,
     to_nested_dict,
 )
-from fv3fit.emulation import models
+from fv3fit.emulation import models, Trainer, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
 from fv3fit.emulation.data.config import SliceConfig
 from fv3fit.emulation.keras import CustomLoss, StandardLoss, save_model, score_model
@@ -64,6 +64,7 @@ class TrainConfig:
         verbose: Verbosity of keras fit output
         shuffle_buffer_size: How many samples to keep in the keras shuffle buffer
             during training
+        checkpoint_model: if true, save a checkpoint after each epoch
     """
 
     train_url: str
@@ -82,6 +83,7 @@ class TrainConfig:
     valid_freq: int = 5
     verbose: int = 2
     shuffle_buffer_size: Optional[int] = 100_000
+    checkpoint_model: bool = True
 
     @property
     def _model(
@@ -208,8 +210,6 @@ def main(config: TrainConfig, seed: int = 0):
 
     model = config.build(train_set)
     output_names = set(model(train_set))
-    config.loss.prepare(output_samples=train_set)
-    config.loss.compile(model)
 
     if config.shuffle_buffer_size is not None:
         train_ds = train_ds.shuffle(config.shuffle_buffer_size)
@@ -220,6 +220,18 @@ def main(config: TrainConfig, seed: int = 0):
             {key: m[key] for key in output_names if key in m},
         )
 
+    trainer = Trainer(model)
+    config.loss.prepare(output_samples=train_set)
+    config.loss.compile(trainer)
+
+    if config.checkpoint_model:
+        callbacks.append(
+            ModelCheckpointCallback(
+                filepath=os.path.join(
+                    config.out_url, "checkpoints", "epoch.{epoch:03d}.tf"
+                )
+            )
+        )
     train_ds = train_ds.map(split_in_out)
     test_ds = test_ds.map(split_in_out)
 
@@ -229,7 +241,7 @@ def main(config: TrainConfig, seed: int = 0):
             train_ds_cached = train_ds.batch(config.batch_size).cache(train_temp)
             test_ds_cached = test_ds.batch(config.batch_size).cache(test_temp)
 
-            history = model.fit(
+            history = trainer.fit(
                 train_ds_cached,
                 epochs=config.epochs,
                 validation_data=test_ds_cached,

--- a/external/fv3fit/fv3fit/wandb.py
+++ b/external/fv3fit/fv3fit/wandb.py
@@ -27,7 +27,10 @@ class WandBConfig:
     @staticmethod
     def get_callback():
         """Grab a callback for logging during keras training"""
-        return wandb.keras.WandbCallback(save_weights_only=False)
+        # disable model saving since wandb doesn't support saving models in
+        # SavedModel format and our models only support that format
+        # see https://github.com/wandb/client/issues/2987
+        return wandb.keras.WandbCallback(save_model=False)
 
     def init(self, config: Optional[Dict[str, Any]] = None):
         """Start logging specified by this config"""

--- a/external/fv3fit/fv3fit/wandb.py
+++ b/external/fv3fit/fv3fit/wandb.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import dataclasses
+import logging
 import wandb
 import matplotlib.pyplot as plt
 import numpy as np
@@ -53,6 +54,7 @@ def log_to_table(log_key: str, data: Dict[str, Any], index: Optional[List[Any]] 
         index: Provide an index for the column values, useful when
             the data are single values, e.g., the scoring metrics
     """
+    logging.getLogger("log_to_table").debug(f"logging {log_key} to weights and biases")
 
     df = pd.DataFrame(data, index=index)
     table = wandb.Table(dataframe=df)
@@ -100,6 +102,9 @@ def log_profile_plots(
     """
     Handle profile plots for single- or multi-output models.
     """
+    logging.getLogger("log_profile_plots").debug(
+        f"logging {list(targets)} to weights and biases"
+    )
     for name in set(targets) & set(predictions):
         t = targets[name]
         p = predictions[name]

--- a/external/fv3fit/tests/emulation/models/test_microphysics_config.py
+++ b/external/fv3fit/tests/emulation/models/test_microphysics_config.py
@@ -100,7 +100,9 @@ def test_precip_conserving_config():
     data = {v: one for v in factory.input_variables + factory.output_variables}
     model = factory.build(data)
     out = model(data)
-    assert factory.fields.surface_precipitation.output_name in out
+    precip = out[factory.fields.surface_precipitation.output_name]
+    # scalar outputs need a singleton dimension to avoid broadcasting mayhem
+    assert tuple(precip.shape) == (one.shape[0], 1)
 
 
 def test_precip_conserving_output_variables():

--- a/external/fv3fit/tests/emulation/test_keras.py
+++ b/external/fv3fit/tests/emulation/test_keras.py
@@ -3,6 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 import fv3fit.emulation
+from fv3fit.emulation.trainer import _ModelWrapper
 from fv3fit.emulation.keras import (
     CustomLoss,
     NormalizedMSE,
@@ -38,7 +39,7 @@ def _get_model_and_data():
 
 def test_checkpoint_callback(tmpdir):
     model, _ = _get_model_and_data()
-    trainer = fv3fit.emulation.Trainer(model)
+    trainer = _ModelWrapper(model)
     callback = fv3fit.emulation.ModelCheckpointCallback(
         filepath=str(tmpdir.join("{epoch:03d}.tf"))
     )
@@ -53,15 +54,9 @@ def test_model_save(tmp_path):
     after fitting"""
 
     model, data = _get_model_and_data()
-    trainer = fv3fit.emulation.Trainer(model)
-    trainer.compile(optimizer="adam", metrics=["mae"], loss={"a": tf.keras.losses.MSE})
-    trainer.fit({"a": data["a"]}, {"b": data["b"]})
-
     output_before_save = model(data)["b"]
-
     save_model(model, str(tmp_path))
     loaded = tf.keras.models.load_model(str(tmp_path / "model.tf"))
-
     np.testing.assert_array_equal(output_before_save, loaded(data)["b"])
 
 

--- a/external/fv3fit/tests/emulation/test_keras.py
+++ b/external/fv3fit/tests/emulation/test_keras.py
@@ -35,6 +35,18 @@ def test_train():
     assert not hasattr(train, "loss")
 
 
+def test_train_wrong_shape_error():
+    data = {"x": tf.ones((1, 10)), "y": tf.ones((1, 2, 3))}
+    loss = CustomLoss(loss_variables=["y"], weights={"y": 1.0})
+
+    def model(x):
+        return {"y": tf.ones((2, 3))}
+
+    ds = tf.data.Dataset.from_tensors(data)
+    with pytest.raises(ValueError):
+        train(model, ds, loss)
+
+
 def _get_model_data_loss():
     in_ = tf.keras.Input(shape=[10], name="a")
     out = tf.keras.layers.Dense(10)(in_)

--- a/external/fv3fit/tests/test__py_function.py
+++ b/external/fv3fit/tests/test__py_function.py
@@ -1,0 +1,29 @@
+import fv3fit
+import numpy as np
+import tensorflow as tf
+
+
+def test_py_function_dict_output():
+    def func(x):
+        return {"a": tf.ones((1, 10)), "b": tf.ones((1, 10))}
+
+    x = tf.ones([1, 1])
+    expected = func(x)
+    signature = {
+        "a": tf.TensorSpec(shape=(1, 10), dtype=tf.float32),
+        "b": tf.TensorSpec(shape=(1, 10), dtype=tf.float32),
+    }
+
+    def wrapped_func(x):
+        return fv3fit.py_function_dict_output(func, [x], signature=signature)
+
+    # check that it works...pretty trivial
+    y = wrapped_func(x)
+    assert set(y) == set(expected)
+    for k in y:
+        np.testing.assert_array_equal(y[k], expected[k])
+
+    # check integration with tf.data...non-trivial (just calling ``func`` won't
+    # always work)
+    tf_ds = tf.data.Dataset.from_tensor_slices([1, 1]).map(wrapped_func)
+    assert signature == tf_ds.element_spec

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -20,7 +20,7 @@ spec:
           - {name: flags, value: " "}
           # - {name: memory, value: "8Gi"}
       container:
-        image: us.gcr.io/vcm-ml/prognostic_run:eeb79d7d38efd440fdaa9b7af0543a21987b4a72
+        image: us.gcr.io/vcm-ml/prognostic_run@sha256:a6d32927b4844d2863ba7916f7d3d33749f4448e20534a66a9d4cb4bb6269887
         command: ["bash", "-c", "-x"]
         envFrom:
         - secretRef:
@@ -49,7 +49,6 @@ spec:
             python3 -m fv3fit.train_microphysics \
               --config-path training_config.yaml \
               --wandb.job_type train \
-              --log_level DEBUG \
               {{inputs.parameters.flags}}
       tolerations:
       - key: "dedicated"

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -20,7 +20,7 @@ spec:
           - {name: flags, value: " "}
           # - {name: memory, value: "8Gi"}
       container:
-        image: us.gcr.io/vcm-ml/prognostic_run@sha256:a6d32927b4844d2863ba7916f7d3d33749f4448e20534a66a9d4cb4bb6269887
+        image: us.gcr.io/vcm-ml/prognostic_run:eeb79d7d38efd440fdaa9b7af0543a21987b4a72
         command: ["bash", "-c", "-x"]
         envFrom:
         - secretRef:
@@ -49,6 +49,7 @@ spec:
             python3 -m fv3fit.train_microphysics \
               --config-path training_config.yaml \
               --wandb.job_type train \
+              --log_level DEBUG \
               {{inputs.parameters.flags}}
       tolerations:
       - key: "dedicated"


### PR DESCRIPTION
The conservative model training crashes with out of memory errors in production cases. This PR fixes that...but...along the way...it picked up several random changes/tweaks. See the commit log for more information.

Added public API:
- fv3fit.emulation.train
- fv3fit.emulation.ModelCheckpointCallback
- fv3fit.py_function_dict_output

Significant internal changes:
- save checkpoints to `checkpoints/epochs.001.tf`
- fix the conservative
- cache data while training (greatly increases speed)