### PR TITLE
bump fsspec/gcsfs to 2021.11.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -63,11 +63,11 @@ fastavro==1.3.0
 fasteners==0.15
 filelock==3.0.12
 flatbuffers==1.12
-fsspec==2021.6.0
+fsspec==2021.11.1
 future==0.18.2
 fv3config==0.8.0
 gast==0.3.3
-gcsfs==2021.6.0
+gcsfs==2021.11.1
 gitdb==4.0.7
 gitpython==3.1.17
 google-api-core==1.22.2

--- a/docker/prognostic_run/requirements.txt
+++ b/docker/prognostic_run/requirements.txt
@@ -34,11 +34,11 @@ entrypoints==0.3
 f90nml==1.1.2
 fasteners==0.15
 flatbuffers==1.12
-fsspec==2021.6.0
+fsspec==2021.11.1
 future==0.18.2
 fv3config==0.8.0
 gast==0.3.3
-gcsfs==2021.6.0
+gcsfs==2021.11.1
 gitdb==4.0.7
 gitpython==3.1.17
 google-api-core==1.22.2


### PR DESCRIPTION
Prognostic runs were unable to download some models with `fs.get(...recursive=True)`.