### PR TITLE
Add water vapor path to timeseries and time-mean diags

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -20,6 +20,7 @@ RMSE_VARS = [
     "PRMSL",
     "PRESsfc",
     "PWAT",
+    "water_vapor_path",
     "VIL",
     "iw",
 ]
@@ -41,6 +42,7 @@ GLOBAL_AVERAGE_DYCORE_VARS = [
     "PRMSL",
     "PRESsfc",
     "PWAT",
+    "water_vapor_path",
     "VIL",
     "iw",
 ]
@@ -115,6 +117,7 @@ TIME_MEAN_VARS = [
     "w500",
     "PRESsfc",
     "PWAT",
+    "water_vapor_path",
     "LHTFLsfc",
     "SHTFLsfc",
     "DSWRFsfc",


### PR DESCRIPTION
The prog run report only shows total water path, which includes water condensate species. It's helpful to be able to see timeseries/maps of the water vapor path without the condensates.