### PR TITLE
Separate offline scoring from training

### DIFF
--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -195,7 +195,11 @@ class TrainConfig:
         )
         self.transform.variables = list(required_variables)
 
-        if self.model is not None and "rnn-v1" in self.model.architecture.name and self.cache:
+        if (
+            self.model is not None
+            and "rnn-v1" in self.model.architecture.name
+            and self.cache
+        ):
             logger.warn("Caching disabled for rnn-v1 architectures due to memory leak")
             self.cache = False
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -248,29 +248,10 @@ def main(config: TrainConfig, seed: int = 0):
                 callbacks=callbacks,
             )
 
+    
     logger.debug("Training complete")
-    train_scores, train_profiles = score_model(model, train_set)
-    test_scores, test_profiles = score_model(model, test_set)
-    logger.debug("Scoring Complete")
-
-    if config.use_wandb:
-        pred_sample = model.predict(test_set)
-        log_profile_plots(test_set, pred_sample)
-
-        # add level for dataframe index, assumes equivalent feature dims
-        sample_profile = next(iter(train_profiles.values()))
-        train_profiles["level"] = np.arange(len(sample_profile))
-        test_profiles["level"] = np.arange(len(sample_profile))
-
-        log_to_table("score/train", train_scores, index=[config.wandb.job.name])
-        log_to_table("score/test", test_scores, index=[config.wandb.job.name])
-        log_to_table("profiles/train", train_profiles)
-        log_to_table("profiles/test", test_profiles)
-
+    
     with put_dir(config.out_url) as tmpdir:
-        # TODO: need to convert ot np.float to serialize
-        with open(os.path.join(tmpdir, "scores.json"), "w") as f:
-            json.dump({"train": train_scores, "test": test_scores}, f)
 
         with open(os.path.join(tmpdir, "history.json"), "w") as f:
             json.dump(history.params, f)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 import dacite
 import fsspec
-import numpy as np
 import tensorflow as tf
 import yaml
 from fv3fit import set_random_seed
@@ -23,11 +22,9 @@ from fv3fit.emulation import models, train, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
 from fv3fit.emulation.data.config import SliceConfig
 from fv3fit.emulation.layers import ArchitectureConfig
-from fv3fit.emulation.keras import CustomLoss, StandardLoss, save_model, score_model
+from fv3fit.emulation.keras import CustomLoss, StandardLoss, save_model
 from fv3fit.wandb import (
     WandBConfig,
-    log_profile_plots,
-    log_to_table,
     store_model_artifact,
 )
 
@@ -213,7 +210,6 @@ def main(config: TrainConfig, seed: int = 0):
     )
 
     train_set = next(iter(train_ds.shuffle(100_000).batch(50_000)))
-    test_set = next(iter(test_ds.shuffle(160_000).batch(80_000)))
 
     model = config.build(train_set)
 
@@ -248,9 +244,8 @@ def main(config: TrainConfig, seed: int = 0):
                 callbacks=callbacks,
             )
 
-    
     logger.debug("Training complete")
-    
+
     with put_dir(config.out_url) as tmpdir:
 
         with open(os.path.join(tmpdir, "history.json"), "w") as f:

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -132,6 +132,21 @@ def test_TrainConfig_from_args_sysargv(monkeypatch):
     assert config.model.architecture.name == "rnn"
 
 
+@pytest.mark.parametrize(
+    "arch_key, expected_cache",
+    [("dense", True), ("rnn-v1", False), ("rnn-v1", False)]
+)
+def test_rnn_v1_cache_disable(arch_key, expected_cache):
+
+    default = get_default_config()
+    d = asdict(default)
+    d["cache"] = True
+    d["model"]["architecture"]["name"] = arch_key
+    config = TrainConfig.from_dict(d)
+
+    assert config.cache == expected_cache
+
+
 @pytest.mark.regression
 def test_training_entry_integration(tmp_path):
 

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -133,7 +133,8 @@ def test_TrainConfig_from_args_sysargv(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "arch_key, expected_cache", [("dense", True), ("rnn-v1", False), ("rnn-v1", False)]
+    "arch_key, expected_cache",
+    [("dense", True), ("rnn-v1", False), ("rnn-v1-shared-weights", False)],
 )
 def test_rnn_v1_cache_disable(arch_key, expected_cache):
 

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -133,8 +133,7 @@ def test_TrainConfig_from_args_sysargv(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "arch_key, expected_cache",
-    [("dense", True), ("rnn-v1", False), ("rnn-v1", False)]
+    "arch_key, expected_cache", [("dense", True), ("rnn-v1", False), ("rnn-v1", False)]
 )
 def test_rnn_v1_cache_disable(arch_key, expected_cache):
 

--- a/projects/microphysics/README.md
+++ b/projects/microphysics/README.md
@@ -51,4 +51,12 @@ monthly-initialized training data generation runs as well as gathering
 of netcdfs into training/testing GCS buckets after all runs have finished.
 
 
+### Training a model
+The `train/` subdirectory provides an argo workflow that trains with
+`fv3fit.train_microphysics` and `scripts/score_training.py`. Scoring
+uses the final saved model from training or the last saved epoch at
+`config.out_url`.  A script, `run.sh` provides a convenience method 
+to submit a suite of training experiments using Argo.  
 
+To run scoring on a pre-trained model, `score_training.py` accepts 
+`--model_url <URL>` as an argument to directly reference a model.

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -90,7 +90,14 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_url", help="Specify model path to run scoring for. Overrides use of models at the config.out_url", default=None)
+    parser.add_argument(
+        "--model_url",
+        help=(
+            "Specify model path to run scoring for. Overrides use of models "
+            "at the config.out_url"
+        ),
+        default=None,
+    )
 
     known, unknown = parser.parse_known_args()
     config = TrainConfig.from_args(unknown)

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -60,10 +60,10 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
     test_ds = nc_dir_to_tf_dataset(
         config.test_url, config.transform, nfiles=config.nfiles_valid
     )
-    
+
     train_set = next(iter(train_ds.shuffle(100_000).batch(50_000)))
     test_set = next(iter(test_ds.shuffle(160_000).batch(80_000)))
-    
+
     train_scores, train_profiles = score_model(model, train_set)
     test_scores, test_profiles = score_model(model, test_set)
     logger.debug("Scoring Complete")

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -1,0 +1,97 @@
+import argparse
+from dataclasses import asdict
+import json
+import logging
+import numpy as np
+import os
+import tensorflow as tf
+
+from fv3fit import set_random_seed
+from fv3fit.train_microphysics import TrainConfig
+from fv3fit._shared import put_dir
+from fv3fit.emulation.data import nc_dir_to_tf_dataset
+from fv3fit.emulation.keras import score_model
+from fv3fit.wandb import (
+    log_profile_plots,
+    log_to_table,
+)
+from vcm import get_fs
+
+logger = logging.getLogger(__name__)
+
+
+def load_final_model_or_checkpoint(train_out_url) -> tf.keras.Model:
+
+    model_url = os.path.join(train_out_url, "model.tf")
+    checkpoints = os.path.join(train_out_url, "checkpoints", "*.tf")
+
+    fs = get_fs(train_out_url)
+    if fs.exists(model_url):
+        logger.info(f"Loading model for scoring from: {model_url}")
+        url_to_load = model_url
+    elif fs.glob(checkpoints):
+        url_to_load = sorted(fs.glob(checkpoints))[-1]
+        logger.info(f"Loading last model checkpoint for scoring from: {url_to_load}")
+    else:
+        raise FileNotFoundError(f"No keras models found at {train_out_url}")
+
+    return tf.keras.models.load_model(url_to_load)
+
+
+def main(config: TrainConfig, seed: int = 0, model_url: str = None):
+
+    logging.basicConfig(level=getattr(logging, config.log_level))
+    set_random_seed(seed)
+
+    if config.use_wandb:
+        d = asdict(config)
+        d["model_url_override"] = model_url
+        config.wandb.init(config=d, job_type="train_scoring")
+
+    if model_url is None:
+        model = load_final_model_or_checkpoint(config.out_url)
+    else:
+        logger.info(f"Loading user specified model from {model_url}")
+        model = tf.keras.models.load_model(model_url)
+
+    train_ds = nc_dir_to_tf_dataset(
+        config.train_url, config.transform, nfiles=config.nfiles
+    )
+    test_ds = nc_dir_to_tf_dataset(
+        config.test_url, config.transform, nfiles=config.nfiles_valid
+    )
+    
+    train_set = next(iter(train_ds.shuffle(100_000).batch(50_000)))
+    test_set = next(iter(test_ds.shuffle(160_000).batch(80_000)))
+    
+    train_scores, train_profiles = score_model(model, train_set)
+    test_scores, test_profiles = score_model(model, test_set)
+    logger.debug("Scoring Complete")
+
+    if config.use_wandb:
+        pred_sample = model.predict(test_set)
+        log_profile_plots(test_set, pred_sample)
+
+        # add level for dataframe index, assumes equivalent feature dims
+        sample_profile = next(iter(train_profiles.values()))
+        train_profiles["level"] = np.arange(len(sample_profile))
+        test_profiles["level"] = np.arange(len(sample_profile))
+
+        log_to_table("score/train", train_scores, index=[config.wandb.job.name])
+        log_to_table("score/test", test_scores, index=[config.wandb.job.name])
+        log_to_table("profiles/train", train_profiles)
+        log_to_table("profiles/test", test_profiles)
+
+    with put_dir(config.out_url) as tmpdir:
+        with open(os.path.join(tmpdir, "scores.json"), "w") as f:
+            json.dump({"train": train_scores, "test": test_scores}, f)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_url", help="Specify model path to run scoring for. Overrides use of models at the config.out_url", default=None)
+
+    known, unknown = parser.parse_known_args()
+    config = TrainConfig.from_args(unknown)
+    main(config, model_url=known.model_url)

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -46,7 +46,7 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
     if config.use_wandb:
         d = asdict(config)
         d["model_url_override"] = model_url
-        config.wandb.init(config=d, job_type="train_scoring")
+        config.wandb.init(config=d)
 
     if model_url is None:
         model = load_final_model_or_checkpoint(config.out_url)

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -91,7 +91,7 @@ spec:
           - name: training-config
           - {name: flags, value: " "}
       container:
-        image: "us.gcr.io/vcm-ml/prognostic_run{{workflows.parameters.tag}}"
+        image: "us.gcr.io/vcm-ml/prognostic_run{{workflow.parameters.tag}}"
         command: ["bash", "-c", "-x"]
         workingDir: "/fv3net/projects/microphysics"
         envFrom:
@@ -112,10 +112,10 @@ spec:
         resources:
           limits:
             cpu: "7"
-            memory: "28Gi"
+            memory: "28G"
           requests:
             cpu: "7"
-            memory: "28Gi"
+            memory: "28G"
         args:
           - |
             echo "{{inputs.parameters.training-config}}" | base64 --decode > training_config.yaml

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -10,8 +10,11 @@ spec:
   arguments:
     parameters:
     - name: tag
-      value: "@sha256:a6d32927b4844d2863ba7916f7d3d33749f4448e20534a66a9d4cb4bb6269887"
+      value: "@sha256:81479b95e3c920951859258b6b9adab570ea63b6ed3dd4985abd852ae250f2fd"
     - name: wandb-run-group
+      value: ""
+    - name: training-config
+    - name: flags
       value: ""
   volumes:
     - name: gcp-key-secret
@@ -21,13 +24,25 @@ spec:
   templates:
     - name: training
       steps:
-      - - name: train_model
-          template: train_model
+      - - name: train-model
+          template: train-model
           continueOn:
             failed: true
-      - - name: score_model
-          template: score_model
-    - name: train_model
+          arguments:
+            parameters:
+            - name: training-config
+              value: "{{workflow.parameters.training-config}}"
+            - name: flags
+              value: "{{workflow.parameters.flags}}"
+      - - name: score-model
+          template: score-model
+          arguments:
+            parameters:
+            - name: training-config
+              value: "{{workflow.parameters.training-config}}"
+            - name: flags
+              value: "{{workflow.parameters.flags}}"
+    - name: train-model
       inputs:
         parameters:
           - name: training-config
@@ -70,7 +85,7 @@ spec:
         operator: "Equal"
         value: "med-sim-pool"
         effect: "NoSchedule"
-    - name: score_model
+    - name: score-model
       inputs:
         parameters:
           - name: training-config

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -7,6 +7,12 @@ metadata:
     job_type: train
 spec:
   entrypoint: training
+  arguments:
+    parameters:
+    - name: tag
+      value: "@sha256:a6d32927b4844d2863ba7916f7d3d33749f4448e20534a66a9d4cb4bb6269887"
+    - name: wandb-run-group
+      value: ""
   volumes:
     - name: gcp-key-secret
       secret:
@@ -14,13 +20,20 @@ spec:
         secretName: gcp-key
   templates:
     - name: training
+      steps:
+      - - name: train_model
+          template: train_model
+          continueOn:
+            failed: true
+      - - name: score_model
+          template: score_model
+    - name: train_model
       inputs:
         parameters:
           - name: training-config
           - {name: flags, value: " "}
-          # - {name: memory, value: "8Gi"}
       container:
-        image: us.gcr.io/vcm-ml/prognostic_run@sha256:a6d32927b4844d2863ba7916f7d3d33749f4448e20534a66a9d4cb4bb6269887
+        image: "us.gcr.io/vcm-ml/prognostic_run{{workflow.parameters.tag}}"
         command: ["bash", "-c", "-x"]
         envFrom:
         - secretRef:
@@ -32,16 +45,18 @@ spec:
             value: /secret/gcp-credentials/key.json
           - name: WANDB_NAME
             value: "{{workflow.name}}"
+          - name: WANDB_RUN_GROUP
+            value: "{{workflow.parameters.wandb-run-group}}"
         volumeMounts:
           - mountPath: /secret/gcp-credentials
             name: gcp-key-secret
         resources:
           limits:
             cpu: "7"
-            memory: "8Gi"
+            memory: "20Gi"
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "15Gi"
         args:
           - |
             echo "{{inputs.parameters.training-config}}" | base64 --decode > training_config.yaml
@@ -54,4 +69,49 @@ spec:
       - key: "dedicated"
         operator: "Equal"
         value: "med-sim-pool"
-        effect: "NoSchedule"  
+        effect: "NoSchedule"
+    - name: score_model
+      inputs:
+        parameters:
+          - name: training-config
+          - {name: flags, value: " "}
+      container:
+        image: "us.gcr.io/vcm-ml/prognostic_run{{workflows.parameters.tag}}"
+        command: ["bash", "-c", "-x"]
+        workingDir: "/fv3net/projects/microphysics"
+        envFrom:
+        - secretRef:
+            name: wandb-andrep
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/gcp-credentials/key.json
+          - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+            value: /secret/gcp-credentials/key.json
+          - name: WANDB_NAME
+            value: "{{workflow.name}}"
+          - name: WANDB_RUN_GROUP
+            value: "{{workflow.parameters.wandb-run-group}}"
+        volumeMounts:
+          - mountPath: /secret/gcp-credentials
+            name: gcp-key-secret
+        resources:
+          limits:
+            cpu: "7"
+            memory: "30Gi"
+          requests:
+            cpu: "7"
+            memory: "30Gi"
+        args:
+          - |
+            echo "{{inputs.parameters.training-config}}" | base64 --decode > training_config.yaml
+
+            python3 scripts/score_training.py \
+              --config-path training_config.yaml \
+              --wandb.job_type train_score \
+              {{inputs.parameters.flags}}
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "med-sim-pool"
+        effect: "NoSchedule"
+

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -10,7 +10,7 @@ spec:
   arguments:
     parameters:
     - name: tag
-      value: ":9cd6272386a410889de0f7bb814aa4bf2ce56e00"
+      value: ":8042f5711237de53e2c539ddc11ae84ec8d795e2"
     - name: wandb-run-group
       value: ""
     - name: training-config

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -10,7 +10,7 @@ spec:
   arguments:
     parameters:
     - name: tag
-      value: "@sha256:81479b95e3c920951859258b6b9adab570ea63b6ed3dd4985abd852ae250f2fd"
+      value: ":9cd6272386a410889de0f7bb814aa4bf2ce56e00"
     - name: wandb-run-group
       value: ""
     - name: training-config
@@ -112,10 +112,10 @@ spec:
         resources:
           limits:
             cpu: "7"
-            memory: "30Gi"
+            memory: "28Gi"
           requests:
             cpu: "7"
-            memory: "30Gi"
+            memory: "28Gi"
         args:
           - |
             echo "{{inputs.parameters.training-config}}" | base64 --decode > training_config.yaml

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [[ "$1" == "--test" ]]; then
-    extra_flags="--nfiles 2 --nfiles_valid 2"
+    extra_flags="--nfiles 2 --nfiles_valid 2 --epochs 5"
     bucket="vcm-ml-scratch"
 else
     bucket="vcm-ml-experiments"
@@ -12,8 +12,8 @@ fi
 
 group="$(openssl rand -hex 3)"
 
-for config in all-tendency-limited direct-cloud-limited; do
-    for model_type in rnn linear dense; do
+for config in all-tendency-limited; do
+    for model_type in dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"
         out_url=$(artifacts resolve-url "$bucket" microphysics-emulation "${model_name}-${group}")

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -13,7 +13,7 @@ fi
 group="$(openssl rand -hex 3)"
 
 for config in all-tendency-limited direct-cloud-limited; do
-    for model_type in rnn linear dense; do
+    for model_type in rnn-v1 dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"
         out_url=$(artifacts resolve-url "$bucket" microphysics-emulation "${model_name}-${group}")

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -13,7 +13,7 @@ fi
 group="$(openssl rand -hex 3)"
 
 for config in all-tendency-limited direct-cloud-limited; do
-    for model_type in rnn-v1 dense; do
+    for model_type in rnn linear dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"
         out_url=$(artifacts resolve-url "$bucket" microphysics-emulation "${model_name}-${group}")

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -12,8 +12,8 @@ fi
 
 group="$(openssl rand -hex 3)"
 
-for config in all-tendency-limited; do
-    for model_type in dense; do
+for config in all-tendency-limited direct-cloud-limited; do
+    for model_type in rnn linear dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"
         out_url=$(artifacts resolve-url "$bucket" microphysics-emulation "${model_name}-${group}")


### PR DESCRIPTION
Split the training and scoring to ease scoring on partially trained models (failure after some epochs) or scoring of user-specified model (e.g., training finished but scoring failed).

Scoring logic moved to `scripts/score_training.py`.   The scoring script accepts the same arguments as `train_microphysics.py` (--config-path and any keyword updates to configuration), and one additional optional argument, `--model_url <URL>` to load a user-specified model instead of checking for models in `config.out_url`.  By default, the scoring script looks for a final saved model `<config.out_url>/model.tf` and if that does not exist, tries for the last saved epoch `<config.out_url>/checkpoints/*.tf`.

### Minor changes:
- Disable caching for `rnn-v1` and `rnn-v1-shared-weights` architectures
- Add optional run grouping to training argo using `-p wandb-run-group=<GROUP_NAME>`


Argo:
```
Name:                all-tendency-limited-dense-5d1bdb
Namespace:           default
ServiceAccount:      default
Status:              Succeeded
Conditions:          
 Completed           True
Created:             Wed Dec 15 23:04:17 +0000 (2 minutes ago)
Started:             Wed Dec 15 23:04:17 +0000 (2 minutes ago)
Finished:            Wed Dec 15 23:06:07 +0000 (10 seconds ago)
Duration:            1 minute 50 seconds
ResourcesDuration:   8m47s*cpu,4h40m15s*memory
Parameters:          
  training-config:   dXNlX3dhbmRiOiB0cnVlCndhbmRiOgogIHdhbmRiX3Byb2plY3Q6IG1pY3JvcGh5c2ljcy1lbXVsYXRpb24KYmF0Y2hfc2l6ZTogMTI4CmVwb2NoczogNTAKbmZpbGVzX3ZhbGlkOiAxMDAKdmFsaWRfZnJlcTogMgpvdXRfdXJsOiBnczovL3ZjbS1tbC1zY3JhdGNoL2FuZHJlcC8yMDIxLTEwLTAyLXdhbmRiLXRyYWluaW5nL2RlbnNlCnRyYWluX3VybDogZ3M6Ly92Y20tbWwtZXhwZXJpbWVudHMvbWljcm9waHlzaWNzLWVtdWxhdGlvbi8yMDIxLTExLTI0L21pY3JvcGh5c2ljcy10cmFpbmluZy1kYXRhLXYzLXRyYWluaW5nX25ldGNkZnMvdHJhaW4KdGVzdF91cmw6IGdzOi8vdmNtLW1sLWV4cGVyaW1lbnRzL21pY3JvcGh5c2ljcy1lbXVsYXRpb24vMjAyMS0xMS0yNC9taWNyb3BoeXNpY3MtdHJhaW5pbmctZGF0YS12My10cmFpbmluZ19uZXRjZGZzL3Rlc3QKbG9zczoKICBvcHRpbWl6ZXI6CiAgICBrd2FyZ3M6CiAgICAgIGxlYXJuaW5nX3JhdGU6IDAuMDAwMQogICAgbmFtZTogQWRhbQogIGxvc3NfdmFyaWFibGVzOgogIC0gYWlyX3RlbXBlcmF0dXJlX2FmdGVyX3ByZWNwZAogIC0gc3BlY2lmaWNfaHVtaWRpdHlfYWZ0ZXJfcHJlY3BkCiAgLSBjbG91ZF93YXRlcl9taXhpbmdfcmF0aW9fYWZ0ZXJfcHJlY3BkCiAgLSB0b3RhbF9wcmVjaXBpdGF0aW9uCiAgd2VpZ2h0czoKICAgIGFpcl90ZW1wZXJhdHVyZV9hZnRlcl9wcmVjcGQ6IDUwMDAwMC4wCiAgICBzcGVjaWZpY19odW1pZGl0eV9hZnRlcl9wcmVjcGQ6IDUwMDAwMC4wCiAgICBjbG91ZF93YXRlcl9taXhpbmdfcmF0aW9fYWZ0ZXJfcHJlY3BkOiAxLjAKICAgIHRvdGFsX3ByZWNpcGl0YXRpb246IC4wNAptb2RlbDoKICBhcmNoaXRlY3R1cmU6CiAgICBrd2FyZ3M6IHt9CiAgICBuYW1lOiBkZW5zZQogIGlucHV0X3ZhcmlhYmxlczoKICAtIGFpcl90ZW1wZXJhdHVyZV9pbnB1dAogIC0gc3BlY2lmaWNfaHVtaWRpdHlfaW5wdXQKICAtIGNsb3VkX3dhdGVyX21peGluZ19yYXRpb19pbnB1dAogIC0gcHJlc3N1cmVfdGhpY2tuZXNzX29mX2F0bW9zcGhlcmljX2xheWVyCiAgZGlyZWN0X291dF92YXJpYWJsZXM6CiAgLSB0b3RhbF9wcmVjaXBpdGF0aW9uCiAgcmVzaWR1YWxfb3V0X3ZhcmlhYmxlczoKICAgIGFpcl90ZW1wZXJhdHVyZV9hZnRlcl9wcmVjcGQ6IGFpcl90ZW1wZXJhdHVyZV9pbnB1dAogICAgc3BlY2lmaWNfaHVtaWRpdHlfYWZ0ZXJfcHJlY3BkOiBzcGVjaWZpY19odW1pZGl0eV9pbnB1dAogICAgY2xvdWRfd2F0ZXJfbWl4aW5nX3JhdGlvX2FmdGVyX3ByZWNwZDogY2xvdWRfd2F0ZXJfbWl4aW5nX3JhdGlvX2lucHV0CiAgbm9ybWFsaXplX2tleTogbWVhbl9zdGQKICBlbmZvcmNlX3Bvc2l0aXZlOiB0cnVlCiAgc2VsZWN0aW9uX21hcDoKICAgIGFpcl90ZW1wZXJhdHVyZV9pbnB1dDoge3N0b3A6IC0xMH0KICAgIGNsb3VkX3dhdGVyX21peGluZ19yYXRpb19pbnB1dDoge3N0b3A6IC0xMH0KICAgIHByZXNzdXJlX3RoaWNrbmVzc19vZl9hdG1vc3BoZXJpY19sYXllcjoge3N0b3A6IC0xMH0KICAgIHNwZWNpZmljX2h1bWlkaXR5X2lucHV0OiB7c3RvcDogLTEwfQogIHRpbWVzdGVwX2luY3JlbWVudF9zZWM6IDkwMAp0cmFuc2Zvcm06CiAgYW50YXJjdGljX29ubHk6IGZhbHNlCiAgZGVyaXZlZF9taWNyb3BoeXNfdGltZXN0ZXA6IDkwMAogIHVzZV90ZW5zb3JzOiB0cnVlCiAgdmVydGljYWxfc3Vic2VsZWN0aW9uczogbnVsbAo=
  flags:             --model.architecture.name dense --out_url gs://vcm-ml-scratch/microphysics-emulation/2021-12-15/all-tendency-limited-dense-5d1bdb --nfiles 2 --nfiles_valid 2 --epochs 5
  tag:               :8042f5711237de53e2c539ddc11ae84ec8d795e2
  wandb-run-group:   

STEP                                  TEMPLATE     PODNAME                                       DURATION  MESSAGE
 ✔ all-tendency-limited-dense-5d1bdb  training                                                               
 ├---✔ train-model                    train-model  all-tendency-limited-dense-5d1bdb-2386333999  58s         
 └---✔ score-model                    score-model  all-tendency-limited-dense-5d1bdb-2926549638  34s 
```

WandB Links
train: https://wandb.ai/ai2cm/microphysics-emulation/runs/20s3t3uk?workspace=user-aperkins
scoring: https://wandb.ai/ai2cm/microphysics-emulation/runs/1ll7crar?workspace=user-aperkins
