### PR TITLE
Add surface and toa flux variables to fine res budget dataset

### DIFF
--- a/external/fv3fit/tests/emulation/thermobasis/test_emulator.py
+++ b/external/fv3fit/tests/emulation/thermobasis/test_emulator.py
@@ -17,7 +17,7 @@ from fv3fit.emulation.thermobasis.loss import (
 )
 from utils import _get_argsin
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import lists, integers
 
 
@@ -152,13 +152,15 @@ def test_Config_register_parser(args, loss_cls):
 
 
 @given(lists(integers(min_value=0, max_value=100)))
+@settings(deadline=None)
 def test_Config_multi_output_levels(levels):
-    str_levels = ",".join(str(s) for s in levels)
+    levels_set = list(set(levels))
+    str_levels = ",".join(str(s) for s in levels_set)
     parser = argparse.ArgumentParser()
     Config.register_parser(parser)
     args = parser.parse_args(["--multi-output", "--levels", str_levels])
     config = Config.from_args(args)
-    assert config.target.levels == levels
+    assert config.target.levels == levels_set
 
 
 @pytest.mark.network

--- a/external/loaders/loaders/mappers/_fine_res_budget.py
+++ b/external/loaders/loaders/mappers/_fine_res_budget.py
@@ -44,6 +44,16 @@ class FineResBudget(Protocol):
     vulcan_omega_coarse: xarray.DataArray
     T_vulcan_omega_coarse: xarray.DataArray
     T_storage: xarray.DataArray
+    DLWRFsfc_coarse: xarray.DataArray
+    DSWRFsfc_coarse: xarray.DataArray
+    DSWRFtoa_coarse: xarray.DataArray
+    ULWRFsfc_coarse: xarray.DataArray
+    ULWRFtoa_coarse: xarray.DataArray
+    USWRFsfc_coarse: xarray.DataArray
+    USWRFtoa_coarse: xarray.DataArray
+    LHTFLsfc_coarse: xarray.DataArray
+    SHTFLsfc_coarse: xarray.DataArray
+    PRATEsrf_coarse: xarray.DataArray
 
 
 def apparent_heating(data: FineResBudget, include_temperature_nudging: bool = False):

--- a/workflows/fine_res_budget/budget/budgets.py
+++ b/workflows/fine_res_budget/budget/budgets.py
@@ -50,8 +50,10 @@ class Grid:
         pi = self.pressure_at_interface(delp_fine)
         pi_c = self.pressure_at_interface(delp_coarse)
         pi_c_up = self.block_upsample(pi_c, factor=factor)
-
-        fg = self.regrid_vertical(pi, field, pi_c_up)
+        if self.z in field.dims:
+            fg = self.regrid_vertical(pi, field, pi_c_up)
+        else:
+            fg = field
         avg = self.weighted_block_average(fg, area, factor)
         return avg.drop_vars([self.x, self.y, self.z], errors="ignore").rename(
             field.name

--- a/workflows/fine_res_budget/budget/config.py
+++ b/workflows/fine_res_budget/budget/config.py
@@ -35,6 +35,16 @@ GFSPHYSICS_VARIABLES = [
     "dt3dt_pbl_coarse",
     "dt3dt_shal_conv_coarse",
     "dt3dt_sw_coarse",
+    "DLWRFsfc_coarse",
+    "DSWRFsfc_coarse",
+    "DSWRFtoa_coarse",
+    "ULWRFsfc_coarse",
+    "ULWRFtoa_coarse",
+    "USWRFsfc_coarse",
+    "USWRFtoa_coarse",
+    "LHTFLsfc_coarse",
+    "SHTFLsfc_coarse",
+    "PRATEsrf_coarse",
 ]
 
 # Output configurations

--- a/workflows/fine_res_budget/budget/config.py
+++ b/workflows/fine_res_budget/budget/config.py
@@ -44,7 +44,7 @@ GFSPHYSICS_VARIABLES = [
     "USWRFtoa_coarse",
     "LHTFLsfc_coarse",
     "SHTFLsfc_coarse",
-    "PRATEsrf_coarse",
+    "PRATEsfc_coarse",
 ]
 
 # Output configurations

--- a/workflows/fine_res_budget/tests/test_data.py
+++ b/workflows/fine_res_budget/tests/test_data.py
@@ -15,4 +15,9 @@ def test_open_merged(data_dirs):
     ):
         assert name in dataset
 
+    # 2d variable should stay 2d
+    assert set(dataset["PRATEsfc_coarse"].dims) == set(
+        ["step", "tile", "time", "grid_yt", "grid_xt"]
+    )
+
     assert len(dataset["time"]) > 0


### PR DESCRIPTION
This PR adds surface fluxes of precip, latent and sensible heat, and radiation, and top of atmosphere fluxes of radiation, to the fine_res_budget dataset.

Refactored public API:
- added surface fluxes of precip, latent and sensible heat, and radiation, and top of atmosphere fluxes of radiation, to the fine_res_budget dataset
- 2D gfs physics variables can now be added to the fine_res_budget workflow as dataset outputs

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
