### PR TITLE
fv3fit: generalize interface of emulator loss functions

### DIFF
--- a/external/fv3fit/fv3fit/emulation/keras.py
+++ b/external/fv3fit/fv3fit/emulation/keras.py
@@ -1,13 +1,10 @@
-import dataclasses
 import logging
 import os
 import tensorflow as tf
-from typing import Mapping, List
+from typing import Mapping
 
-from fv3fit.emulation.layers.normalization import NormalizeConfig
 import fv3fit.keras.adapters
 from .scoring import score_multi_output, ScoringOutput
-from .._shared.config import OptimizerConfig
 from toolz import get
 
 logger = logging.getLogger(__name__)
@@ -51,78 +48,3 @@ def score_model(model: tf.keras.Model, data: Mapping[str, tf.Tensor],) -> Scorin
     prediction = model(data)
     names = sorted(set(prediction) & set(data))
     return score_multi_output(get(names, data), get(names, prediction), names)
-
-
-class NormalizedMSE(tf.keras.losses.MeanSquaredError):
-    """
-    Keras MSE that uses an emulation normalization class before
-    scoring
-    """
-
-    def __init__(self, norm_cls_name, sample_data, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._normalize = NormalizeConfig(norm_cls_name, sample_data).initialize_layer()
-
-    def call(self, y_true, y_pred):
-        return super().call(self._normalize(y_true), self._normalize(y_pred))
-
-
-@dataclasses.dataclass
-class CustomLoss:
-    """
-    Use custom custom normalized MSE-based losses for specified
-    variables
-
-    Args:
-        optimizer: configuration for the optimizer to
-            compile with the model
-        normalization: the normalization type (see normalization.py) to
-            use for the MSE
-        loss_variables: variable names to include in the MSE loss dict
-        metric_variables: variable names to include in the metrics dict
-        weights: custom scaling for the loss variables applied in the
-            overall keras "loss" term
-    """
-
-    optimizer: OptimizerConfig = dataclasses.field(
-        default_factory=lambda: OptimizerConfig("Adam")
-    )
-    normalization: str = "mean_std"
-    loss_variables: List[str] = dataclasses.field(default_factory=list)
-    metric_variables: List[str] = dataclasses.field(default_factory=list)
-    weights: Mapping[str, float] = dataclasses.field(default_factory=dict)
-
-    def prepare(self, output_samples: Mapping[str, tf.Tensor]):
-        """
-        Prepare the normalized losses for each variable by creating a
-        fitted NormalizedMSE object and place them into the respective
-        loss (+ weights) or metrics group
-
-        Args:
-            output_names: names of each output the model produces
-            output_samples: sample tensors for each output to fit
-                the normalizing layer
-
-        """
-        self.loss_funcs = {}
-        for out_varname, sample in output_samples.items():
-            self.loss_funcs[out_varname] = NormalizedMSE(self.normalization, sample)
-
-    def __call__(self, x, y):
-        try:
-            self.loss_funcs
-        except AttributeError:
-            raise ValueError("Cannot compute loss without first calling prepare().")
-
-        metrics = {}
-        loss = 0.0
-        for out_varname in x:
-            if out_varname in self.loss_variables + self.metric_variables:
-                loss_value = self.loss_funcs[out_varname](
-                    x[out_varname], y[out_varname]
-                )
-                weight = self.weights.get(out_varname, 1.0)
-                if out_varname in self.loss_variables:
-                    loss += loss_value * weight
-                metrics[out_varname] = loss_value
-        return loss, metrics

--- a/external/fv3fit/fv3fit/emulation/losses.py
+++ b/external/fv3fit/fv3fit/emulation/losses.py
@@ -1,0 +1,82 @@
+import dataclasses
+from typing import List, Mapping
+
+import tensorflow as tf
+from fv3fit.emulation.layers.normalization import NormalizeConfig
+
+from .._shared.config import OptimizerConfig
+
+
+class NormalizedMSE(tf.keras.losses.MeanSquaredError):
+    """
+    Keras MSE that uses an emulation normalization class before
+    scoring
+    """
+
+    def __init__(self, norm_cls_name, sample_data, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._normalize = NormalizeConfig(norm_cls_name, sample_data).initialize_layer()
+
+    def call(self, y_true, y_pred):
+        return super().call(self._normalize(y_true), self._normalize(y_pred))
+
+
+@dataclasses.dataclass
+class CustomLoss:
+    """
+    Use custom custom normalized MSE-based losses for specified
+    variables
+
+    Args:
+        optimizer: configuration for the optimizer to
+            compile with the model
+        normalization: the normalization type (see normalization.py) to
+            use for the MSE
+        loss_variables: variable names to include in the MSE loss dict
+        metric_variables: variable names to include in the metrics dict
+        weights: custom scaling for the loss variables applied in the
+            overall keras "loss" term
+    """
+
+    optimizer: OptimizerConfig = dataclasses.field(
+        default_factory=lambda: OptimizerConfig("Adam")
+    )
+    normalization: str = "mean_std"
+    loss_variables: List[str] = dataclasses.field(default_factory=list)
+    metric_variables: List[str] = dataclasses.field(default_factory=list)
+    weights: Mapping[str, float] = dataclasses.field(default_factory=dict)
+
+    def prepare(self, output_samples: Mapping[str, tf.Tensor]):
+        """
+        Prepare the normalized losses for each variable by creating a
+        fitted NormalizedMSE object and place them into the respective
+        loss (+ weights) or metrics group
+
+        Args:
+            output_names: names of each output the model produces
+            output_samples: sample tensors for each output to fit
+                the normalizing layer
+
+        """
+        self.loss_funcs = {}
+        for out_varname, sample in output_samples.items():
+            self.loss_funcs[out_varname] = NormalizedMSE(self.normalization, sample)
+
+    def __call__(self, x, y):
+        try:
+            self.loss_funcs
+        except AttributeError:
+            raise ValueError("Cannot compute loss without first calling prepare().")
+
+        metrics = {}
+        loss = 0.0
+        for out_varname in x:
+            if out_varname in self.loss_variables + self.metric_variables:
+                loss_value = self.loss_funcs[out_varname](
+                    x[out_varname], y[out_varname]
+                )
+                weight = self.weights.get(out_varname, 1.0)
+                if out_varname in self.loss_variables:
+                    loss += loss_value * weight
+                metrics[out_varname] = loss_value
+        return loss, metrics

--- a/external/fv3fit/fv3fit/emulation/losses.py
+++ b/external/fv3fit/fv3fit/emulation/losses.py
@@ -78,5 +78,6 @@ class CustomLoss:
                 weight = self.weights.get(out_varname, 1.0)
                 if out_varname in self.loss_variables:
                     loss += loss_value * weight
-                metrics[out_varname] = loss_value
+                # append "_loss" for backwards compatibility
+                metrics[out_varname + "_loss"] = loss_value
         return loss, metrics

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -1,6 +1,6 @@
 from typing import Any, Sequence, Optional
 import tensorflow as tf
-from fv3fit.emulation.keras import CustomLoss
+from fv3fit.emulation.losses import CustomLoss
 
 
 class _ModelWrapper(tf.keras.Model):

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -22,7 +22,6 @@ class _LayerTrainer(tf.keras.Model):
     """
 
     def __init__(self, model: tf.keras.Model, loss: LossFunction):
-        # TODO doesn't work for "StandardLoss"...can we delete that one?
         super().__init__()
         self.model = model
         self._loss = loss

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -95,7 +95,7 @@ def train(
     return wrapped_model.fit(
         dataset,
         epochs=epochs,
-        validation_data=validation_data if validation_data is not None else None,
+        validation_data=validation_data,
         validation_freq=validation_freq,
         verbose=verbose,
         callbacks=callbacks,

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -23,7 +23,7 @@ from fv3fit.emulation import models, train, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
 from fv3fit.emulation.data.config import SliceConfig
 from fv3fit.emulation.layers import ArchitectureConfig
-from fv3fit.emulation.keras import CustomLoss, StandardLoss, save_model, score_model
+from fv3fit.emulation.keras import CustomLoss, save_model, score_model
 from fv3fit.wandb import (
     WandBConfig,
     log_profile_plots,
@@ -82,7 +82,7 @@ class TrainConfig:
     nfiles_valid: Optional[int] = None
     use_wandb: bool = True
     wandb: WandBConfig = field(default_factory=WandBConfig)
-    loss: Union[StandardLoss, CustomLoss] = field(default_factory=StandardLoss)
+    loss: CustomLoss = field(default_factory=CustomLoss)
     epochs: int = 1
     batch_size: int = 128
     valid_freq: int = 5

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -23,7 +23,8 @@ from fv3fit.emulation import models, train, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
 from fv3fit.emulation.data.config import SliceConfig
 from fv3fit.emulation.layers import ArchitectureConfig
-from fv3fit.emulation.keras import CustomLoss, save_model, score_model
+from fv3fit.emulation.keras import save_model, score_model
+from fv3fit.emulation.losses import CustomLoss
 from fv3fit.wandb import (
     WandBConfig,
     log_profile_plots,

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -242,6 +242,7 @@ def main(config: TrainConfig, seed: int = 0):
                 model,
                 train_ds_cached,
                 config.loss,
+                optimizer=config.loss.optimizer.instance,
                 epochs=config.epochs,
                 validation_data=test_ds_cached,
                 validation_freq=config.valid_freq,

--- a/external/fv3fit/tests/emulation/test_keras.py
+++ b/external/fv3fit/tests/emulation/test_keras.py
@@ -32,7 +32,7 @@ def test_train():
     model, data, loss = _get_model_data_loss()
     ds = tf.data.Dataset.from_tensors(data)
     train(model, ds, loss)
-    assert not hasattr(train, "loss")
+    assert not hasattr(model, "loss")
 
 
 def test_train_wrong_shape_error():

--- a/external/fv3fit/tests/emulation/test_keras.py
+++ b/external/fv3fit/tests/emulation/test_keras.py
@@ -34,7 +34,9 @@ def test_train_loss_integration():
     }
     ds = tf.data.Dataset.from_tensor_slices(batch)
     loss.prepare(batch)
-    history = train(model, ds.batch(2), loss=loss, epochs=3)
+    history = train(
+        model, ds.batch(2), loss=loss, optimizer=tf.keras.optimizers.Adam(), epochs=3
+    )
 
     # this magic number is regression data
     # update it if you expect this test to break

--- a/external/fv3fit/tests/emulation/test_losses.py
+++ b/external/fv3fit/tests/emulation/test_losses.py
@@ -1,0 +1,39 @@
+import pytest
+import numpy as np
+import tensorflow as tf
+from fv3fit.emulation.losses import (
+    CustomLoss,
+    NormalizedMSE,
+)
+
+
+def test_NormalizeMSE():
+    sample = np.array([[25.0], [75.0]])
+    target = np.array([[50.0], [50.0]])
+
+    mse_func = NormalizedMSE("mean_std", sample)
+    mse = mse_func(target, sample)
+    np.testing.assert_approx_equal(mse, 1.0, 6)
+
+
+def test_CustomLoss():
+    loss_fn = CustomLoss(
+        normalization="mean_std",
+        loss_variables=["fieldA", "fieldB"],
+        metric_variables=["fieldC"],
+        weights=dict(fieldA=2.0),
+    )
+
+    tensor = tf.random.normal((100, 2))
+
+    names = ["fieldA", "fieldB", "fieldC", "fieldD"]
+    samples = [tensor] * 4
+    m = dict(zip(names, samples))
+    loss_fn.prepare(m)
+
+    # make a copy with some error
+    compare = m.copy()
+
+    loss, info = loss_fn(m, compare)
+    assert set(info) == set(loss_fn.loss_variables) | set(loss_fn.metric_variables)
+    assert loss.numpy() == pytest.approx(0.0)

--- a/external/fv3fit/tests/emulation/test_losses.py
+++ b/external/fv3fit/tests/emulation/test_losses.py
@@ -35,5 +35,7 @@ def test_CustomLoss():
     compare = m.copy()
 
     loss, info = loss_fn(m, compare)
-    assert set(info) == set(loss_fn.loss_variables) | set(loss_fn.metric_variables)
+    all_loss_vars = set(loss_fn.loss_variables) | set(loss_fn.metric_variables)
+    expected_variables = set(v + "_loss" for v in all_loss_vars)
+    assert set(info) == expected_variables
     assert loss.numpy() == pytest.approx(0.0)


### PR DESCRIPTION
Keras' .compile function is poorly documented for multiple output problems.
Also, for more complex loss functions (e.g. temperature scaled loss), this
interface is not suitable.

* refactor loss functions to have the interface `loss, info = loss_fn(data, prediction)`
* remove the unused StandardLoss object
* move loss functions to `fv3fit.emulation.losses`
* `fv3fit.emulation.train`: separate loss and optimzer into separate args 