### PR TITLE
rename argument of parse_example from 'records' to 'serialized'

### DIFF
--- a/external/emulation/emulation/serialize.py
+++ b/external/emulation/emulation/serialize.py
@@ -96,8 +96,8 @@ dtype=float32)>
             }
 
         @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.string)])
-        def parse_example(self, records: tf.Tensor) -> tf.data.Dataset:
-            parsed = tf.io.parse_example(records, features)
+        def parse_example(self, serialized: tf.Tensor) -> tf.data.Dataset:
+            parsed = tf.io.parse_example(serialized, features)
             return tf.map_fn(
                 self._parse_dict_of_bytes,
                 parsed,


### PR DESCRIPTION
Follow on PR to https://github.com/ai2cm/fv3net/pull/1541 renaming an argument so the names match between methods.