### PR TITLE
Implement log transformation for microphysics emulators

### DIFF
--- a/docs/design-docs/log-transformed-emulator.md
+++ b/docs/design-docs/log-transformed-emulator.md
@@ -1,0 +1,77 @@
+# Goal 
+
+Train a microphysics emulator in log-transformed humidity/cloud water space. 
+
+# Background
+
+Microphysics emulators have especially poor predictions of cloud water in polar
+regions
+([proof]()https://wandb.ai/ai2cm/microphysics-emulation/reports/Shared-panel-21-12-21-10-12-70--VmlldzoxMzY1OTYx)
+and the upper troposphere.
+The prediction of specific humidity and temperature are significantly better except for the most poleward latitudes.
+Log-transforming the cloud water in particular should be helpful.
+
+# Requirements
+
+- data has input fields: specific humidity, cloud water
+- loss is evaluated in log space...model predicts and uses log transformed input
+- metrics information is logged equivalently to allow clean comparison in w and b
+- serialized artifact must predict in original (non-transformed space)
+- can use with ConservativeWaterConfig
+
+# Design
+
+## Configuration
+
+Add `transform` option to `variables`. this will be a dataclass
+`TransformedVariable` which can be configured like this:
+
+```
+...
+transform:
+  variables:
+  - to: log_specific_humidity
+    from: specific_humidity
+    transform: log
+```
+
+## Implementation
+
+We first need a code abstraction defining a "Transform".  Losses and models all
+take in and received dicts of tensors so this should too.  These suggests the
+following transform abstraction:
+
+```python
+TensorDict = Mapping[str, tf.Tensor]
+
+class TensorTransform:
+    def forward(self, x: TensorDict):
+        """transform inputs into a new prognostic basis (e.g. log transform)"""
+
+    def backward(self, transformed: TensorDict) -> TensorDict:
+        """undo the transformation"""
+
+class TransformedLayer(tf.keras.layers.Layer):
+    model: tf.keras.layers.Layer
+    transform: TensorTransform
+    def call(self, x):
+        return transform.backward(self.model(transform.forward(x)))
+```
+
+I will need to write the following implementations
+
+```python
+class PerVariableTransform(Transform):
+    # potentially empty
+    _fields: List[TransformedVariable]
+```
+
+Model-building: hook into `TrainingConfig.build`. Implementation will look like:
+```python
+transform = get_transform(transform_config.variables)
+data_with_transform = transform.forward(data)
+model = build_model(config, data_with_transforms)
+TransformedLayer(model, transform)
+```
+
+Data: hook into  `fv3fit.emulation.data.config.TransformConfig.call`

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -31,16 +31,42 @@ class NoModel:
     """
 
     @property
-    def output_names(self):
-        return []
-
-    @property
     def input_names(self):
         return []
 
     @staticmethod
     def predict(x):
         return {}
+
+
+class CustomModelWrapper:
+    def __init__(self, model):
+        self.model = model
+        in_kwargs = self.model.call.concrete_functions[0].structured_input_signature[0][
+            0
+        ]
+        self.input_names = list(in_kwargs)
+
+    def predict(self, x):
+        out = self.model(x)
+        return {key: tensor.numpy() for key, tensor in out.items()}
+
+
+def load_model(path):
+    model = tf.keras.models.load_model(path)
+    if model.input_names is None:
+        return CustomModelWrapper(model)
+    else:
+        # These following two adapters are for backwards compatibility
+        dict_output_model = adapters.ensure_dict_output(model)
+        return adapters.rename_dict_output(
+            dict_output_model,
+            translation={
+                "air_temperature_output": "air_temperature_after_precpd",
+                "specific_humidity_output": "specific_humidity_after_precpd",
+                "cloud_water_mixing_ratio_output": "cloud_water_mixing_ratio_after_precpd",  # noqa: E501
+            },
+        )
 
 
 @print_errors
@@ -65,17 +91,7 @@ def _load_tf_model(model_path: str) -> tf.keras.Model:
         return NoModel()
     else:
         with get_dir(model_path) as local_model_path:
-            model = tf.keras.models.load_model(local_model_path)
-            # These following two adapters are for backwards compatibility
-            dict_output_model = adapters.ensure_dict_output(model)
-            return adapters.rename_dict_output(
-                dict_output_model,
-                translation={
-                    "air_temperature_output": "air_temperature_after_precpd",
-                    "specific_humidity_output": "specific_humidity_after_precpd",
-                    "cloud_water_mixing_ratio_output": "cloud_water_mixing_ratio_after_precpd",  # noqa: E501
-                },
-            )
+            return load_model(local_model_path)
 
 
 class MicrophysicsHook:

--- a/external/emulation/tests/conftest.py
+++ b/external/emulation/tests/conftest.py
@@ -49,40 +49,22 @@ def dummy_rundir(tmp_path):
         yield rundir
 
 
-T_in = "air_temperature_input"
-T_out = "air_temperature_dummy"
-nz = 63
-
-
 def _create_model():
-    in_ = tf.keras.layers.Input(shape=(nz,), name=T_in)
-    out_ = tf.keras.layers.Lambda(lambda x: x + 1, name=T_out)(in_)
+    in_ = tf.keras.layers.Input(shape=(63,), name="air_temperature_input")
+    out_ = tf.keras.layers.Lambda(lambda x: x + 1, name="air_temperature_dummy")(in_)
     model = tf.keras.Model(inputs=in_, outputs=out_)
 
     return model
 
 
 def _create_model_dict():
-    in_ = tf.keras.layers.Input(shape=(nz,), name=T_in)
+    in_ = tf.keras.layers.Input(shape=(63,), name="air_temperature_input")
     out_ = tf.keras.layers.Lambda(lambda x: x + 1)(in_)
-    model = tf.keras.Model(inputs=in_, outputs={T_out: out_})
+    model = tf.keras.Model(inputs=in_, outputs={"air_temperature_dummy": out_})
     return model
 
 
-def _create_custom_model():
-    class CustomModel(tf.keras.Model):
-        def call(self, x):
-            return {T_out: x[T_in] + 1}
-
-    model = CustomModel()
-    d = {T_in: tf.ones((1, nz))}
-    model(d)
-    return model
-
-
-@pytest.fixture(
-    scope="session", params=[_create_model, _create_model_dict, _create_custom_model]
-)
+@pytest.fixture(scope="session", params=[_create_model, _create_model_dict])
 def saved_model_path(tmp_path_factory, request):
     model = request.param()
     path = tmp_path_factory.mktemp("tf_models") / "dummy_model.tf"

--- a/external/emulation/tests/conftest.py
+++ b/external/emulation/tests/conftest.py
@@ -49,22 +49,40 @@ def dummy_rundir(tmp_path):
         yield rundir
 
 
+T_in = "air_temperature_input"
+T_out = "air_temperature_dummy"
+nz = 63
+
+
 def _create_model():
-    in_ = tf.keras.layers.Input(shape=(63,), name="air_temperature_input")
-    out_ = tf.keras.layers.Lambda(lambda x: x + 1, name="air_temperature_dummy")(in_)
+    in_ = tf.keras.layers.Input(shape=(nz,), name=T_in)
+    out_ = tf.keras.layers.Lambda(lambda x: x + 1, name=T_out)(in_)
     model = tf.keras.Model(inputs=in_, outputs=out_)
 
     return model
 
 
 def _create_model_dict():
-    in_ = tf.keras.layers.Input(shape=(63,), name="air_temperature_input")
+    in_ = tf.keras.layers.Input(shape=(nz,), name=T_in)
     out_ = tf.keras.layers.Lambda(lambda x: x + 1)(in_)
-    model = tf.keras.Model(inputs=in_, outputs={"air_temperature_dummy": out_})
+    model = tf.keras.Model(inputs=in_, outputs={T_out: out_})
     return model
 
 
-@pytest.fixture(scope="session", params=[_create_model, _create_model_dict])
+def _create_custom_model():
+    class CustomModel(tf.keras.Model):
+        def call(self, x):
+            return {T_out: x[T_in] + 1}
+
+    model = CustomModel()
+    d = {T_in: tf.ones((1, nz))}
+    model(d)
+    return model
+
+
+@pytest.fixture(
+    scope="session", params=[_create_model, _create_model_dict, _create_custom_model]
+)
 def saved_model_path(tmp_path_factory, request):
     model = request.param()
     path = tmp_path_factory.mktemp("tf_models") / "dummy_model.tf"

--- a/external/emulation/tests/test_microphysics.py
+++ b/external/emulation/tests/test_microphysics.py
@@ -47,9 +47,10 @@ def test_NoModel():
     model = NoModel()
 
     in_ = model.input_names
+    out_ = model.output_names
     pred = model.predict(1)
 
-    for value in [in_, pred]:
+    for value in [in_, out_, pred]:
         assert not value
         assert isinstance(value, Iterable)
 

--- a/external/emulation/tests/test_microphysics.py
+++ b/external/emulation/tests/test_microphysics.py
@@ -47,10 +47,9 @@ def test_NoModel():
     model = NoModel()
 
     in_ = model.input_names
-    out_ = model.output_names
     pred = model.predict(1)
 
-    for value in [in_, out_, pred]:
+    for value in [in_, pred]:
         assert not value
         assert isinstance(value, Iterable)
 

--- a/external/fv3fit/fv3fit/emulation/data/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/data/__init__.py
@@ -1,5 +1,5 @@
 from .config import TransformConfig
 from . import transforms
-from .load import nc_files_to_tf_dataset, nc_dir_to_tf_dataset, batches_to_tf_dataset
+from .load import nc_files_to_tf_dataset, nc_dir_to_tf_dataset
 from .io import get_nc_files
 from .dict_dataset import netcdf_url_to_dataset

--- a/external/fv3fit/fv3fit/emulation/jacobian.py
+++ b/external/fv3fit/fv3fit/emulation/jacobian.py
@@ -63,3 +63,13 @@ def standardize_jacobians(
             standardized_jacobians.setdefault(out_name, {})[in_name] = j * factor
 
     return standardized_jacobians
+
+
+def compute_standardized_jacobians(model, data, input_variables):
+    avg_profiles = {
+        name: tf.reduce_mean(data[name], axis=0, keepdims=True)
+        for name in input_variables
+    }
+    jacobians = get_jacobians(model, avg_profiles)
+    std_jacobians = standardize_jacobians(jacobians, data)
+    return std_jacobians

--- a/external/fv3fit/fv3fit/emulation/layers/fields.py
+++ b/external/fv3fit/fv3fit/emulation/layers/fields.py
@@ -84,8 +84,10 @@ class FieldOutput(tf.keras.layers.Layer):
                 lambda x: x, name=f"passthru_{self.name}"
             )
 
-        self.relu = tf.keras.layers.ReLU()
         self.use_relu = enforce_positive
+
+        if enforce_positive:
+            self.relu = tf.keras.layers.ReLU()
 
     def call(self, tensor):
 
@@ -168,7 +170,8 @@ class IncrementedFieldOutput(tf.keras.layers.Layer):
         )
         self.increment = IncrementStateLayer(dt_sec, name=f"increment_{self.name}")
         self.use_relu = enforce_positive
-        self.relu = tf.keras.layers.ReLU()
+        if self.use_relu:
+            self.relu = tf.keras.layers.ReLU()
 
     def call(self, field_input, network_output):
 

--- a/external/fv3fit/fv3fit/emulation/models/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/models/__init__.py
@@ -1,1 +1,2 @@
 from .microphysics import *  # noqa: F403
+from .transformed_model import *  # noqa: F403

--- a/external/fv3fit/fv3fit/emulation/models/microphysics.py
+++ b/external/fv3fit/fv3fit/emulation/models/microphysics.py
@@ -1,13 +1,18 @@
 import dataclasses
 import dacite
 import tensorflow as tf
-from typing import List, Mapping
+from typing import Any, List, Mapping
 
-from ..layers import FieldInput, FieldOutput, IncrementedFieldOutput, ArchitectureConfig
 from fv3fit._shared import SliceConfig
 from fv3fit.emulation import thermo
 from fv3fit.keras.adapters import ensure_dict_output
 from fv3fit.emulation.zhao_carr_fields import Field, ZhaoCarrFields
+from fv3fit.emulation.layers import (
+    FieldInput,
+    FieldOutput,
+    IncrementedFieldOutput,
+    ArchitectureConfig,
+)
 
 
 @dataclasses.dataclass
@@ -134,7 +139,7 @@ class MicrophysicsConfig:
             for name in self.input_variables
         }
 
-    def build(self, data: Mapping[str, tf.Tensor],) -> tf.keras.Model:
+    def build(self, data: Mapping[str, tf.Tensor], transform: Any) -> tf.keras.Model:
         """
         Build model described by the configuration
 
@@ -210,7 +215,7 @@ class ConservativeWaterConfig:
             timestep_increment_sec=self.timestep_increment_sec,
             enforce_positive=self.enforce_positive,
             selection_map={v.input_name: v.selection for v in self._input_variables},
-        ).build(data)
+        ).build(data, None)
 
     @property
     def _input_variables(self) -> List[Field]:
@@ -234,7 +239,7 @@ class ConservativeWaterConfig:
     def name(self):
         return f"conservative-microphysics-emulator-{self.architecture.name}"
 
-    def build(self, data: Mapping[str, tf.Tensor]) -> tf.keras.Model:
+    def build(self, data: Mapping[str, tf.Tensor], transform: Any) -> tf.keras.Model:
         model = self._build_base_model(data)
         return _assoc_conservative_precipitation(model, self.fields)
 

--- a/external/fv3fit/fv3fit/emulation/models/microphysics.py
+++ b/external/fv3fit/fv3fit/emulation/models/microphysics.py
@@ -7,6 +7,7 @@ from ..layers import FieldInput, FieldOutput, IncrementedFieldOutput, Architectu
 from fv3fit._shared import SliceConfig
 from fv3fit.emulation import thermo
 from fv3fit.keras.adapters import ensure_dict_output
+from fv3fit.emulation.zhao_carr_fields import Field, ZhaoCarrFields
 
 
 @dataclasses.dataclass
@@ -150,61 +151,6 @@ class MicrophysicsConfig:
                 **self._get_residual_outputs(inputs, data, hidden),
             },
         )
-
-
-@dataclasses.dataclass(frozen=True)
-class Field:
-    """Configuration describing a prognostic field
-
-    A field with no ``output_name`` can be interpreted as an ML input only.
-    A field with no ``input_name`` is a diagnostic.
-
-    Attributes:
-        output_name: the name of the variable representing a field after being
-            modified by the an emulator
-        input_name: the name of the output variable
-        tendency_name: the name to call the output-input difference by
-        selection: how to subset the feature-space of the field
-    
-    Example:
-
-        >>> air_temperature = Field(
-        ...     output_name="air_temperature_after_step",
-        ...     input_name="air_temperature_before_step",
-        ...     tendency_name="tendency_of_air_temperature_due_to_step",
-        ...)
-
-    """
-
-    output_name: str = ""
-    input_name: str = ""
-    residual: bool = True
-    # only used if residual is True
-    tendency_name: str = ""
-    selection: SliceConfig = dataclasses.field(default_factory=SliceConfig)
-
-
-@dataclasses.dataclass(frozen=True)
-class ZhaoCarrFields:
-    """Relationship between names and the physical input/outputs of the
-    Zhao-carr microphysics
-    """
-
-    cloud_water: Field = Field(
-        "cloud_water_mixing_ratio_after_precpd",
-        "cloud_water_mixing_ratio_input",
-        residual=False,
-    )
-
-    specific_humidity: Field = Field(
-        "specific_humidity_after_precpd", "specific_humidity_input", residual=True,
-    )
-
-    air_temperature: Field = Field(
-        "air_temperature_after_precpd", "air_temperature_input", residual=True,
-    )
-    surface_precipitation: Field = Field(output_name="total_precipitation")
-    pressure_thickness = Field(input_name="pressure_thickness_of_atmospheric_layer")
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/emulation/models/microphysics.py
+++ b/external/fv3fit/fv3fit/emulation/models/microphysics.py
@@ -139,7 +139,9 @@ class MicrophysicsConfig:
             for name in self.input_variables
         }
 
-    def build(self, data: Mapping[str, tf.Tensor], transform: Any) -> tf.keras.Model:
+    def build(
+        self, data: Mapping[str, tf.Tensor], transform: Any = None
+    ) -> tf.keras.Model:
         """
         Build model described by the configuration
 
@@ -239,7 +241,9 @@ class ConservativeWaterConfig:
     def name(self):
         return f"conservative-microphysics-emulator-{self.architecture.name}"
 
-    def build(self, data: Mapping[str, tf.Tensor], transform: Any) -> tf.keras.Model:
+    def build(
+        self, data: Mapping[str, tf.Tensor], transform: Any = None
+    ) -> tf.keras.Model:
         model = self._build_base_model(data)
         return _assoc_conservative_precipitation(model, self.fields)
 

--- a/external/fv3fit/fv3fit/emulation/models/transformed_model.py
+++ b/external/fv3fit/fv3fit/emulation/models/transformed_model.py
@@ -42,6 +42,18 @@ class TransformedModelConfig:
     normalize: str = "mean_std"
     enforce_positive: bool = False
 
+    @property
+    def name(self) -> str:
+        return "transformed-model"
+
+    @property
+    def input_variables(self) -> List[str]:
+        return [field.input_name for field in self.fields if field.input_name]
+
+    @property
+    def output_variables(self) -> List[str]:
+        return [field.output_name for field in self.fields if field.output_name]
+
     def build(
         self,
         data: Mapping[str, tf.Tensor],

--- a/external/fv3fit/fv3fit/emulation/models/transformed_model.py
+++ b/external/fv3fit/fv3fit/emulation/models/transformed_model.py
@@ -62,9 +62,20 @@ class TransformedModelConfig:
         factory = FieldFactory(
             self.timestep_increment_sec, self.normalize_key, self.enforce_positive, data
         )
-        return TransformedModel(
+        model = TransformedModel(
             self.fields, self.architecture, factory, transform=transform
         )
+        # first call to model must not have output data
+        # or the serialized model will think the outputs are required inputs
+        model(
+            {
+                name: tensor
+                for name, tensor in data.items()
+                if name in self.input_variables
+            }
+        )
+
+        return model
 
 
 def build_field_output(

--- a/external/fv3fit/fv3fit/emulation/models/transformed_model.py
+++ b/external/fv3fit/fv3fit/emulation/models/transformed_model.py
@@ -1,0 +1,158 @@
+import dataclasses
+from typing import List, Union, Mapping
+from fv3fit.emulation.layers import (
+    FieldInput,
+    FieldOutput,
+    IncrementedFieldOutput,
+    ArchitectureConfig,
+)
+from fv3fit.emulation.zhao_carr_fields import Field
+from fv3fit.emulation import transforms
+import tensorflow as tf
+
+__all__ = ["TransformedModelConfig"]
+
+
+@dataclasses.dataclass
+class TransformedModelConfig:
+    """Builds a model supporting transformed input/output variables
+
+    The ML prediction has the following flow::
+
+        (input data dict) ->
+        transform ->
+        scale ->
+        embed ->
+        architecture ->
+        unscale ->
+        untransform
+
+        Attributes:
+            fields: a list of input/output fields...inputs and outputs are
+                inferred like this::
+
+                    outputs = [field for field in fields if field.output_name]
+                    inputs = [field for field in fields if field.input_name]
+
+    """
+
+    architecture_config: ArchitectureConfig
+    fields: List[Field]
+    dt_sec: int
+    normalize: str = "mean_std"
+    enforce_positive: bool = False
+
+    def build(
+        self,
+        data: Mapping[str, tf.Tensor],
+        transform: transforms.TensorTransform = transforms.Identity,
+    ) -> "TransformedModel":
+        factory = FieldFactory(self.dt_sec, self.normalize, self.enforce_positive, data)
+        return TransformedModel(
+            self.fields, self.architecture_config, factory, transform=transform
+        )
+
+
+def build_field_output(
+    field: Field,
+    data: Mapping[str, tf.Tensor],
+    dt_sec: int,
+    normalize: str,
+    enforce_positive: bool,
+) -> Union[FieldInput, FieldOutput, IncrementedFieldOutput]:
+    if field.residual:
+        return IncrementedFieldOutput(
+            dt_sec=dt_sec,
+            sample_in=data[field.input_name],
+            sample_out=data[field.output_name],
+            denormalize=normalize,
+            enforce_positive=enforce_positive,
+        )
+    else:
+        return FieldOutput(
+            sample_out=data[field.output_name],
+            denormalize=normalize,
+            enforce_positive=enforce_positive,
+        )
+
+
+def build_field_input(
+    field: Field, data: Mapping[str, tf.Tensor], normalize: str,
+) -> Union[FieldOutput, IncrementedFieldOutput]:
+    return FieldInput(
+        sample_in=data[field.input_name],
+        normalize=normalize,
+        selection=field.selection.slice,
+    )
+
+
+@dataclasses.dataclass
+class FieldFactory:
+    _dt_sec: int
+    _normalize: str
+    _enforce_positive: bool
+    _data: Mapping[str, tf.Tensor]
+
+    def build_input(
+        self, field: Field, transform: transforms.TensorTransform
+    ) -> FieldInput:
+        return build_field_input(field, transform.forward(self._data), self._normalize)
+
+    def build_output(
+        self, field: Field, transform: transforms.TensorTransform
+    ) -> tf.keras.layers.Layer:
+        return build_field_output(
+            field,
+            transform.forward(self._data),
+            self._dt_sec,
+            self._normalize,
+            self._enforce_positive,
+        )
+
+    def build_architecture(
+        self,
+        config: ArchitectureConfig,
+        output_variables: List[str],
+        transform: transforms.TensorTransform,
+    ) -> tf.keras.layers.Layer:
+        data = transform.forward(self._data)
+        output_features = {key: data[key].shape[-1] for key in output_variables}
+        return config.build(output_features)
+
+
+class TransformedModel(tf.keras.Model):
+    def __init__(
+        self,
+        fields: List[Field],
+        architecture_config: ArchitectureConfig,
+        factory: FieldFactory,
+        transform: transforms.TensorTransform = transforms.Identity,
+    ):
+        super().__init__()
+        self.transform = transform
+
+        outputs = [field for field in fields if field.output_name]
+        inputs = [field for field in fields if field.input_name]
+
+        self.arch = factory.build_architecture(
+            architecture_config,
+            output_variables=[field.output_name for field in outputs],
+            transform=transform,
+        )
+
+        self.inputs = {
+            field.input_name: factory.build_input(field, transform) for field in inputs
+        }
+
+        self.outputs = {
+            field.output_name: factory.build_output(field, transform)
+            for field in outputs
+        }
+
+    @tf.function
+    def call(self, data: Mapping[str, tf.Tensor]):
+        data = self.transform.forward(data)
+        processed_inputs = {key: self.inputs[key](data[key]) for key in self.inputs}
+        outputs = self.arch(processed_inputs)
+        processed_outputs = {key: outputs[key] for key in self.outputs}
+        return self.transform.backward(processed_outputs)

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -63,8 +63,8 @@ def train(
             and target variables.
         validation_data: same as ``dataset`` but used for computing validation
             scores
-        loss: a loss function ...loss_fn(x,y) returns a scalar and dictionary of
-            scalar metrics when x,y are dicts of tensors
+        loss: a loss function ...loss_fn(truth,prediction) returns a scalar and
+            dictionary of scalar metrics when truth, prediction are dicts of tensors
         optimizer: the optimizer. defaults to tf.keras.layers.Adam.
  
     Returns:

--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -1,9 +1,6 @@
-from typing import Any, Callable, Mapping, Sequence, Optional, Tuple
+from fv3fit.emulation.types import LossFunction
+from typing import Any, Sequence, Optional
 import tensorflow as tf
-
-
-TensorDict = Mapping[str, tf.Tensor]
-LossFunction = Callable[[TensorDict, TensorDict], Tuple[tf.Tensor, TensorDict]]
 
 
 class _ModelWrapper(tf.keras.Model):

--- a/external/fv3fit/fv3fit/emulation/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List
+from typing import List, Set
 
 import tensorflow as tf
 from typing_extensions import Protocol
@@ -11,6 +11,14 @@ class TensorTransform(Protocol):
         pass
 
     def backward(self, x: TensorDict) -> TensorDict:
+        pass
+
+    def backward_names(self, requested_names: Set[str]) -> Set[str]:
+        """input names needed to compute the requested transformed names
+
+        Needed for data loading purposes.
+        
+        """
         pass
 
 
@@ -63,6 +71,10 @@ class PerVariableTransform(TensorTransform):
             except KeyError:
                 pass
         return out
+
+    def backward_names(self, requested_names: Set[str]) -> Set[str]:
+        input_by_output_name = {field.to: field.source for field in self.fields}
+        return {input_by_output_name.get(name, name) for name in requested_names}
 
 
 Identity = PerVariableTransform([])

--- a/external/fv3fit/fv3fit/emulation/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms.py
@@ -1,0 +1,79 @@
+import dataclasses
+from typing import List, Mapping
+
+import tensorflow as tf
+from typing_extensions import Protocol
+
+TensorDict = Mapping[str, tf.Tensor]
+
+
+class TensorTransform(Protocol):
+    def forward(self, x: TensorDict) -> TensorDict:
+        pass
+
+    def backward(self, x: TensorDict) -> TensorDict:
+        pass
+
+
+class TransformedLayer(tf.keras.layers.Layer):
+    """Transform variables for a model
+    """
+
+    def __init__(self, model: tf.keras.layers.Layer, transform: TensorTransform):
+        super().__init__()
+        self._model = model
+        self._transform = transform
+
+    def call(self, x: TensorDict) -> TensorDict:
+        return self._transform.backward(self._model(self._transform.forward(x)))
+
+
+@dataclasses.dataclass
+class LogTransform:
+    """A univariate transformation for::
+
+        y := log(x  + epsilon)
+
+    Attributes:
+        epsilon: the size of the log transform
+    """
+
+    epsilon: float = 1e-23
+
+    def forward(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.math.log(x + self.epsilon)
+
+    def backward(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.math.exp(x) - self.epsilon
+
+
+@dataclasses.dataclass
+class TransformedVariableConfig:
+    """A user facing implementation"""
+
+    source: str
+    to: str
+    transform: LogTransform
+
+
+class PerVariableTransform(TensorTransform):
+    def __init__(self, fields: List[TransformedVariableConfig]):
+        self.fields = fields
+
+    def forward(self, x: TensorDict) -> TensorDict:
+        out = {**x}
+        for transform in self.fields:
+            try:
+                out[transform.to] = transform.transform.forward(x[transform.source])
+            except KeyError:
+                pass
+        return out
+
+    def backward(self, y: TensorDict) -> TensorDict:
+        out = {**y}
+        for transform in self.fields:
+            try:
+                out[transform.source] = transform.transform.backward(y[transform.to])
+            except KeyError:
+                pass
+        return out

--- a/external/fv3fit/fv3fit/emulation/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms.py
@@ -15,19 +15,6 @@ class TensorTransform(Protocol):
         pass
 
 
-class TransformedLayer(tf.keras.layers.Layer):
-    """Transform variables for a model
-    """
-
-    def __init__(self, model: tf.keras.layers.Layer, transform: TensorTransform):
-        super().__init__()
-        self._model = model
-        self._transform = transform
-
-    def call(self, x: TensorDict) -> TensorDict:
-        return self._transform.backward(self._model(self._transform.forward(x)))
-
-
 @dataclasses.dataclass
 class LogTransform:
     """A univariate transformation for::
@@ -77,3 +64,6 @@ class PerVariableTransform(TensorTransform):
             except KeyError:
                 pass
         return out
+
+
+Identity = PerVariableTransform([])

--- a/external/fv3fit/fv3fit/emulation/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms.py
@@ -26,19 +26,22 @@ class TensorTransform(Protocol):
 class LogTransform:
     """A univariate transformation for::
 
-        y := log(x  + epsilon)
+        y := log(max(x,epsilon))
+        x : = exp(x)
+
+    This is not strictly a bijection because of the quashing at epsilon.
 
     Attributes:
         epsilon: the size of the log transform
     """
 
-    epsilon: float = 1e-23
+    epsilon: float = 1e-30
 
     def forward(self, x: tf.Tensor) -> tf.Tensor:
-        return tf.math.log(x + self.epsilon)
+        return tf.math.log(tf.maximum(x, self.epsilon))
 
     def backward(self, x: tf.Tensor) -> tf.Tensor:
-        return tf.math.exp(x) - self.epsilon
+        return tf.math.exp(x)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/emulation/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms.py
@@ -1,10 +1,9 @@
 import dataclasses
-from typing import List, Mapping
+from typing import List
 
 import tensorflow as tf
 from typing_extensions import Protocol
-
-TensorDict = Mapping[str, tf.Tensor]
+from fv3fit.emulation.types import TensorDict
 
 
 class TensorTransform(Protocol):

--- a/external/fv3fit/fv3fit/emulation/types.py
+++ b/external/fv3fit/fv3fit/emulation/types.py
@@ -1,0 +1,5 @@
+import tensorflow as tf
+from typing import Callable, Mapping, Tuple
+
+TensorDict = Mapping[str, tf.Tensor]
+LossFunction = Callable[[TensorDict, TensorDict], Tuple[tf.Tensor, TensorDict]]

--- a/external/fv3fit/fv3fit/emulation/zhao_carr_fields.py
+++ b/external/fv3fit/fv3fit/emulation/zhao_carr_fields.py
@@ -1,0 +1,57 @@
+from fv3fit.emulation.data.config import SliceConfig
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class Field:
+    """Configuration describing a prognostic field
+
+    A field with no ``output_name`` can be interpreted as an ML input only.
+    A field with no ``input_name`` is a diagnostic.
+
+    Attributes:
+        output_name: the name of the variable representing a field after being
+            modified by the an emulator
+        input_name: the name of the output variable
+        tendency_name: the name to call the output-input difference by
+        selection: how to subset the feature-space of the field
+    
+    Example:
+
+        >>> air_temperature = Field(
+        ...     output_name="air_temperature_after_step",
+        ...     input_name="air_temperature_before_step",
+        ...     tendency_name="tendency_of_air_temperature_due_to_step",
+        ...)
+
+    """
+
+    output_name: str = ""
+    input_name: str = ""
+    residual: bool = True
+    # only used if residual is True
+    tendency_name: str = ""
+    selection: SliceConfig = dataclasses.field(default_factory=SliceConfig)
+
+
+@dataclasses.dataclass(frozen=True)
+class ZhaoCarrFields:
+    """Relationship between names and the physical input/outputs of the
+    Zhao-carr microphysics
+    """
+
+    cloud_water: Field = Field(
+        "cloud_water_mixing_ratio_after_precpd",
+        "cloud_water_mixing_ratio_input",
+        residual=False,
+    )
+
+    specific_humidity: Field = Field(
+        "specific_humidity_after_precpd", "specific_humidity_input", residual=True,
+    )
+
+    air_temperature: Field = Field(
+        "air_temperature_after_precpd", "air_temperature_input", residual=True,
+    )
+    surface_precipitation: Field = Field(output_name="total_precipitation")
+    pressure_thickness = Field(input_name="pressure_thickness_of_atmospheric_layer")

--- a/external/fv3fit/fv3fit/keras/adapters.py
+++ b/external/fv3fit/fv3fit/keras/adapters.py
@@ -68,15 +68,15 @@ def ensure_dict_output(model: tf.keras.Model) -> tf.keras.Model:
     return _rename_graph_outputs_to_match_output_keys(_convert_to_dict_output(model))
 
 
-def _ensure_inputs_are_dict(inputs):
-    if isinstance(inputs, Mapping):
-        return inputs
-    else:
-        return {input.name: input for input in inputs}
-
-
 def get_inputs(model: tf.keras.Model) -> Mapping[str, tf.Tensor]:
-    return _ensure_inputs_are_dict(model.inputs)
+    if isinstance(model.inputs, Mapping):
+        return model.inputs
+    elif model.inputs is None:
+        raise ValueError(
+            f"Cannot detect inputs of model {model}. " "Custom models may not work."
+        )
+    else:
+        return {input.name: input for input in model.inputs}
 
 
 def _convert_to_dict_output(model: tf.keras.Model) -> tf.keras.Model:

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -112,7 +112,7 @@ class TrainConfig:
         else:
             raise ValueError("Neither .model or .conservative_model provided.")
 
-    def build(self, data: Mapping[str, tf.Tensor]) -> tf.keras.Model:
+    def build_model(self, data: Mapping[str, tf.Tensor]) -> tf.keras.Model:
         return self._model.build(data)
 
     @classmethod
@@ -227,7 +227,7 @@ def main(config: TrainConfig, seed: int = 0):
 
     train_set = next(iter(train_ds.shuffle(100_000).batch(50_000)))
 
-    model = config.build(train_set)
+    model = config.build_model(train_set)
 
     if config.shuffle_buffer_size is not None:
         train_ds = train_ds.shuffle(config.shuffle_buffer_size)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -241,8 +241,6 @@ def main(config: TrainConfig, seed: int = 0):
             )
         )
 
-    config.loss.prepare(output_samples=train_set)
-
     with tempfile.TemporaryDirectory() as train_temp:
         with tempfile.TemporaryDirectory() as test_temp:
 
@@ -256,7 +254,7 @@ def main(config: TrainConfig, seed: int = 0):
             history = train(
                 model,
                 train_ds_batched,
-                config.loss,
+                config.loss.build(output_samples=train_set),
                 optimizer=config.loss.optimizer.instance,
                 epochs=config.epochs,
                 validation_data=test_ds_batched,

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -210,9 +210,10 @@ class TrainConfig:
     def get_dataset_convertor(
         self,
     ) -> Callable[[xarray.Dataset], Mapping[str, tf.Tensor]]:
-        required_variables = set(self._model.input_variables) | set(
+        model_variables = set(self._model.input_variables) | set(
             self._model.output_variables
         )
+        required_variables = self.get_transform().backward_names(model_variables)
         return self.transform.get_pipeline(required_variables)
 
     def __post_init__(self) -> None:

--- a/external/fv3fit/tests/emulation/test_data_config.py
+++ b/external/fv3fit/tests/emulation/test_data_config.py
@@ -15,16 +15,13 @@ def test_SliceConfig(start, stop, step):
 
 def _get_config() -> TransformConfig:
     return TransformConfig(
-        variables=["a", "b", "c", "d"],
-        antarctic_only=False,
-        vertical_subselections={"a": SliceConfig(start=5)},
+        antarctic_only=False, vertical_subselections={"a": SliceConfig(start=5)},
     )
 
 
 def test_TransformConfig():
     transform = _get_config()
     assert transform.vert_sel_as_slices["a"] == slice(5, None)
-    assert callable(transform)
 
 
 def test_TransformConfig_from_dict():

--- a/external/fv3fit/tests/emulation/test_data_load.py
+++ b/external/fv3fit/tests/emulation/test_data_load.py
@@ -22,9 +22,8 @@ def _get_dataset() -> xr.Dataset:
 
 @pytest.fixture
 def config():
-    return TransformConfig(
-        variables=["air_temperature", "specific_humidity"], use_tensors=True,
-    )
+    variables = ["air_temperature", "specific_humidity"]
+    return TransformConfig(use_tensors=True).get_pipeline(variables)
 
 
 @pytest.fixture(scope="module")
@@ -115,13 +114,6 @@ def test_netcdf_dir_to_tf_dataset_with_shuffle(config, nc_dir):
 
     with pytest.raises(AssertionError):
         np.testing.assert_array_equal(get_first_tensor(ds1), get_first_tensor(ds2))
-
-
-def test_batches_to_tf_dataset(config):
-    xr_dataset = _get_dataset()
-    batches = [xr_dataset] * 3
-    tf_ds = load.batches_to_tf_dataset(batches, config)
-    assert isinstance(tf_ds, tf.data.Dataset)
 
 
 def test_netcdf_url_to_dataset(tmpdir):

--- a/external/fv3fit/tests/emulation/test_keras.py
+++ b/external/fv3fit/tests/emulation/test_keras.py
@@ -24,7 +24,9 @@ def test_train_loss_integration():
     out = tf.keras.layers.Dense(5, name="y1")(in_)
     out2 = tf.keras.layers.Dense(5, name="y2")(in_)
     model = tf.keras.Model(inputs=[in_], outputs={"y1": out, "y2": out2})
-    loss = CustomLoss(loss_variables=["y1", "y2"], weights={"y1": 4.0, "y2": 1.0})
+    loss_config = CustomLoss(
+        loss_variables=["y1", "y2"], weights={"y1": 4.0, "y2": 1.0}
+    )
 
     batch_size = 10
     batch = {
@@ -33,7 +35,7 @@ def test_train_loss_integration():
         "y2": tf.random.uniform((batch_size, 5)),
     }
     ds = tf.data.Dataset.from_tensor_slices(batch)
-    loss.prepare(batch)
+    loss = loss_config.build(batch)
     history = train(
         model, ds.batch(2), loss=loss, optimizer=tf.keras.optimizers.Adam(), epochs=3
     )
@@ -62,8 +64,7 @@ def _get_model_data_loss():
     one = tf.ones((5, 10))
     data = {"a": one, "b": one}
     loss = CustomLoss(loss_variables=["b"], weights={"b": 1.0})
-    loss.prepare(data)
-    return model, data, loss
+    return model, data, loss.build(data)
 
 
 def test_checkpoint_callback(tmpdir):

--- a/external/fv3fit/tests/emulation/test_losses.py
+++ b/external/fv3fit/tests/emulation/test_losses.py
@@ -17,7 +17,7 @@ def test_NormalizeMSE():
 
 
 def test_CustomLoss():
-    loss_fn = CustomLoss(
+    loss_config = CustomLoss(
         normalization="mean_std",
         loss_variables=["fieldA", "fieldB"],
         metric_variables=["fieldC"],
@@ -29,7 +29,7 @@ def test_CustomLoss():
     names = ["fieldA", "fieldB", "fieldC", "fieldD"]
     samples = [tensor] * 4
     m = dict(zip(names, samples))
-    loss_fn.prepare(m)
+    loss_fn = loss_config.build(m)
 
     # make a copy with some error
     compare = m.copy()

--- a/external/fv3fit/tests/emulation/test_models.py
+++ b/external/fv3fit/tests/emulation/test_models.py
@@ -158,7 +158,9 @@ def test_MicrophysicConfig_model_save_reload(arch):
         reloaded = tf.keras.models.load_model(model_path, compile=False)
 
     result = reloaded(sample)
-    np.testing.assert_array_equal(expected["field_output"], result["field_output"])
+    np.testing.assert_allclose(
+        expected["field_output"], result["field_output"], rtol=2e-5
+    )
 
 
 def test_RNN_downward_dependence():

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -58,3 +58,11 @@ def test_per_variable_transform_round_trip():
     assert set(y) >= set(x)
     for key in x:
         _assert_scalar_approx(x[key], y[key])
+
+
+def test_per_variable_transform_backward_names():
+    transform = PerVariableTransform(
+        [TransformedVariableConfig("a", "b", LogTransform())]
+    )
+    assert transform.backward_names({"b"}) == {"a"}
+    assert transform.backward_names({"b", "random"}) == {"a", "random"}

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -1,0 +1,86 @@
+import pytest
+import tensorflow as tf
+from fv3fit.emulation.transforms import (
+    LogTransform,
+    PerVariableTransform,
+    TransformedLayer,
+    TransformedVariableConfig,
+)
+from hypothesis import given
+from hypothesis.strategies import floats
+
+
+def _to_float(x: tf.Tensor) -> float:
+    return x.numpy().item()
+
+
+def _assert_scalar_approx(expected, actual):
+    assert _to_float(expected) == pytest.approx(_to_float(actual))
+
+
+def test_LogTransform_forward_backward():
+    transform = LogTransform()
+    x = tf.constant(0.001)
+    x_approx = transform.backward(transform.forward(x))
+    _assert_scalar_approx(x, x_approx)
+
+
+def _get_per_variable_mocks():
+    class MockTransform:
+        def forward(self, x):
+            return x + 1
+
+        def backward(self, y):
+            return y - 1
+
+    x = {"a": tf.constant(1.0), "b": tf.constant(1.0)}
+    mock_xform = MockTransform()
+    transform = PerVariableTransform(
+        [TransformedVariableConfig("a", "transformed", mock_xform)]
+    )
+    expected_forward = {
+        "a": tf.constant(1.0),
+        "b": tf.constant(1.0),
+        "transformed": tf.constant(mock_xform.forward(x["a"])),
+    }
+
+    return transform, x, expected_forward
+
+
+def test_per_variable_transform_forward():
+    transform, x, expected_forward = _get_per_variable_mocks()
+    y = transform.forward(x)
+    assert set(y) == set(expected_forward)
+    for key in y:
+        _assert_scalar_approx(expected_forward[key], y[key])
+
+
+def test_per_variable_transform_round_trip():
+    transform, x, _ = _get_per_variable_mocks()
+    y = transform.backward(transform.forward(x))
+    assert set(y) >= set(x)
+    for key in x:
+        _assert_scalar_approx(x[key], y[key])
+
+
+@given(floats(-100, 100), floats(-100, 100))
+def test_transformed_layer(a: float, b: float):
+    class MockTransform:
+        def forward(self, x):
+            return x + a
+
+        def backward(self, y):
+            return y - a
+
+    def increment_a(x):
+        return {"transformed": x["transformed"] + b}
+
+    x = {"a": tf.constant(1.0), "b": tf.constant(1.0)}
+    transform = PerVariableTransform(
+        [TransformedVariableConfig("a", "transformed", MockTransform())]
+    )
+    layer = TransformedLayer(increment_a, transform)
+
+    expected = x["a"] + b
+    actual = layer(x)["a"]
+    _to_float(expected) == pytest.approx(_to_float(actual), rel=1e-9)

--- a/external/fv3fit/tests/emulation/thermobasis/test_emulator.py
+++ b/external/fv3fit/tests/emulation/thermobasis/test_emulator.py
@@ -15,7 +15,7 @@ from fv3fit.emulation.thermobasis.loss import (
     RHLossSingleLevel,
     QVLossSingleLevel,
 )
-from utils import _get_argsin
+from ..utils import _get_argsin
 import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import lists, integers

--- a/external/fv3fit/tests/emulation/thermobasis/test_loss.py
+++ b/external/fv3fit/tests/emulation/thermobasis/test_loss.py
@@ -5,7 +5,7 @@ from fv3fit.emulation.thermobasis.loss import (
     MultiVariableLoss,
 )
 import tensorflow as tf
-from utils import _get_argsin
+from ..utils import _get_argsin
 import pytest
 
 

--- a/external/fv3fit/tests/emulation/thermobasis/test_models.py
+++ b/external/fv3fit/tests/emulation/thermobasis/test_models.py
@@ -15,7 +15,7 @@ from fv3fit.emulation.thermobasis.emulator import (
     Config as OnlineEmulatorConfig,
 )
 
-from utils import _get_argsin
+from ..utils import _get_argsin
 
 
 @pytest.mark.parametrize("with_scalars", [True, False])

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -21,9 +21,9 @@ def get_env(args):
     env = {}
     env["TF_MODEL_PATH"] = args.model
     env["OUTPUT_FREQ_SEC"] = args.output_frequency
-    env["SAVE_ZARR"] = args.save_zarr
-    env["SAVE_TFRECORD"] = args.save_tfrecord
-    env["SAVE_NC"] = args.save_nc
+    env["SAVE_ZARR"] = str(args.save_zarr)
+    env["SAVE_TFRECORD"] = str(args.save_tfrecord)
+    env["SAVE_NC"] = str(args.save_nc)
     return env
 
 

--- a/projects/microphysics/train/argo.yaml
+++ b/projects/microphysics/train/argo.yaml
@@ -10,7 +10,7 @@ spec:
   arguments:
     parameters:
     - name: tag
-      value: ":8042f5711237de53e2c539ddc11ae84ec8d795e2"
+      value: ":8fc663ea9bf56db13196ed2a21e89737f35c4550"
     - name: wandb-run-group
       value: ""
     - name: training-config

--- a/projects/microphysics/train/direct-cloud-limited.yaml
+++ b/projects/microphysics/train/direct-cloud-limited.yaml
@@ -23,28 +23,32 @@ loss:
     specific_humidity_after_precpd: 500000.0
     cloud_water_mixing_ratio_after_precpd: 1.0
     total_precipitation: .04
-model:
+transformed_model:
   architecture:
     kwargs: {}
     name: dense
-  input_variables:
-  - air_temperature_input
-  - specific_humidity_input
-  - cloud_water_mixing_ratio_input
-  - pressure_thickness_of_atmospheric_layer
-  direct_out_variables:
-  - cloud_water_mixing_ratio_after_precpd
-  - total_precipitation
-  residual_out_variables:
-    air_temperature_after_precpd: air_temperature_input
-    specific_humidity_after_precpd: specific_humidity_input
+  fields:
+    # prognostic variables
+    - input_name: air_temperature_input
+      output_name: air_temperature_after_precpd
+      selection: {stop: -10}
+      residual: true
+    - input_name: specific_humidity_input
+      output_name: specific_humidity_after_precpd
+      selection: {stop: -10}
+      residual: true
+    - input_name: cloud_water_mixing_ratio_input
+      output_name: cloud_water_mixing_ratio_after_precpd
+      selection: {stop: -10}
+      residual: false
+    # diagnostic variables
+    - output_name: total_precipitation
+      residual: false
+    # inputs
+    - input_name: pressure_thickness_of_atmospheric_layer
+      selection: {stop: -10}
   normalize_key: mean_std
   enforce_positive: true
-  selection_map:
-    air_temperature_input: {stop: -10}
-    cloud_water_mixing_ratio_input: {stop: -10}
-    pressure_thickness_of_atmospheric_layer: {stop: -10}
-    specific_humidity_input: {stop: -10}
   timestep_increment_sec: 900
 transform:
   antarctic_only: false

--- a/projects/microphysics/train/log-cloud.yaml
+++ b/projects/microphysics/train/log-cloud.yaml
@@ -30,8 +30,8 @@ loss:
   weights:
     air_temperature_after_precpd: 500000.0
     specific_humidity_after_precpd: 500000.0
-    log_cloud_output: 0.2
-    total_precipitation: .04
+    log_cloud_output: 2.0
+    total_precipitation: 5
 transformed_model:
   architecture:
     kwargs: {}

--- a/projects/microphysics/train/log-cloud.yaml
+++ b/projects/microphysics/train/log-cloud.yaml
@@ -1,0 +1,66 @@
+use_wandb: true
+wandb:
+  wandb_project: microphysics-emulation
+batch_size: 128
+epochs: 50
+nfiles_valid: 100
+valid_freq: 2
+out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
+train_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/train
+test_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/test
+tensor_transform:
+  - source: cloud_water_mixing_ratio_after_precpd
+    to: log_cloud_output
+    # log by default
+    transform: {}
+  - source: cloud_water_mixing_ratio_input
+    to: log_cloud_input
+    # log by default
+    transform: {}
+loss:
+  optimizer:
+    kwargs:
+      learning_rate: 0.0001
+    name: Adam
+  loss_variables:
+  - air_temperature_after_precpd
+  - specific_humidity_after_precpd
+  - log_cloud_output
+  - total_precipitation
+  weights:
+    air_temperature_after_precpd: 500000.0
+    specific_humidity_after_precpd: 500000.0
+    log_cloud_output: 0.2
+    total_precipitation: .04
+transformed_model:
+  architecture:
+    kwargs: {}
+    name: dense
+  fields:
+    # prognostic variables
+    - input_name: air_temperature_input
+      output_name: air_temperature_after_precpd
+      selection: {stop: -10}
+      residual: true
+    - input_name: specific_humidity_input
+      output_name: specific_humidity_after_precpd
+      selection: {stop: -10}
+      residual: true
+    - input_name: log_cloud_input
+      output_name: log_cloud_output
+      selection: {stop: -10}
+      residual: false
+    # diagnostic variables
+    - output_name: total_precipitation
+      residual: false
+    # inputs
+    - input_name: pressure_thickness_of_atmospheric_layer
+      selection: {stop: -10}
+  normalize_key: mean_std
+  enforce_positive: true
+  timestep_increment_sec: 900
+transform:
+  antarctic_only: false
+  derived_microphys_timestep: 900
+  use_tensors: true
+  vertical_subselections: null

--- a/projects/microphysics/train/log-cloud.yaml
+++ b/projects/microphysics/train/log-cloud.yaml
@@ -57,7 +57,8 @@ transformed_model:
     - input_name: pressure_thickness_of_atmospheric_layer
       selection: {stop: -10}
   normalize_key: mean_std
-  enforce_positive: true
+  # very important to turn this off for log transformed data
+  enforce_positive: false
   timestep_increment_sec: 900
 transform:
   antarctic_only: false

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -12,7 +12,7 @@ fi
 
 group="$(openssl rand -hex 3)"
 
-for config in direct-cloud-limited log-cloud; do
+for config in log-cloud; do
     for model_type in dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"

--- a/projects/microphysics/train/run.sh
+++ b/projects/microphysics/train/run.sh
@@ -12,8 +12,8 @@ fi
 
 group="$(openssl rand -hex 3)"
 
-for config in all-tendency-limited direct-cloud-limited; do
-    for model_type in rnn linear dense; do
+for config in direct-cloud-limited log-cloud; do
+    for model_type in dense; do
         model_name="${config}-${model_type}"
         config_file="${config}.yaml"
         out_url=$(artifacts resolve-url "$bucket" microphysics-emulation "${model_name}-${group}")
@@ -21,7 +21,9 @@ for config in all-tendency-limited direct-cloud-limited; do
         argo submit argo.yaml \
             --name "${model_name}-${group}" \
             -p training-config="$(base64 --wrap 0 $config_file)"\
-            -p flags="--model.architecture.name ${model_type} --out_url ${out_url} ${extra_flags}"
+            -p flags="--transformed_model.architecture.name ${model_type} \
+            --out_url ${out_url} ${extra_flags}" \
+            | tee -a experiment-log.txt
 
     done
 done


### PR DESCRIPTION
log-transformation may improve our skill in antarctica. This PR implements an extensible framework for arbitrary per-input transformations like log. Integrating this with conservative precipitation is left for a later PR...

`fv3ift.emulation.models.TranformedModelConfig` basically replaces `fv3fit.emulation.models.MicrophysicsConfig`...maybe we should delete it once we have tested these changes more thoroughly.

The PR includes some preparatory refactors and cleanups. I tried to separate these commits from the actual feature code. So I recommend reviewing commit-by-commit.

# Smoke tests:

Here are some quicks runs of 2 epochs with 2 files. 

- log-cloud.yaml: https://wandb.ai/ai2cm/microphysics-emulation/runs/rago9xpp
- direct-cloud-limited.yaml: https://wandb.ai/ai2cm/microphysics-emulation/runs/23ekcba5

# Production tests

Here are some production level experiments: https://wandb.ai/ai2cm/microphysics-emulation/reports/Log-transformed-PR-1568---VmlldzoxMzcwNzU1