### PR TITLE
emulation: allow rnn to train with 2d inputs

### DIFF
--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -31,6 +31,7 @@ def combine_inputs(
     """
         Args:
             inputs: a datastructure of tensors to combine into a single tensor
+                (sorted by key)
             combine_axis: Axis to concatenate tensors along.  Note that if expand_axis
                 is specified, it is applied before concatenation.  E.g., combine_axis=1
                 and expand_axis=1 will concatenate along the newly created dimension.

--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -52,10 +52,11 @@ def combine_inputs(
 class RNNLayer(tf.keras.layers.Layer):
     """Base class for RNN architectures
 
-    Scalar inputs (with singleton final dimensions) are passed to every element
     of the input sequence like this::
 
         h[i+1] = rnn(inputs[i], h[i], scalars)
+    Note:
+        Scalar inputs (with singleton final dimensions) are passed to every element
 
     """
 

--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -28,6 +28,14 @@ def combine_inputs(
     combine_axis: int = -1,
     expand_axis: Optional[int] = None,
 ) -> tf.Tensor:
+    """
+        Args:
+            inputs: a datastructure of tensors to combine into a single tensor
+            combine_axis: Axis to concatenate tensors along.  Note that if expand_axis
+                is specified, it is applied before concatenation.  E.g., combine_axis=1
+                and expand_axis=1 will concatenate along the newly created dimension.
+            expand_axis: New axis to add to the input tensors
+    """
 
     if isinstance(inputs, Mapping):
         list_inputs = [inputs[key] for key in sorted(inputs)]

--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -18,13 +18,13 @@ This has the following (haskell-like) pseudocode::
 """
 import dataclasses
 import tensorflow as tf
-from typing import Mapping, Optional, Sequence, Union, Any
+from typing import Mapping, Optional, Any
 
 __all__ = ["ArchitectureConfig"]
 
 
 def combine_inputs(
-    inputs: Union[Sequence[tf.Tensor], Mapping[str, tf.Tensor]],
+    inputs: Mapping[str, tf.Tensor],
     combine_axis: int = -1,
     expand_axis: Optional[int] = None,
 ) -> tf.Tensor:
@@ -36,11 +36,7 @@ def combine_inputs(
                 and expand_axis=1 will concatenate along the newly created dimension.
             expand_axis: New axis to add to the input tensors
     """
-
-    if isinstance(inputs, Mapping):
-        list_inputs = [inputs[key] for key in sorted(inputs)]
-    else:
-        list_inputs = list(inputs)
+    list_inputs = [inputs[key] for key in sorted(inputs)]
 
     if expand_axis is not None:
         expanded_inputs = [

--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -18,7 +18,7 @@ This has the following (haskell-like) pseudocode::
 """
 import dataclasses
 import tensorflow as tf
-from typing import Mapping, Optional, Any
+from typing import Callable, Mapping, Optional, Any
 
 __all__ = ["ArchitectureConfig"]
 
@@ -403,7 +403,7 @@ class _HiddenArchitecture(tf.keras.layers.Layer):
 
     def __init__(
         self,
-        input_layer: tf.keras.layers.Layer,
+        input_layer: Callable[[Mapping[str, tf.Tensor]], tf.Tensor],
         arch_layer: tf.keras.layers.Layer,
         output_layer: tf.keras.layers.Layer,
     ):

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -7,7 +7,7 @@ from fv3fit.emulation.layers.architecture import (
     _HiddenArchitecture,
     MLPBlock,
     HybridRNN,
-    CombineInputs,
+    combine_inputs,
     NoWeightSharingSLP,
     RNNOutput,
     StandardOutput,
@@ -67,8 +67,7 @@ def test_RNN():
 def test_CombineInputs_no_expand():
 
     tensor = _get_tensor((20, 4))
-    combiner = CombineInputs(-1, expand_axis=None)
-    result = combiner((tensor, tensor))
+    result = combine_inputs((tensor, tensor), -1, expand_axis=None)
 
     assert result.shape == (20, 8)
     np.testing.assert_array_equal(result[..., 4:8], tensor)
@@ -77,8 +76,7 @@ def test_CombineInputs_no_expand():
 def test_CombineInputs_expand():
 
     tensor = _get_tensor((20, 4))
-    combiner = CombineInputs(2, expand_axis=2)
-    result = combiner((tensor, tensor, tensor))
+    result = combine_inputs((tensor, tensor, tensor), 2, expand_axis=2)
 
     assert result.shape == (20, 4, 3)
     np.testing.assert_array_equal(result[..., 2], tensor)
@@ -105,7 +103,7 @@ def test_no_weight_sharing_num_weights():
     assert num_weights_expected == total
 
 
-@pytest.mark.parametrize("layer_cls", [CombineInputs, MLPBlock, HybridRNN, RNNBlock])
+@pytest.mark.parametrize("layer_cls", [MLPBlock, HybridRNN, RNNBlock])
 def test_from_config(layer_cls):
 
     layer = layer_cls()

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -100,7 +100,7 @@ def test_rnn_input_layer(scalar_input):
 def test_CombineInputs_no_expand():
 
     tensor = _get_tensor((20, 4))
-    result = combine_inputs((tensor, tensor), -1, expand_axis=None)
+    result = combine_inputs({"a": tensor, "b": tensor}, -1, expand_axis=None)
 
     assert result.shape == (20, 8)
     np.testing.assert_array_equal(result[..., 4:8], tensor)
@@ -109,7 +109,7 @@ def test_CombineInputs_no_expand():
 def test_CombineInputs_expand():
 
     tensor = _get_tensor((20, 4))
-    result = combine_inputs((tensor, tensor, tensor), 2, expand_axis=2)
+    result = combine_inputs({"a": tensor, "b": tensor, "c": tensor}, 2, expand_axis=2)
 
     assert result.shape == (20, 4, 3)
     np.testing.assert_array_equal(result[..., 2], tensor)


### PR DESCRIPTION
When passed scalar inputs like surface pressure, the RNN architecture complains about incompatible shapes. It does not handle the broadcasting of inputs appropriately.

I suggest reviewing commit-by-commit.