### PR TITLE
Fix bug in prescriber

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -470,6 +470,10 @@ class TimeLoop(
                     self._state[TOTAL_PRECIP], net_moistening, self._timestep,
                 )
                 self._state.update_mass_conserving(updated_state_from_tendency)
+        self._log_info(
+            "Applying state updates to postphysics dycore state: "
+            f"{self._state_updates.keys()}"
+        )
         self._state.update_mass_conserving(self._state_updates)
 
         diagnostics.update({name: self._state[name] for name in self._states_to_output})

--- a/workflows/prognostic_c48_run/runtime/names.py
+++ b/workflows/prognostic_c48_run/runtime/names.py
@@ -35,6 +35,7 @@ PREPHYSICS_OVERRIDES = [
     "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface",
     "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",
     "ocean_surface_temperature",
+    "surface_temperature",
 ]
 
 

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -180,9 +180,17 @@ def _get_prescribed_ds(
 def _time_interpolate_data(ds, timesteps, variables):
     vars_interp_nearest = [var for var in variables if var in INTERPOLATE_NEAREST]
     vars_interp_linear = [var for var in variables if var not in INTERPOLATE_NEAREST]
-    ds_interp_nearest = ds[vars_interp_nearest].interp(time=timesteps, method="nearest")
-    ds_interp_linear = ds[vars_interp_linear].interp(time=timesteps)
-    return xr.merge([ds_interp_nearest, ds_interp_linear])
+
+    ds_interp = xr.Dataset()
+    if len(vars_interp_nearest) > 0:
+        ds_interp_nearest = ds[vars_interp_nearest].interp(
+            time=timesteps, method="nearest"
+        )
+        ds_interp.update(ds_interp_nearest)
+    if len(vars_interp_linear) > 0:
+        ds_interp_linear = ds[vars_interp_linear].interp(time=timesteps)
+        ds_interp.update(ds_interp_linear)
+    return ds_interp
 
 
 def _open_ds(dataset_key: str, consolidated: bool) -> xr.Dataset:


### PR DESCRIPTION
The last commit to master (3180d4) contained a bug that would not allow for prescribed datasets to have only linearly or nearest neighbor interpolation. This fixes that bug.

