### PR TITLE
Add DZ to RESTART_VARIABLES in fine-res budget

### DIFF
--- a/workflows/fine_res_budget/budget/config.py
+++ b/workflows/fine_res_budget/budget/config.py
@@ -21,6 +21,7 @@ RESTART_VARIABLES = [
     "delp",
     "sphum",
     "T",
+    "DZ",
 ]
 
 GFSPHYSICS_VARIABLES = [


### PR DESCRIPTION
This will ensure that the vertical thickness is included in the coarsened fine-res budget. This variable is necessary for computing density and relative humidity.
