### PR TITLE
emulation: improve online memory usage

### DIFF
--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -1,3 +1,4 @@
+import gc
 import sys
 from typing import Mapping
 from .._typing import FortranState
@@ -87,11 +88,13 @@ class MicrophysicsHook:
     Instanced at the top level of `_emulate`
     """
 
-    def __init__(self, model_path: str) -> None:
+    def __init__(self, model_path: str, garbage_collection_interval: int = 10) -> None:
 
         self.name = "microphysics emulator"
         self.model = _load_tf_model(model_path)
         self.orig_outputs = None
+        self.garbage_collection_interval = garbage_collection_interval
+        self._calls_since_last_collection = 0
 
     @classmethod
     def from_environ(cls, d: Mapping):
@@ -106,6 +109,13 @@ class MicrophysicsHook:
 
         model_path = d["TF_MODEL_PATH"]
         return cls(model_path)
+
+    def _maybe_garbage_collect(self):
+        if self._calls_since_last_collection % self.garbage_collection_interval:
+            gc.collect()
+            self._calls_since_last_collection = 0
+        else:
+            self._calls_since_last_collection += 1
 
     def microphysics(self, state: FortranState) -> None:
         """
@@ -137,3 +147,4 @@ class MicrophysicsHook:
         }
         state.update(model_outputs)
         state.update(microphysics_diag)
+        self._maybe_garbage_collect()

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -91,8 +91,6 @@ class MicrophysicsHook:
 
         self.name = "microphysics emulator"
         self.model = _load_tf_model(model_path)
-        self.namelist = _load_nml()
-        self.dt_sec = _get_timestep(self.namelist)
         self.orig_outputs = None
 
     @classmethod
@@ -107,7 +105,6 @@ class MicrophysicsHook:
         """
 
         model_path = d["TF_MODEL_PATH"]
-
         return cls(model_path)
 
     def microphysics(self, state: FortranState) -> None:

--- a/external/emulation/tests/test_microphysics.py
+++ b/external/emulation/tests/test_microphysics.py
@@ -9,7 +9,7 @@ from emulation._emulate.microphysics import (
 )
 
 
-def test_Config_integration(saved_model_path, dummy_rundir):
+def test_Config_integration(saved_model_path):
 
     config = MicrophysicsHook(saved_model_path)
 
@@ -60,7 +60,7 @@ def test_load_tf_model_NoModel():
     assert isinstance(model, NoModel)
 
 
-def test_microphysics_NoModel(dummy_rundir):
+def test_microphysics_NoModel():
 
     state = {"empty_state": 1}
     hook = MicrophysicsHook("NO_MODEL")


### PR DESCRIPTION
Certain RNNs (and other models) eventually run out of memory. Proof that this works: [wandb report](https://wandb.ai/ai2cm/microphysics-emulation/reports/Debug-RNN-memory-usage--VmlldzoxNDM4NzA3).