### PR TITLE
Add variables derived from transmissivity to `DerivedMapping`

### DIFF
--- a/external/vcm/tests/test_derived_mapping.py
+++ b/external/vcm/tests/test_derived_mapping.py
@@ -148,6 +148,43 @@ def test_net_downward_shortwave_sfc_flux_derived():
     np.testing.assert_array_almost_equal(derived_net_sw, [1.0, 0.5, 0.0])
 
 
+def test_downward_shortwave_sfc_flux_via_transmissivity():
+    ds = xr.Dataset(
+        {
+            "total_sky_downward_shortwave_flux_at_top_of_atmosphere": xr.DataArray(
+                [2.0, 1.0, 3.0], dims=["x"]
+            ),
+            "shortwave_transmissivity_of_atmospheric_column": (
+                xr.DataArray([0.5, 0.75, 1.0], dims=["x"])
+            ),
+        }
+    )
+    derived_state = DerivedMapping(ds)
+    derived_downward_shortwave = derived_state[
+        "downward_shortwave_sfc_flux_via_transmissivity"
+    ]
+    np.testing.assert_array_almost_equal(derived_downward_shortwave, [1.0, 0.75, 3.0])
+
+
+def test_net_downward_shortwave_sfc_flux_via_transmissivity():
+    ds = xr.Dataset(
+        {
+            "total_sky_downward_shortwave_flux_at_top_of_atmosphere": xr.DataArray(
+                [2.0, 1.0, 3.0], dims=["x"]
+            ),
+            "shortwave_transmissivity_of_atmospheric_column": (
+                xr.DataArray([0.5, 0.75, 1.0], dims=["x"])
+            ),
+            "surface_diffused_shortwave_albedo": xr.DataArray(
+                [0, 0.5, 1.0], dims=["x"]
+            ),
+        }
+    )
+    derived_state = DerivedMapping(ds)
+    derived_net_shortwave = derived_state["net_shortwave_sfc_flux_via_transmissivity"]
+    np.testing.assert_array_almost_equal(derived_net_shortwave, [1.0, 0.375, 0.0])
+
+
 def test_required_inputs():
     @DerivedMapping.register("test_derived_var", required_inputs=["required_input"])
     def test_derived_var(self):

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -171,6 +171,10 @@ def horizontal_wind_tendency_parallel_to_horizontal_wind(self):
     return tendency_projection_onto_wind
 
 
+def _net_sfc_shortwave_flux_via_albedo(downward_sfc_shortwave_flux, albedo):
+    return (1 - albedo) * downward_sfc_shortwave_flux
+
+
 @DerivedMapping.register(
     "net_shortwave_sfc_flux_derived",
     required_inputs=["surface_diffused_shortwave_albedo"],
@@ -181,7 +185,34 @@ def net_shortwave_sfc_flux_derived(self):
     downward_sfc_shortwave_flux = self[
         "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface"
     ]
-    return (1 - albedo) * downward_sfc_shortwave_flux
+    return _net_sfc_shortwave_flux_via_albedo(downward_sfc_shortwave_flux, albedo)
+
+
+@DerivedMapping.register(
+    "downward_shortwave_sfc_flux_via_transmissivity",
+    required_inputs=[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+        "shortwave_transmissivity_of_atmospheric_column",
+    ],
+)
+def downward_shortwave_sfc_flux_via_transmissivity(self):
+    toa_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    transmissivity = self["shortwave_transmissivity_of_atmospheric_column"]
+    return transmissivity * toa_flux
+
+
+@DerivedMapping.register(
+    "net_shortwave_sfc_flux_via_transmissivity",
+    required_inputs=[
+        "surface_diffused_shortwave_albedo",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+        "shortwave_transmissivity_of_atmospheric_column",
+    ],
+)
+def net_shortwave_sfc_flux_via_transmissivity(self):
+    downward_sfc_shortwave_flux = self["downward_shortwave_sfc_flux_via_transmissivity"]
+    albedo = self["surface_diffused_shortwave_albedo"]
+    return _net_sfc_shortwave_flux_via_albedo(downward_sfc_shortwave_flux, albedo)
 
 
 @DerivedMapping.register(


### PR DESCRIPTION
This PR adds the following two variables to the `DerivedMapping` which are useful for using the transmissivity approach to predict the surface shortwave radiative fluxes:
- `"downward_shortwave_sfc_flux_via_transmissivity"`
- `"net_shortwave_sfc_flux_via_transmissivity"`

- [x] Tests added

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
