### PR TITLE
Store intermediate variables in `PureMLStepper.__call__` as diagnostics

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -387,6 +387,11 @@ class TimeLoop(
             _, diagnostics, state_updates = self._prephysics_stepper(
                 self._state.time, self._state
             )
+            if isinstance(self._prephysics_stepper, PureMLStepper) and diagnostics:
+                self._log_debug(
+                    f"Exposing intermediate ML predictands {list(diagnostics.keys())} "
+                    f"from prephysics stepper as diagnostics"
+                )
             if self._prephysics_only_diagnostic_ml:
                 rename_diagnostics(diagnostics)
             else:
@@ -443,6 +448,11 @@ class TimeLoop(
                 "Postphysics stepper updates state directly for "
                 f"{state_updates.keys()}"
             )
+            if isinstance(self._postphysics_stepper, PureMLStepper) and diagnostics:
+                self._log_debug(
+                    f"Exposing intermediate ML predictands {list(diagnostics.keys())} "
+                    f"from postphysics stepper as diagnostics"
+                )
             self._state_updates.update(state_updates)
 
             return diagnostics
@@ -474,6 +484,8 @@ class TimeLoop(
             "Applying state updates to postphysics dycore state: "
             f"{self._state_updates.keys()}"
         )
+        if stepper_diags:
+            self._log_info("Exposing intermediate ")
         self._state.update_mass_conserving(self._state_updates)
 
         diagnostics.update({name: self._state[name] for name in self._states_to_output})

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -453,7 +453,7 @@ class TimeLoop(
                 self._log_debug(
                     f"Exposing ML predictands {list(diagnostics.keys())} from "
                     f"postphysics stepper as diagnostics because they are not "
-                    "state updates or tendencies"
+                    f"state updates or tendencies"
                 )
             self._state_updates.update(state_updates)
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -389,8 +389,9 @@ class TimeLoop(
             )
             if isinstance(self._prephysics_stepper, PureMLStepper) and diagnostics:
                 self._log_debug(
-                    f"Exposing ML predictands {list(diagnostics.keys())} from prephysics "
-                    f"stepper as diagnostics because they are not state updates or tendencies"
+                    f"Exposing ML predictands {list(diagnostics.keys())} from "
+                    f"prephysics stepper as diagnostics because they are not "
+                    f"state updates or tendencies"
                 )
             if self._prephysics_only_diagnostic_ml:
                 rename_diagnostics(diagnostics)
@@ -450,8 +451,9 @@ class TimeLoop(
             )
             if isinstance(self._postphysics_stepper, PureMLStepper) and diagnostics:
                 self._log_debug(
-                    f"Exposing ML predictands {list(diagnostics.keys())} from postphysics "
-                    f"stepper as diagnostics because they are not state updates or tendencies"
+                    f"Exposing ML predictands {list(diagnostics.keys())} from "
+                    f"postphysics stepper as diagnostics because they are not "
+                    "state updates or tendencies"
                 )
             self._state_updates.update(state_updates)
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -389,8 +389,8 @@ class TimeLoop(
             )
             if isinstance(self._prephysics_stepper, PureMLStepper) and diagnostics:
                 self._log_debug(
-                    f"Exposing intermediate ML predictands {list(diagnostics.keys())} "
-                    f"from prephysics stepper as diagnostics"
+                    f"Exposing ML predictands {list(diagnostics.keys())} from prephysics "
+                    f"stepper as diagnostics because they are not state updates or tendencies"
                 )
             if self._prephysics_only_diagnostic_ml:
                 rename_diagnostics(diagnostics)
@@ -450,8 +450,8 @@ class TimeLoop(
             )
             if isinstance(self._postphysics_stepper, PureMLStepper) and diagnostics:
                 self._log_debug(
-                    f"Exposing intermediate ML predictands {list(diagnostics.keys())} "
-                    f"from postphysics stepper as diagnostics"
+                    f"Exposing ML predictands {list(diagnostics.keys())} from postphysics "
+                    f"stepper as diagnostics because they are not state updates or tendencies"
                 )
             self._state_updates.update(state_updates)
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -484,8 +484,6 @@ class TimeLoop(
             "Applying state updates to postphysics dycore state: "
             f"{self._state_updates.keys()}"
         )
-        if stepper_diags:
-            self._log_info("Exposing intermediate ")
         self._state.update_mass_conserving(self._state_updates)
 
         diagnostics.update({name: self._state[name] for name in self._states_to_output})

--- a/workflows/prognostic_c48_run/runtime/names.py
+++ b/workflows/prognostic_c48_run/runtime/names.py
@@ -49,3 +49,7 @@ def is_state_update_variable(key, state: State):
         return True
     else:
         return False
+
+
+def is_tendency_variable(key):
+    return key in TENDENCY_TO_STATE_NAME

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -191,6 +191,8 @@ class PureMLStepper:
                 state_updates[key] = value
             elif is_tendency_variable(key):
                 tendency[key] = value
+            else:
+                diagnostics[key] = value
 
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -8,7 +8,7 @@ from typing import Hashable, Iterable, Mapping, Sequence, Set, Tuple, cast
 import fv3fit
 import xarray as xr
 from runtime.diagnostics import compute_diagnostics, compute_ml_momentum_diagnostics
-from runtime.names import DELP, SPHUM, is_state_update_variable
+from runtime.names import DELP, SPHUM, is_state_update_variable, is_tendency_variable
 from runtime.types import Diagnostics, State
 import vcm
 
@@ -189,7 +189,7 @@ class PureMLStepper:
         for key, value in prediction.items():
             if is_state_update_variable(key, state):
                 state_updates[key] = value
-            else:
+            elif is_tendency_variable(key):
                 tendency[key] = value
 
         for name in state_updates.keys():

--- a/workflows/prognostic_c48_run/tests/machine_learning_mocks.py
+++ b/workflows/prognostic_c48_run/tests/machine_learning_mocks.py
@@ -43,6 +43,12 @@ def get_mock_predictor(
         ]
     elif model_predictands == "state_and_tendency":
         output_variables = ["dQ1", "total_sky_downward_shortwave_flux_at_surface"]
+    elif model_predictands == "state_tendency_and_intermediate":
+        output_variables = [
+            "dQ1",
+            "total_sky_downward_shortwave_flux_at_surface",
+            "shortwave_transmissivity_of_atmospheric_column",
+        ]
     outputs = {
         "dQ1": np.full(nz, dQ1_tendency),
         # include nonzero moistening to test for mass conservation
@@ -51,6 +57,7 @@ def get_mock_predictor(
         "dQv": np.full(nz, 1 / 86400),
         "total_sky_downward_shortwave_flux_at_surface": 300.0,
         "total_sky_downward_longwave_flux_at_surface": 400.0,
+        "shortwave_transmissivity_of_atmospheric_column": 0.5,
     }
     predictor = fv3fit.testing.ConstantOutputPredictor(
         input_variables=["air_temperature", "specific_humidity"],

--- a/workflows/prognostic_c48_run/tests/test_machine_learning.py
+++ b/workflows/prognostic_c48_run/tests/test_machine_learning.py
@@ -61,9 +61,12 @@ def test_ml_steppers_regression_checksum(state, ml_stepper, regtest):
     print(checksums, file=regtest)
 
 
-def test_ml_stepper_state_update(state):
+@pytest.mark.parametrize(
+    "mock_predictor", ["state_and_tendency", "state_tendency_and_intermediate"]
+)
+def test_ml_stepper_state_update(state, mock_predictor):
     ml_stepper = PureMLStepper(
-        get_mock_predictor("state_and_tendency"), timestep=900, hydrostatic=False
+        get_mock_predictor(mock_predictor), timestep=900, hydrostatic=False
     )
     (tendencies, diagnostics, states) = ml_stepper(None, state)
     assert set(states) == {"total_sky_downward_shortwave_flux_at_surface"}

--- a/workflows/prognostic_c48_run/tests/test_machine_learning.py
+++ b/workflows/prognostic_c48_run/tests/test_machine_learning.py
@@ -71,3 +71,5 @@ def test_ml_stepper_state_update(state, mock_predictor):
     (tendencies, diagnostics, states) = ml_stepper(None, state)
     assert set(states) == {"total_sky_downward_shortwave_flux_at_surface"}
     assert set(tendencies) == {"dQ1"}
+    if mock_predictor == "state_tendendency_and_intermediate":
+        assert "shortwave_transmissivity_of_atmospheric_column" in diagnostics


### PR DESCRIPTION
The transmissivity approach for predicting the downward and net shortwave radiative fluxes depends on first predicting a transmissivity that is neither a state update or a tendency.  Before this change, the predicted transmissivity would be incorrectly classified as a tendency in the prognostic run, leading to an error.  Now any intermediate variables are simply stored as potential diagnostics.

- [x] Tests added

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
