### PR TITLE
fv3fit.emulation: add temperature scaling

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/io.py
+++ b/external/fv3fit/fv3fit/emulation/data/io.py
@@ -1,8 +1,27 @@
+import hashlib
 import os
-import fsspec
 from typing import List, Optional
 
+import fsspec
+import tensorflow as tf
+import logging
 from vcm import get_fs
+
+CACHE_DIR = ".data"
+
+logger = logging.getLogger(__name__)
+
+
+def download_cached(path):
+    hash = hashlib.md5(path.encode()).hexdigest()
+    filepath = os.path.join(CACHE_DIR, hash)
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    if not os.path.exists(filepath):
+        logger.info(f"Downloading {path} to {filepath}")
+        tf.io.gfile.copy(path, filepath, overwrite=True)
+    else:
+        logger.debug(f"{path} found in cache at {filepath}.")
+    return filepath
 
 
 def get_nc_files(

--- a/external/fv3fit/fv3fit/emulation/data/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/data/transforms.py
@@ -8,10 +8,9 @@ import numpy as np
 import tensorflow as tf
 from vcm.derived_mapping import DerivedMapping
 import xarray as xr
+from .io import download_cached
 from toolz.functoolz import curry
 from typing import Hashable, Mapping, Sequence, Union
-
-from vcm import get_fs, open_remote_nc
 
 
 logger = logging.getLogger(__name__)
@@ -58,11 +57,8 @@ def _register_derived_variables(mapping: DerivedMapping, timestep):
 
 def open_netcdf_dataset(path: str) -> xr.Dataset:
     """Open a netcdf from a local/remote path"""
-
-    fs = get_fs(path)
-    data = open_remote_nc(fs, path)
-
-    return data
+    local_path = download_cached(path)
+    return xr.open_dataset(local_path)
 
 
 @curry

--- a/external/fv3fit/fv3fit/emulation/transforms/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/__init__.py
@@ -1,2 +1,6 @@
-from .transforms import Identity, TensorTransform, LogTransform, ComposedTransform
-from .factories import ComposedTransformFactory, TransformedVariableConfig
+from .factories import (
+    ComposedTransformFactory,
+    ConditionallyScaled,
+    TransformedVariableConfig,
+)
+from .transforms import ComposedTransform, Identity, LogTransform, TensorTransform

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -74,17 +74,21 @@ def fit_conditional(
 class ConditionallyScaled(TransformFactory):
     """Conditionally scaled transformation
 
-    Scales data by conditional standard deviation and mean::
+    Scales the output-input difference of ``field`` by conditional standard
+    deviation and mean::
 
-                  field - E[field|on]
+                  d field - E[d field|on]
         to =  --------------------------------
-               max[Std[field|on], min_scale]
+               max[Std[d field|on], min_scale]
 
     Attributes:
-        to: name of the transformed variable
+        to: name of the transformed variable.
         condition_on: the variable to condition on
         bins: the number of bins
-        field: the prognostic variable spec
+        field: the prognostic variable spec. The difference between input and
+            output data (``d field``) is normalized.
+        min_scale: the minimium scale to normalize by. Used when the scale might
+            be 0.
 
     """
 

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -57,8 +57,6 @@ def reduce_std(x: tf.Tensor) -> tf.Tensor:
 def fit_conditional(
     x: tf.Tensor, y: tf.Tensor, reduction: Callable[[tf.Tensor], tf.Tensor], bins: int,
 ) -> Callable[[tf.Tensor], tf.Tensor]:
-    # TODO test
-    # should work for vals < min and > max
     min = tf.reduce_min(x)
     max = tf.reduce_max(x)
     edges = tf.linspace(min, max, bins + 1)

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List
+from typing import Callable, List
 
 import tensorflow as tf
 from typing_extensions import Protocol
@@ -50,6 +50,45 @@ class UnivariateTransform(TensorTransform):
     def backward(self, y: TensorDict) -> TensorDict:
         out = {**y}
         out[self.source] = self.transform.backward(y[self.to])
+        return out
+
+
+class ConditionallyScaledTransform(TensorTransform):
+    def __init__(
+        self,
+        to: str,
+        input_name: str,
+        output_name: str,
+        on: str,
+        scale: Callable[[tf.Tensor], tf.Tensor],
+        center: Callable[[tf.Tensor], tf.Tensor],
+        min_scale: float = 0.0,
+    ) -> None:
+        self.to = to
+        self.input_name = input_name
+        self.output_name = output_name
+        self.on = on
+        self.scale = scale
+        self.center = center
+        self.min_scale = min_scale
+
+    def _limited_scale(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.maximum(self.scale(x), self.min_scale)
+
+    def forward(self, x: TensorDict) -> TensorDict:
+        out = {**x}
+        out[self.to] = (
+            x[self.output_name] - x[self.input_name] - self.center(x[self.on])
+        ) / self._limited_scale(x[self.on])
+        return out
+
+    def backward(self, y: TensorDict) -> TensorDict:
+        out = {**y}
+        out[self.output_name] = (
+            y[self.to] * self._limited_scale(y[self.on])
+            + y[self.input_name]
+            + self.center(y[self.on])
+        )
         return out
 
 

--- a/external/fv3fit/fv3fit/keras/math.py
+++ b/external/fv3fit/fv3fit/keras/math.py
@@ -1,7 +1,7 @@
+from typing import Callable
 import tensorflow as tf
 
 
-@tf.function
 def piecewise(x: tf.Tensor, y: tf.Tensor, xg: tf.Tensor) -> tf.Tensor:
     """1D 0th order interpolation
 
@@ -9,13 +9,34 @@ def piecewise(x: tf.Tensor, y: tf.Tensor, xg: tf.Tensor) -> tf.Tensor:
         x: original ordinate, 1D, must be sorted
         y:  original value, 1D
         xg: points to interpolate at
-    
+
     Return:
         yg: interpolated values. same shape as xg. Uses constant extrapolation.
             Within the min/max of x it has the following form::
 
                 f(xg) = y[i] if x[i] <= xg < x[i+1]
     """
-    index = tf.searchsorted(x, xg, side="right") - 1
+    xg_flat = tf.reshape(xg, [-1])
+    index = tf.searchsorted(x, xg_flat, side="right") - 1
     index = tf.maximum(index, 0)
-    return tf.gather(y, index)
+    yg = tf.gather(y, index)
+    return tf.reshape(yg, tf.shape(xg))
+
+
+def groupby_bins(
+    edges: tf.Tensor,
+    x: tf.Tensor,
+    y: tf.Tensor,
+    reduction: Callable[[tf.Tensor], tf.Tensor],
+) -> tf.Tensor:
+    """Groupby edges (left inclusive)"""
+
+    assert tf.rank(edges).numpy() == 1, edges
+    assert tf.reduce_all(edges[1:] - edges[:-1] > 0), "edges not sorted"
+    assert x.shape == y.shape
+
+    n = edges.shape[0] - 1
+
+    output = [reduction(y[(edges[i] <= x) & (x < edges[i + 1])]) for i in range(n)]
+
+    return tf.stack(output)

--- a/external/fv3fit/fv3fit/keras/math.py
+++ b/external/fv3fit/fv3fit/keras/math.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+@tf.function
+def piecewise(x: tf.Tensor, y: tf.Tensor, xg: tf.Tensor) -> tf.Tensor:
+    """1D 0th order interpolation
+
+    Args:
+        x: original ordinate, 1D, must be sorted
+        y:  original value, 1D
+        xg: points to interpolate at
+    
+    Return:
+        yg: interpolated values. same shape as xg. Uses constant extrapolation.
+            Within the min/max of x it has the following form::
+
+                f(xg) = y[i] if x[i] <= xg < x[i+1]
+    """
+    index = tf.searchsorted(x, xg, side="right") - 1
+    index = tf.maximum(index, 0)
+    return tf.gather(y, index)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -19,6 +19,7 @@ from fv3fit._shared.config import (
     get_arg_updated_config_dict,
     to_nested_dict,
 )
+from fv3fit.emulation.transforms.factories import ConditionallyScaled
 from fv3fit.emulation.types import LossFunction, TensorDict
 from fv3fit.emulation import models, train, ModelCheckpointCallback
 from fv3fit.emulation.data import TransformConfig, nc_dir_to_tf_dataset
@@ -89,7 +90,9 @@ class TrainConfig:
     test_url: str
     out_url: str
     transform: TransformConfig = field(default_factory=TransformConfig)
-    tensor_transform: List[TransformedVariableConfig] = field(default_factory=list)
+    tensor_transform: List[
+        Union[TransformedVariableConfig, ConditionallyScaled]
+    ] = field(default_factory=list)
     model: Optional[models.MicrophysicsConfig] = None
     conservative_model: Optional[models.ConservativeWaterConfig] = None
     transformed_model: Optional[models.TransformedModelConfig] = None

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -237,7 +237,13 @@ class TrainConfig:
         self, url: str, nfiles: Optional[int], required_variables: Set[str],
     ) -> tf.data.Dataset:
         nc_open_fn = self.transform.get_pipeline(required_variables)
-        return nc_dir_to_tf_dataset(url, nc_open_fn, nfiles=nfiles)
+        return nc_dir_to_tf_dataset(
+            url,
+            nc_open_fn,
+            nfiles=nfiles,
+            shuffle=True,
+            random_state=np.random.RandomState(0),
+        )
 
     @property
     def model_variables(self) -> Set[str]:

--- a/external/fv3fit/tests/emulation/test_models.py
+++ b/external/fv3fit/tests/emulation/test_models.py
@@ -231,6 +231,8 @@ def test_transform_model_input_names():
         def backward(self, x):
             y = {**x}
             y["out"] = x["transform_out"]
+            # try to grab input field
+            x["a"]
             return y
 
     original_inputs = {"a": tf.keras.Input(10, name="a")}

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+import numpy as np
 import pytest
 import tensorflow as tf
 from fv3fit.emulation.transforms import (
@@ -6,6 +8,9 @@ from fv3fit.emulation.transforms import (
     ComposedTransform,
     TransformedVariableConfig,
 )
+from fv3fit.emulation.transforms.transforms import ConditionallyScaledTransform
+from fv3fit.emulation.transforms.factories import ConditionallyScaled, fit_conditional
+from fv3fit.emulation.zhao_carr_fields import Field
 
 
 def _to_float(x: tf.Tensor) -> float:
@@ -88,3 +93,113 @@ def test_ComposedTransform_forward_backward_on_sequential_transforms():
     data = {"a": tf.ones((1,))}
     assert set(transform.forward(data)) == {"c"}
     assert set(transform.backward(transform.forward(data))) == set(data)
+
+
+def test_fit_conditional():
+    x = tf.convert_to_tensor([0.0, 1, 2])
+    y = tf.convert_to_tensor([1.0, 2, 2])
+    interp = fit_conditional(x, y, tf.reduce_mean, 2)
+    # bins will be 0, 1, 2
+    # mean is [1, 2]
+    out = interp([-1, 0.0, 1, 3])
+    expected = [1, 1, 2, 2]
+    np.testing.assert_array_almost_equal(expected, out)
+
+
+def test_fit_conditional_2d():
+    # should work with multiple dimensions
+    x = tf.convert_to_tensor([0.0, 1, 2])
+    y = tf.convert_to_tensor([1.0, 2, 2])
+    interp = fit_conditional(x, y, tf.reduce_mean, 2)
+
+    in_ = tf.ones((10, 10))
+    out = interp(in_)
+    assert out.shape == in_.shape
+
+
+def _get_mocked_transform(scale_value=2.0):
+    scale = Mock()
+    scale.return_value = scale_value
+    center = Mock()
+    center.return_value = 0.0
+
+    input_name = "x_in"
+    output_name = "x_out"
+    to = "difference"
+
+    zero = tf.zeros((3, 4), dtype=tf.float32)
+
+    expected = 1.0
+
+    data = {input_name: zero, output_name: zero + expected * scale.return_value}
+
+    transform = ConditionallyScaledTransform(
+        input_name=input_name,
+        output_name=output_name,
+        to=to,
+        on=input_name,
+        scale=scale,
+        center=center,
+    )
+
+    return scale, center, transform, data, expected, to
+
+
+def test_ConditionallyScaledTransform_forward():
+    scale, center, transform, data, expected, to = _get_mocked_transform()
+    out = transform.forward(data)
+    np.testing.assert_array_almost_equal(out[to], expected)
+    scale.assert_called_once()
+    center.assert_called_once()
+
+
+def test_ConditionallyScaledTransform_backward():
+    # need a scale-value other than one to find round-tripped errors
+    scale, center, transform, data, expected, to = _get_mocked_transform(
+        scale_value=2.0
+    )
+    out = transform.forward(data)
+    round_tripped = transform.backward(out)
+    assert set(round_tripped) == set(data) | set(out)
+    for key in data:
+        np.testing.assert_array_almost_equal(data[key], round_tripped[key])
+
+
+def test_ConditionallyScaled_backward_names():
+    in_name = "x_in"
+    out_name = "x_out"
+    on = "T"
+    to = "diff"
+    factory = ConditionallyScaled(
+        field=Field(in_name, out_name), to=to, bins=10, condition_on=on
+    )
+    assert factory.backward_names({to}) == {in_name, on, out_name}
+
+
+def test_ConditionallyScaled_backward_names_output_not_in_request():
+    factory = ConditionallyScaled(
+        field=Field("x", "y"), to="z", bins=10, condition_on="T"
+    )
+    assert factory.backward_names({"a", "b"}) == {"a", "b"}
+
+
+def test_ConditionallyScaled_build():
+    tf.random.set_seed(0)
+    in_name = "x_in"
+    out_name = "x_out"
+    on = "T"
+    to = "diff"
+    factory = ConditionallyScaled(
+        field=Field(in_name, out_name), to=to, bins=3, condition_on=on
+    )
+    shape = (10, 4)
+    data = {
+        in_name: tf.random.uniform(shape) * 5,
+        out_name: tf.random.uniform(shape) * 3,
+        on: tf.random.uniform(shape),
+    }
+    transform = factory.build(data)
+    out = transform.forward(data)
+
+    assert tf.reduce_mean(out[to]).numpy() == pytest.approx(0.0, abs=0.1)
+    assert tf.reduce_mean(out[to] ** 2).numpy() == pytest.approx(1.0, abs=0.1)

--- a/external/fv3fit/tests/keras/test_math.py
+++ b/external/fv3fit/tests/keras/test_math.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+import numpy as np
+
+from fv3fit.keras.math import piecewise
+
+
+def test_piecewise_interp():
+
+    x = tf.convert_to_tensor([0.0, 1, 2])
+    y = 2.0 * x
+    xg = tf.convert_to_tensor([-2, 0.5, 0.75, 1, 1.5, 2.5])
+
+    yg = piecewise(x, y, xg)
+    expected = tf.gather(y, [0, 0, 0, 1, 1, 2])
+    np.testing.assert_array_almost_equal(expected, yg.numpy())

--- a/external/fv3fit/tests/keras/test_math.py
+++ b/external/fv3fit/tests/keras/test_math.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 import numpy as np
 
-from fv3fit.keras.math import piecewise
+from fv3fit.keras.math import piecewise, groupby_bins
 
 
 def test_piecewise_interp():
@@ -13,3 +13,18 @@ def test_piecewise_interp():
     yg = piecewise(x, y, xg)
     expected = tf.gather(y, [0, 0, 0, 1, 1, 2])
     np.testing.assert_array_almost_equal(expected, yg.numpy())
+
+
+def test_piecewise_multiple_dimensions():
+    x = tf.convert_to_tensor([0.0, 1, 2])
+    y = 2.0 * x
+    xg = tf.ones((10, 10))
+    yg = piecewise(x, y, xg)
+    assert xg.shape == yg.shape
+
+
+def test_groupby_bins():
+    edges = tf.convert_to_tensor([0.0, 1, 4])
+    values = tf.convert_to_tensor([0.5, 0.75, 1, 2, 3])
+    out = groupby_bins(edges, values, values, tf.size)
+    assert [2, 3] == out.numpy().tolist()


### PR DESCRIPTION
The microphysics emulator performs poorly in cold places. Performing ML in a temperature-scaled space should help.

Added public API:
- `fv3fit.emulation.transforms.ConditionallyScaled` configuration class

Some interpolation and groupby-apply-combine functions utilties:
- `fv3fit.keras.math.piecewise`
- `fv3fit.keras.math.groupby_bins`