### PR TITLE
fv3fit.DerivedModel: fix bug in additional_inputs

### DIFF
--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -36,9 +36,7 @@ class DerivedModel(Predictor):
         ) else model
 
         self._derived_output_variables = derived_output_variables
-        self._additional_input_variables = vcm.DerivedMapping.find_all_required_inputs(
-            derived_output_variables
-        )
+        self._additional_input_variables = self.get_additional_inputs()
 
         full_input_variables = sorted(
             list(
@@ -55,6 +53,16 @@ class DerivedModel(Predictor):
         # necessary state for input to .predict()) is the set of
         # base_model_input_variables arg and hyperparameters.additional_inputs.
         super().__init__(full_input_variables, full_output_variables)
+
+    def get_additional_inputs(self):
+        derived_variable_inputs = vcm.DerivedMapping.find_all_required_inputs(
+            self._derived_output_variables
+        )
+        return [
+            input
+            for input in derived_variable_inputs
+            if input not in self.base_model.output_variables
+        ]
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
         self._check_additional_inputs_present(X)

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -31,7 +31,7 @@ def test_wrap_another_derived_model():
         base_model, derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
     derived_model_1 = DerivedModel(derived_model_0, derived_output_variables=["Q2"])
-
+    print(derived_model_1.input_variables)
     assert not isinstance(derived_model_1.base_model, DerivedModel)
     assert set(derived_model_1.input_variables) == {
         "input",
@@ -48,9 +48,10 @@ def test_get_additional_inputs():
     derived_model = DerivedModel(
         base_model, derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
-    assert (
-        "surface_diffused_shortwave_albedo" in derived_model._additional_input_variables
-    )
+    # base output for dw shortwave override should not be in the additional inputs
+    assert derived_model._additional_input_variables == [
+        "surface_diffused_shortwave_albedo"
+    ]
 
 
 def test_derived_prediction():

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -177,7 +177,10 @@ def _net_sfc_shortwave_flux_via_albedo(downward_sfc_shortwave_flux, albedo):
 
 @DerivedMapping.register(
     "net_shortwave_sfc_flux_derived",
-    required_inputs=["surface_diffused_shortwave_albedo"],
+    required_inputs=[
+        "surface_diffused_shortwave_albedo",
+        "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface",
+    ],
 )
 def net_shortwave_sfc_flux_derived(self):
     # Positive = downward direction


### PR DESCRIPTION
There was a bug in the DerivedModel where the base model output variables that were used to get derived outputs were also added to the input_variables. This bug leads to issues in the prognostic run since you'll get a KeyError when the base model predicted variable (e.g. transmissivity) is not in the state when it tries to grab inputs.

This was obscured for a while because the main derived variable we used, `net_shortwave_sfc_flux_derived`, didn't include the ML-predicted `override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface` in its `required_inputs`. This PR also fixes that.

