### PR TITLE
Fix offline diags jacobian plotting bug

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -188,7 +188,10 @@ def _plot_jacobians(jacobians: Mapping[str, OutputSensitivity]):
     num_outputs = len(jacobians)
     num_inputs = max([len(output) for output in jacobians.values()])
     fig, axes = plt.subplots(
-        ncols=num_inputs, nrows=num_outputs, figsize=(4 * num_inputs, 4 * num_outputs)
+        ncols=num_inputs,
+        nrows=num_outputs,
+        figsize=(4 * num_inputs, 4 * num_outputs),
+        squeeze=False,
     )
     for i, (output_name, output) in enumerate(jacobians.items()):
         num_inputs = len(output)


### PR DESCRIPTION
The last PR that updated the Jacobian plotting in the offline diags forgot to account for cases where the input/output length was 1, which messed up the dimensions of the subplots. This ensures two dimensions.

I reran the failed integration test step successfully.