### PR TITLE
Restore original order of shuffling and thinning of training data batches

### DIFF
--- a/external/fv3fit/fv3fit/_shared/stacking.py
+++ b/external/fv3fit/fv3fit/_shared/stacking.py
@@ -41,8 +41,8 @@ class StackedBatches(Sequence[xr.Dataset]):
             dim=SAMPLE_DIM_NAME
         )
         ds = check_empty(ds)
-        ds = preserve_samples_per_batch(ds)
-        return shuffled(self._random_state, [ds])[0]
+        ds = shuffled(self._random_state, [ds])[0]
+        return preserve_samples_per_batch(ds)
 
 
 def stack(ds: xr.Dataset, unstacked_dims: Sequence[str]):

--- a/external/fv3fit/tests/test_stacking.py
+++ b/external/fv3fit/tests/test_stacking.py
@@ -43,20 +43,9 @@ def test_StackedBatches_shuffles_before_thinning():
     # are stacked, shuffled, and then thinned (in that order).  Since
     # we are setting the random seed, we can expect the same shuffling
     # order every time.
-    ds_unstacked_multiple_datasets = xr.Dataset(
-        {
-            "var": xr.DataArray(
-                np.arange(0, 36).reshape(2, 6, 3), dims=["z", "x", DATASET_DIM_NAME],
-            )
-        }
-    )
-    batches_unstacked_multiple_datasets = [
-        ds_unstacked_multiple_datasets,
-        ds_unstacked_multiple_datasets,
-    ]
-    stacked_batches = StackedBatches(
-        batches_unstacked_multiple_datasets, np.random.RandomState(0)
-    )
+    data = np.arange(0, 36).reshape(2, 6, 3)
+    batch = xr.Dataset({"var": xr.DataArray(data, dims=["z", "x", DATASET_DIM_NAME],)})
+    stacked_batches = StackedBatches([batch, batch], np.random.RandomState(0))
     stacked_batch = stacked_batches[0]
 
     # If the order of shuffling and thinning were reversed, we would


### PR DESCRIPTION
This PR restores the original order of shuffling and thinning in producing stacked sample batches (shuffling then thinning).  When the order is flipped, it leads to sampling biases depending on the order of the stacked dimensions (see [this notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2021-10-01-offline-skill/2022-02-03-batching-investigation.ipynb) for more discussion).

- [x] Tests added

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
