### PR TITLE
fix Local so it loads datasets before saving to disk

### DIFF
--- a/external/loaders/loaders/batches/_sequences.py
+++ b/external/loaders/loaders/batches/_sequences.py
@@ -69,13 +69,20 @@ class Local(BaseSequence[T]):
 
     @classmethod
     def dump(cls, dataset, path):
-        joblib.dump(dataset, path)
+        try:
+            joblib.dump(dataset.load(), path)
+        except AttributeError:
+            joblib.dump(dataset, path)
 
     def __len__(self):
         return len(self.files)
 
     def __getitem__(self, i):
-        return joblib.load(self.files[i])
+        slice_value = self.files[i]
+        if isinstance(slice_value, str):
+            return joblib.load(slice_value)
+        else:
+            return [joblib.load(file) for file in slice_value]
 
 
 def to_local(sequence: Sequence[T], path: str, n_jobs: int = 4) -> Local[T]:

--- a/external/loaders/loaders/batches/_sequences.py
+++ b/external/loaders/loaders/batches/_sequences.py
@@ -70,9 +70,13 @@ class Local(BaseSequence[T]):
     @classmethod
     def dump(cls, dataset, path):
         try:
-            joblib.dump(dataset.load(), path)
+            loaded_data = dataset.load()
         except AttributeError:
-            joblib.dump(dataset, path)
+            pass
+        else:
+            loaded_data = dataset
+         
+        joblib.dump(loaded_data, path)
 
     def __len__(self):
         return len(self.files)

--- a/external/loaders/loaders/batches/_sequences.py
+++ b/external/loaders/loaders/batches/_sequences.py
@@ -75,7 +75,7 @@ class Local(BaseSequence[T]):
             pass
         else:
             loaded_data = dataset
-         
+
         joblib.dump(loaded_data, path)
 
     def __len__(self):

--- a/external/loaders/tests/test__sequences.py
+++ b/external/loaders/tests/test__sequences.py
@@ -75,3 +75,19 @@ def test__sequence_local(tmpdir):
 
     local = Local(str(tmpdir))
     xr.testing.assert_equal(local[0], ds)
+
+
+def test__sequence_local_getitem_slice(tmpdir):
+    ds = xr.Dataset({"a": (["x"], np.array([1]))})
+    test_seq = Map(identity, [ds, ds, ds])
+    local = test_seq.local(str(tmpdir))
+
+    assert len(local) == len(test_seq)
+    for k in range(len(local)):
+        xr.testing.assert_equal(local[k], test_seq[k])
+
+    local = Local(str(tmpdir))
+    result = local[:2]
+    assert len(result) == 2
+    xr.testing.assert_equal(result[0], ds)
+    xr.testing.assert_equal(result[1], ds)


### PR DESCRIPTION
Significant internal changes:
- Fixed `Local` so it will eagerly load Dataset objects before saving to disk
- Local now accepts slices in `__getitem__`

- [x] Tests added (for getitem only, only manual test for eager loading because mocking load makes the serialization fail, and dask is not a requirement of `loaders`)