### PR TITLE
Allow variable_names argument in configuration for BatchesLoader

### DIFF
--- a/external/loaders/loaders/_config.py
+++ b/external/loaders/loaders/_config.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, TypeVar, Callable
+from typing import Dict, Optional, Sequence, TypeVar, Callable
 from loaders.typing import (
     Mapper,
     Batches,
@@ -62,10 +62,11 @@ class BatchesLoader(abc.ABC):
     """
 
     @abc.abstractmethod
-    def load_batches(self, variables) -> Batches:
+    def load_batches(self, variables: Optional[Sequence[str]] = None) -> Batches:
         """
         Args:
-            config: data configuration
+            variables: if given, these variables are guaranteed to be present in
+                the returned batches, or an exception will be raised
 
         Returns:
             Sequence of datasets according to configuration
@@ -104,17 +105,23 @@ class BatchesFromMapperConfig(BatchesLoader):
     def load_mapper(self) -> Mapper:
         return self.mapper_config.load_mapper()
 
-    def load_batches(self, variables) -> Batches:
+    def load_batches(self, variables: Optional[Sequence[str]] = None) -> Batches:
         """
         Args:
-            variables: names of variables to include in dataset
+            variables: if given, these variables are guaranteed to be present in
+                the returned batches, or an exception will be raised
 
         Returns:
             Sequence of datasets according to configuration
         """
+        if variables is None:
+            variables = []
         mapper = self.mapper_config.load_mapper()
         batches_function = batches_from_mapper_functions[self.function]
-        return batches_function(mapper, list(variables), **self.kwargs,)
+        kwargs = {**self.kwargs}
+        kwargs["variable_names"] = list(kwargs.get("variable_names", []))
+        kwargs["variable_names"].extend(variables)
+        return batches_function(mapper, **kwargs)
 
     def __post_init__(self):
         if self.function not in batches_from_mapper_functions:
@@ -148,16 +155,22 @@ class BatchesConfig(BatchesLoader):
     function: str
     kwargs: dict
 
-    def load_batches(self, variables) -> Batches:
+    def load_batches(self, variables: Optional[Sequence[str]] = None) -> Batches:
         """
         Args:
-            variables: names of variables to include in dataset
+            variables: if given, these variables are guaranteed to be present in
+                the returned batches, or an exception will be raised
 
         Returns:
             Sequence of datasets according to configuration
         """
+        if variables is None:
+            variables = []
         batches_function = batches_functions[self.function]
-        return batches_function(variable_names=list(variables), **self.kwargs,)
+        kwargs = {**self.kwargs}
+        kwargs["variable_names"] = list(kwargs.get("variable_names", []))
+        kwargs["variable_names"].extend(variables)
+        return batches_function(**kwargs)
 
     def __post_init__(self):
         if self.function not in batches_functions:

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -215,7 +215,9 @@ def test_load_batches_from_mapper():
         result = config.load_batches(variables=variables)
         assert result is mock_batches_function.return_value
         mock_batches_function.assert_called_once_with(
-            mock_mapper_function.return_value, variables, **batches_kwargs
+            mock_mapper_function.return_value,
+            variable_names=variables,
+            **batches_kwargs,
         )
         mock_mapper_function.assert_called_once_with(**mapper_kwargs)
 


### PR DESCRIPTION
Currently BatchesLoader does not allow setting the keyword argument value for variable_names, instead taking it as an argument to `load_batches`. This PR updates that behavior to combine any value of variable_names provided in the configuration with the value given as an argument.

This will be necessary down the line for producing cached datasets directly from a configuration yaml for a BatchesLoader.

Refactored public API:
- The variables argument to BatchesLoader.load_batches is now optional, and will merge any value given in its configuration kwargs for variable_names with the argument passed to load_batches

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
