### PR TITLE
fv3fit: add logging callback

### DIFF
--- a/external/fv3fit/fv3fit/__init__.py
+++ b/external/fv3fit/fv3fit/__init__.py
@@ -21,8 +21,6 @@ from .keras._models.shared import (
     PureKerasModel,
     TrainingLoopConfig,
     EpochResult,
-    EpochLossHistory,
-    History,
 )
 from .keras._models.precipitative import PrecipitativeHyperparameters
 from .keras._models.convolutional import ConvolutionalHyperparameters

--- a/external/fv3fit/fv3fit/keras/__init__.py
+++ b/external/fv3fit/fv3fit/keras/__init__.py
@@ -5,8 +5,6 @@ from ._models.shared.pure_keras import PureKerasModel
 from ._models.shared.training_loop import (
     TrainingLoopConfig,
     EpochResult,
-    EpochLossHistory,
-    History,
 )
 from ._models.shared.utils import get_input_vector
 from ._models.recurrent import StepwiseModel

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -9,7 +9,12 @@ from ..._shared.config import (
     OptimizerConfig,
     register_training_function,
 )
-from .shared import TrainingLoopConfig, XyMultiArraySequence, DenseNetworkConfig
+from .shared import (
+    TrainingLoopConfig,
+    XyMultiArraySequence,
+    DenseNetworkConfig,
+    TrainingLoopLossHistory,
+)
 from fv3fit.keras._models.shared import PureKerasModel, LossConfig, ClipConfig
 from fv3fit.keras._models.shared.utils import (
     standard_denormalize,
@@ -117,17 +122,22 @@ def train_dense_model(
     )
     del train_batches
 
+    loss_history = TrainingLoopLossHistory()
     hyperparameters.training_loop.fit_loop(
-        model=train_model, Xy=train_data, validation_data=validation_data
+        model=train_model,
+        Xy=train_data,
+        validation_data=validation_data,
+        callbacks=[loss_history.callback],
     )
     predictor = PureKerasModel(
         input_variables=hyperparameters.input_variables,
         output_variables=hyperparameters.output_variables,
         output_metadata=output_metadata,
         model=predict_model,
-        unstacked_dims=("z",),
+        unstacked_dims=("z"),
         n_halo=0,
     )
+    loss_history.log_summary()
     return predictor
 
 

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -134,7 +134,7 @@ def train_dense_model(
         output_variables=hyperparameters.output_variables,
         output_metadata=output_metadata,
         model=predict_model,
-        unstacked_dims=("z"),
+        unstacked_dims=("z",),
         n_halo=0,
     )
     loss_history.log_summary()

--- a/external/fv3fit/fv3fit/keras/_models/shared/__init__.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/__init__.py
@@ -7,7 +7,8 @@ from .convolutional_network import (
     Diffusive,
 )
 from .pure_keras import PureKerasModel
-from .training_loop import TrainingLoopConfig, EpochResult, EpochLossHistory, History
+from .training_loop import TrainingLoopConfig, EpochResult
+from .callbacks import TrainingLoopLossHistory
 from .loss import LossConfig
 from .utils import get_input_vector, standard_denormalize, standard_normalize
 from .sequences import XyArraySequence, XyMultiArraySequence, ThreadedSequencePreLoader

--- a/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from .training_loop import EpochResult
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TrainingLoopLossHistory:
+    """Summarizes the history across epochs and batches
+    *_loss_end: loss at end of epoch
+    *_loss_full: loss after each iteration over batches in epochs
+    """
+
+    def __init__(self):
+        self.train_loss_end_of_epoch = []
+        self.val_loss_end_of_epoch = []
+        self.train_loss_all = []
+        self.val_loss_all = []
+
+    def callback(self, epoch_result: EpochResult):
+        for batch in epoch_result.history:
+            self.train_loss_end_of_epoch.append(batch.history["loss"][-1])
+            self.val_loss_end_of_epoch.append(
+                batch.history.get("val_loss", [np.nan])[-1]
+            )
+            self.train_loss_all += batch.history["loss"]
+            self.val_loss_all += batch.history.get("val_loss", [])
+
+    def log_summary(self):
+        logger.info(f"All batches train loss history: {self.train_loss_all}")
+        logger.info(f"All batches Validation loss history: {self.val_loss_all}")
+        logger.info(f"End of epoch train loss history: {self.train_loss_end_of_epoch}")
+        logger.info(
+            f"End of epoch validation loss history: {self.val_loss_end_of_epoch}"
+        )

--- a/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
@@ -9,11 +9,17 @@ logger = logging.getLogger(__name__)
 
 class TrainingLoopLossHistory:
     """Summarizes the history across epochs and batches
-    *_loss_end: loss at end of epoch
-    *_loss_full: loss after each iteration over batches in epochs
+
+    Attributes:
+        train_loss_end_of_epoch: training loss recorded at end of each epoch
+            (i.e. after the last batch iterated upon in the epoch)
+        val_loss_end_of_epoch: validation loss recorded at end of each epoch
+        train_loss_all: training loss after each iteration over batches in epochs
+        val_loss_all: validation loss after each iteration over batches in epochs
     """
 
     def __init__(self):
+
         self.train_loss_end_of_epoch = []
         self.val_loss_end_of_epoch = []
         self.train_loss_all = []

--- a/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
@@ -1,18 +1,14 @@
 import tensorflow as tf
-from typing import Iterable, Optional, Sequence, Union, Mapping, Tuple, Callable
+from typing import Iterable, Optional, Sequence, Tuple, Callable
 import dataclasses
 import numpy as np
+
 from .sequences import ThreadedSequencePreLoader
 from loaders.batches import shuffle
 import logging
 
 
-# Description of the training loss progression over epochs
-# Outer array indexes epoch, inner array indexes batch (if applicable)
-EpochLossHistory = Sequence[Sequence[Union[float, int]]]
-History = Mapping[str, EpochLossHistory]
-
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -17,9 +17,6 @@ import tempfile
 from vcm.cloud import copy
 
 
-LOG_OUTPUT = "training.log"
-
-
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
- Adds a `TrainingLoopLossHistory` class with a callback that can be used in the training loop `.fit` method to save the loss history for each timestep batch in the epochs. The `log_summary` method can be used after training is complete to print the loss history to the logs. I chose this over just saving all stdout to the logs because the progress bars in the the keras training output would save in multiple lines and made parsing the logs annoying.
- Saves the logs in the model output location if using the train script. I find it easier to have it here than having to look up the name of the job name that trained the model to get the logs.

