### PR TITLE
Fix "antarctic-only" selection for emulation training

### DIFF
--- a/external/fv3fit/tests/emulation/test_data_transforms.py
+++ b/external/fv3fit/tests/emulation/test_data_transforms.py
@@ -74,7 +74,6 @@ def test_select_antarctic(lats, data, expected):
     xr.testing.assert_equal(expected_da, result["field"])
 
 
-@pytest.mark.xfail
 def test_select_antarctic_xarray_netCDF():
     """
     xarray can't use an empty index mask (i.e., all False) along

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -9,7 +9,6 @@ import tensorflow as tf
 from fv3fit import set_random_seed
 from fv3fit.train_microphysics import TrainConfig
 from fv3fit._shared import put_dir
-from fv3fit.emulation.data import nc_dir_to_tf_dataset
 from fv3fit.emulation.keras import score_model
 from fv3fit.wandb import (
     log_profile_plots,

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -54,11 +54,11 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
         logger.info(f"Loading user specified model from {model_url}")
         model = tf.keras.models.load_model(model_url)
 
-    train_ds = nc_dir_to_tf_dataset(
-        config.train_url, config.transform, nfiles=config.nfiles
+    train_ds = config.open_dataset(
+        config.train_url, config.nfiles, config.model_variables
     )
-    test_ds = nc_dir_to_tf_dataset(
-        config.test_url, config.transform, nfiles=config.nfiles_valid
+    test_ds = config.open_dataset(
+        config.train_url, config.nfiles, config.model_variables
     )
 
     train_set = next(iter(train_ds.shuffle(100_000).batch(50_000)))


### PR DESCRIPTION
Somewhere along the line the antarctic-only selection pipeline broke when encountering tile data outside of the Antarctic.  

resolves #1617 

It seems to be a change in behavior when using `.isel` with an empty mask (i.e., all false values) on an unloaded xarray dataset opened from a netCDF.  Added a workaround and test for this case, but we'll probably just scrub this in place of a more general selection transform down the line.