### PR TITLE
fv3fit: Add `input_sensitivity` method to `Predictor`

### DIFF
--- a/external/fv3fit/fv3fit/_shared/__init__.py
+++ b/external/fv3fit/fv3fit/_shared/__init__.py
@@ -21,6 +21,7 @@ from .scaler import (
     NormalizeTransform,
 )
 from .predictor import Predictor
+from .input_sensitivity import InputSensitivity
 from .stacking import (
     StackedBatches,
     stack_non_vertical,

--- a/external/fv3fit/fv3fit/_shared/input_sensitivity.py
+++ b/external/fv3fit/fv3fit/_shared/input_sensitivity.py
@@ -9,5 +9,5 @@ JacobianInputSensitivity = Mapping[str, Mapping[str, np.ndarray]]
 
 @dataclass
 class InputSensitivity:
-    rf_feature_importances: Optional[RandomForestInputSensitivity]
-    jacobians: Optional[JacobianInputSensitivity]
+    rf_feature_importances: Optional[RandomForestInputSensitivity] = None
+    jacobians: Optional[JacobianInputSensitivity] = None

--- a/external/fv3fit/fv3fit/_shared/input_sensitivity.py
+++ b/external/fv3fit/fv3fit/_shared/input_sensitivity.py
@@ -1,13 +1,34 @@
 import numpy as np
-from typing import Optional, Mapping
+from typing import Optional, Mapping, Sequence
 from dataclasses import dataclass
 
 
-RandomForestInputSensitivity = Mapping[str, Mapping[str, np.ndarray]]
+# Jacobian format: {y_name: {x_name: dy/dx}}
 JacobianInputSensitivity = Mapping[str, Mapping[str, np.ndarray]]
 
 
 @dataclass
+class RandomForestInputSensitivity:
+    """
+    Attributes:
+        name: input feature name
+        mean_importances: average value of feature importance across ensemble
+        std_importances: standard deviation of feature importance across ensemble
+        indices: for input features of length >1 along feature dimension, the indices
+            corresponding to position along feature dimension. Has length of 1 with
+            nan index for scalar features.
+    """
+
+    name: str
+    mean_importances: Sequence[float]
+    std_importances: Sequence[float]
+    indices: Sequence[int]
+
+
+RandomForestInputSensitivities = Sequence[RandomForestInputSensitivity]
+
+
+@dataclass
 class InputSensitivity:
-    rf_feature_importances: Optional[RandomForestInputSensitivity] = None
+    rf_feature_importances: Optional[RandomForestInputSensitivities] = None
     jacobians: Optional[JacobianInputSensitivity] = None

--- a/external/fv3fit/fv3fit/_shared/input_sensitivity.py
+++ b/external/fv3fit/fv3fit/_shared/input_sensitivity.py
@@ -1,0 +1,13 @@
+import numpy as np
+from typing import Optional, Mapping
+from dataclasses import dataclass
+
+
+RandomForestInputSensitivity = Mapping[str, Mapping[str, np.ndarray]]
+JacobianInputSensitivity = Mapping[str, Mapping[str, np.ndarray]]
+
+
+@dataclass
+class InputSensitivity:
+    rf_feature_importances: Optional[RandomForestInputSensitivity]
+    jacobians: Optional[JacobianInputSensitivity]

--- a/external/fv3fit/fv3fit/_shared/input_sensitivity.py
+++ b/external/fv3fit/fv3fit/_shared/input_sensitivity.py
@@ -19,13 +19,12 @@ class RandomForestInputSensitivity:
             nan index for scalar features.
     """
 
-    name: str
     mean_importances: Sequence[float]
     std_importances: Sequence[float]
     indices: Sequence[int]
 
 
-RandomForestInputSensitivities = Sequence[RandomForestInputSensitivity]
+RandomForestInputSensitivities = Mapping[str, RandomForestInputSensitivity]
 
 
 @dataclass

--- a/external/fv3fit/fv3fit/_shared/predictor.py
+++ b/external/fv3fit/fv3fit/_shared/predictor.py
@@ -85,7 +85,7 @@ class Predictor(abc.ABC):
         )
         return self.predict(X)
 
-    def input_sensitivity(self, **kwargs) -> InputSensitivity:
+    def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
         """Calculate sensitivity to input features."""
         raise NotImplementedError(
             "input_sensitivity is not implemented for Predictor subclass "

--- a/external/fv3fit/fv3fit/_shared/predictor.py
+++ b/external/fv3fit/fv3fit/_shared/predictor.py
@@ -4,6 +4,8 @@ from typing import Hashable, Iterable, Sequence
 import logging
 import warnings
 
+from .input_sensitivity import InputSensitivity
+
 DATASET_DIM_NAME = "dataset"
 logger = logging.getLogger(__file__)
 
@@ -82,3 +84,10 @@ class Predictor(abc.ABC):
             DeprecationWarning,
         )
         return self.predict(X)
+
+    def input_sensitivity(self, **kwargs) -> InputSensitivity:
+        """Calculate sensitivity to input features."""
+        raise NotImplementedError(
+            "input_sensitivity is not implemented for Predictor subclass "
+            f"{self.__class__.__name__}."
+        )

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -364,13 +364,12 @@ class SklearnWrapper(Predictor):
                 feature_importances[name]["mean_importances"].append(mean_importance)
                 feature_importances[name]["std_importances"].append(std_importance)
 
-        formatted_feature_importances = [
-            RandomForestInputSensitivity(
-                name=name,
+        formatted_feature_importances = {
+            name: RandomForestInputSensitivity(
                 indices=info["indices"],
                 mean_importances=info["mean_importances"],
                 std_importances=info["std_importances"],
             )
             for name, info in feature_importances.items()
-        ]
+        }
         return InputSensitivity(rf_feature_importances=formatted_feature_importances)

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -53,15 +53,6 @@ def train_random_forest(
     return model
 
 
-"""@dataclasses.dataclass
-class RandomForestFeatureImportance:
-    name: str
-    indices: Sequence[int]
-    mean_importances: Sequence[float]
-    std_importances: Sequence[float]
-    """
-
-
 @_shared.io.register("sklearn")
 class RandomForest(Predictor):
     def __init__(

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -17,9 +17,9 @@ from .._shared import (
     multiindex_to_tuple,
     tuple_to_multiindex,
     PackerConfig,
-    InputSensitivity,
 )
 
+from .._shared.input_sensitivity import InputSensitivity, RandomForestInputSensitivity
 from .._shared.config import RandomForestHyperparameters
 from .. import _shared
 from .._shared import (
@@ -363,4 +363,14 @@ class SklearnWrapper(Predictor):
                 feature_importances[name]["indices"].append(feature_index)
                 feature_importances[name]["mean_importances"].append(mean_importance)
                 feature_importances[name]["std_importances"].append(std_importance)
-        return InputSensitivity(rf_feature_importances=feature_importances)
+
+        formatted_feature_importances = [
+            RandomForestInputSensitivity(
+                name=name,
+                indices=info["indices"],
+                mean_importances=info["mean_importances"],
+                std_importances=info["std_importances"],
+            )
+            for name, info in feature_importances.items()
+        ]
+        return InputSensitivity(rf_feature_importances=formatted_feature_importances)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -76,8 +76,8 @@ def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
     if "derivation" in ds.dims:
         ds = ds.sel({"derivation": "predict"})
     if "time" in ds.dims:
-        data = ds.isel(time=0).squeeze(drop=True)
-    return data.stack(sample=["tile", "x", "y"]).transpose("sample", ...)
+        ds = ds.isel(time=0).squeeze(drop=True)
+    return ds.stack(sample=["tile", "x", "y"]).transpose("sample", ...)
 
 
 def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -62,9 +62,7 @@ def _get_variable_indices(
     stacked: xr.Dataset, variables: Iterable[Hashable]
 ) -> Dict[Hashable, Tuple[int, int]]:
 
-    variable_dims = _count_features_2d(
-        variables, stacked.transpose("sample", ...), "sample"
-    )
+    variable_dims = _count_features_2d(variables, stacked, "sample")
     start = 0
     variable_indices = {}
     for var, var_dim in variable_dims.items():
@@ -74,6 +72,9 @@ def _get_variable_indices(
 
 
 def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
+    # for predictions, drop the 'target' values
+    if "derivation" in ds.dims:
+        ds = ds.sel({"derivation": "predict"})
     if "time" in ds.dims:
         data = ds.isel(time=0).squeeze(drop=True)
     return data.stack(sample=["tile", "x", "y"]).transpose("sample", ...)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -16,17 +16,14 @@ OutputSensitivity = Dict[str, np.ndarray]
 
 
 def dataset_to_dict_input(ds):
-    if "time" in ds.dims:
-        ds = ds.isel(time=0).squeeze(drop=True)
-    stacked = ds.stack(sample=["tile", "x", "y"]).transpose("sample", ...)
     data = {}
-    for var in stacked:
+    for var in ds:
         # for predictions, drop the 'target' values
-        if "derivation" in stacked[var].dims:
-            values = stacked[var].sel({"derivation": "predict"}).values
+        if "derivation" in ds[var].dims:
+            values = ds[var].sel({"derivation": "predict"}).values
         else:
-            values = stacked[var].values
-        if len(stacked[var].dims) == 1:
+            values = ds[var].values
+        if len(ds[var].dims) == 1:
             values = values.reshape(-1, 1)
         data[var] = values
     return data
@@ -62,11 +59,9 @@ def _count_features_2d(
 
 
 def _get_variable_indices(
-    data: xr.Dataset, variables: Iterable[Hashable]
+    stacked: xr.Dataset, variables: Iterable[Hashable]
 ) -> Dict[Hashable, Tuple[int, int]]:
-    if "time" in data.dims:
-        data = data.isel(time=0).squeeze(drop=True)
-    stacked = data.stack(sample=["tile", "x", "y"])
+
     variable_dims = _count_features_2d(
         variables, stacked.transpose("sample", ...), "sample"
     )
@@ -78,11 +73,17 @@ def _get_variable_indices(
     return variable_indices
 
 
+def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
+    if "time" in ds.dims:
+        data = ds.isel(time=0).squeeze(drop=True)
+    return data.stack(sample=["tile", "x", "y"]).transpose("sample", ...)
+
+
 def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):
     base_model = model.base_model if isinstance(model, fv3fit.DerivedModel) else model
-
+    stacked_sample = _stack_sample_data(sample)
     try:
-        data_dict = dataset_to_dict_input(sample)
+        data_dict = dataset_to_dict_input(stacked_sample)
         jacobians = compute_jacobians(
             base_model.get_dict_compatible_model(),  # type: ignore
             data_dict,
@@ -98,7 +99,7 @@ def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):
     except AttributeError:
         try:
             input_feature_indices = _get_variable_indices(
-                data=sample, variables=base_model.input_variables
+                stacked=stacked_sample, variables=base_model.input_variables
             )
             fig = _plot_rf_feature_importance(
                 input_feature_indices, base_model  # type: ignore

--- a/workflows/diagnostics/tests/offline/test__input_sensitivity.py
+++ b/workflows/diagnostics/tests/offline/test__input_sensitivity.py
@@ -3,6 +3,7 @@ import numpy as np
 from fv3net.diagnostics.offline._input_sensitivity import (
     _get_variable_indices,
     _count_features_2d,
+    _stack_sample_data,
 )
 
 
@@ -15,7 +16,7 @@ def data_array_with_feature_dim(feature_dim: int, has_time_dim=True):
         da = da.isel(time=0).squeeze(drop=True)
     if feature_dim == 1:
         da = da.isel(z=0).squeeze(drop=True)
-    return da
+    return _stack_sample_data(da)
 
 
 def test__get_variable_indices():


### PR DESCRIPTION
This adds a method `Predictor.input_sensitivity` which takes in a sample dataset and returns a `InputSensitivity` container which uses different formats to describe RF and NN input sensitivity. This helps to decouple some of the input sensitivity calculations from the offline diags (https://github.com/ai2cm/fv3net/issues/1596). 

I also cleaned up some of the dataset handling in the input sensitivity calculation of the offline diags so that the `input_sensitivity` methods take an already-stacked dataset of sample data.

The actual calculation and plotting of the input sensitivities in the offline diags is unchanged in this PR. A follow on PR will change that code to use the `input_sensitivity` method and adjust the plotting code to use the data from the `InputSensitivity` container.

Added public API:
-  `Predictor.input_sensitivity()`


Resolves #<[github issues](https://github.com/ai2cm/fv3net/issues/1596)>
