### PR TITLE
emulation: add dense-local architecture

### DIFF
--- a/external/fv3fit/fv3fit/emulation/layers/architecture.py
+++ b/external/fv3fit/fv3fit/emulation/layers/architecture.py
@@ -395,6 +395,7 @@ _ARCHITECTURE_KEYS = (
     "rnn",
     "dense",
     "linear",
+    "dense-local",
 )
 
 
@@ -471,6 +472,12 @@ class ArchitectureConfig:
         elif key == "dense":
             return _HiddenArchitecture(
                 combine_inputs, MLPBlock(**kwargs), StandardOutput(feature_lengths)
+            )
+        elif key == "dense-local":
+            return _HiddenArchitecture(
+                combine_sequence_inputs,
+                MLPBlock(**kwargs),
+                RNNOutput(feature_lengths, share_conv_weights=True),
             )
         elif key == "linear":
             if kwargs:

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -203,6 +203,11 @@ def test_rnn_fails_with_inconsistent_vertical_dimensions(rnn_key):
         layer({"a": tensor1, "b": tensor2})
 
 
+def _assert_is_diagonal(matrix: np.ndarray) -> bool:
+    diagonal = np.diag(np.diag(matrix))
+    np.testing.assert_array_equal(matrix, diagonal)
+
+
 @pytest.mark.parametrize("seed", range(10))
 def test_dense_local_is_local(seed):
     tf.random.set_seed(seed)
@@ -217,4 +222,4 @@ def test_dense_local_is_local(seed):
 
     jacobian = g.jacobian(output, in_).numpy()
     assert jacobian.shape == (nz, nz)
-    np.testing.assert_array_equal(jacobian, np.diag(np.diag(jacobian)))
+    _assert_is_diagonal(jacobian)

--- a/external/fv3fit/tests/emulation/layers/test_architectures.py
+++ b/external/fv3fit/tests/emulation/layers/test_architectures.py
@@ -203,7 +203,7 @@ def test_rnn_fails_with_inconsistent_vertical_dimensions(rnn_key):
         layer({"a": tensor1, "b": tensor2})
 
 
-def _assert_is_diagonal(matrix: np.ndarray) -> bool:
+def _assert_is_diagonal(matrix: np.ndarray) -> None:
     diagonal = np.diag(np.diag(matrix))
     np.testing.assert_array_equal(matrix, diagonal)
 


### PR DESCRIPTION
Condensation is local to each (x,y,z) grid point.

Added public API:
- add name=`dense-local` option to ArchitectureConfig for emulation
