### PR TITLE
Fix fv3fit.keras.adapters.get_inputs

### DIFF
--- a/external/fv3fit/fv3fit/keras/adapters.py
+++ b/external/fv3fit/fv3fit/keras/adapters.py
@@ -69,8 +69,14 @@ def ensure_dict_output(model: tf.keras.Model) -> tf.keras.Model:
 
 
 def get_inputs(model: tf.keras.Model) -> Mapping[str, tf.Tensor]:
-    if isinstance(model.inputs, Mapping):
-        return model.inputs
+
+    # As far as I can tell, the "input" property is not documented in tf,
+    # but it does retain information about the input to the model being a dict.
+    # "inputs" always seems to be a list even when a dict is used
+    # to create the model
+
+    if model.inputs and isinstance(model.input, Mapping):
+        return model.input
     elif model.inputs is None:
         raise ValueError(
             f"Cannot detect inputs of model {model}. " "Custom models may not work."

--- a/external/fv3fit/tests/keras/test_adapters.py
+++ b/external/fv3fit/tests/keras/test_adapters.py
@@ -11,7 +11,6 @@ from fv3fit.keras.adapters import (
 )
 
 
-@pytest.mark.xfail
 def test_get_inputs_already_mapping():
 
     in_ = {"a": tf.keras.Input(shape=[2])}

--- a/external/fv3fit/tests/keras/test_adapters.py
+++ b/external/fv3fit/tests/keras/test_adapters.py
@@ -1,11 +1,26 @@
 import numpy as np
+import pytest
 import tensorflow as tf
 from fv3fit.keras.adapters import (
+    get_inputs,
     ensure_dict_output,
     rename_dict_output,
     rename_dict_input,
     _ensure_list_input,
 )
+
+
+@pytest.mark.xfail
+def test_get_inputs_already_mapping():
+
+    in_ = {"a": tf.keras.Input(shape=[2])}
+    out = tf.keras.layers.Lambda(lambda x: x)(in_)
+    model = tf.keras.Model(inputs=in_, outputs=out)
+
+    retrieved_inputs = get_inputs(model)
+
+    assert "a" in retrieved_inputs
+    tf.debugging.assert_equal(retrieved_inputs["a"], in_["a"])
 
 
 def test_ensure_dict_output_multiple_out():

--- a/external/fv3fit/tests/keras/test_adapters.py
+++ b/external/fv3fit/tests/keras/test_adapters.py
@@ -1,3 +1,4 @@
+from typing import Mapping
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -19,8 +20,27 @@ def test_get_inputs_already_mapping():
 
     retrieved_inputs = get_inputs(model)
 
+    assert isinstance(retrieved_inputs, Mapping)
     assert "a" in retrieved_inputs
     tf.debugging.assert_equal(retrieved_inputs["a"], in_["a"])
+
+
+def test_get_inputs_no_input_raises():
+    model = tf.keras.Model()
+    with pytest.raises(ValueError):
+        get_inputs(model)
+
+
+def test_get_inputs_named_inputs():
+    in_ = [tf.keras.Input(2, name="a")]
+    out = tf.keras.layers.Lambda(lambda x: x)(in_)
+    model = tf.keras.Model(inputs=in_, outputs=out)
+
+    retrieved_inputs = get_inputs(model)
+
+    assert isinstance(retrieved_inputs, Mapping)
+    assert "a" in retrieved_inputs
+    tf.debugging.assert_equal(retrieved_inputs["a"], in_[0])
 
 
 def test_ensure_dict_output_multiple_out():


### PR DESCRIPTION
The `_convert_dict_output` uses the function `get_inputs` to retrieve the input dictionary for the model, but this was untested.  It did not always preserve names for dictionary inputs.


 The bug is related to the fact that `tf.keras.Model.inputs` seems to return a list despite the input format. The previous implementation worked in the case where the layer names already correspond to the dict keys, but failed if input layers just used defaults (e.g., "layer_2").  The fix uses the `.input` model property instead of `.inputs`, but I can't seem to find any documentation on these model properties/attributes. 🙃


- [x] Tests added
