### PR TITLE
Add command-line tool loaders.batches.save

### DIFF
--- a/external/loaders/docs/conf.py
+++ b/external/loaders/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinxarg.ext",
     "m2r2",
 ]
 

--- a/external/loaders/docs/loaders_api.rst
+++ b/external/loaders/docs/loaders_api.rst
@@ -2,7 +2,6 @@
 loaders API
 ===========
 
-
 Mappers
 -------
 We use the following mappers to load data used by diagnostic and ML training routines.
@@ -30,6 +29,9 @@ The second type can be initialized using the :py:class:`loaders.BatchesFromMappe
 
 The functions themselves take a ``data_path`` argument, followed by the keyword arguments in their API documentation below.
 
+Command-line validation
+-----------------------
+
 Configuration files for batches data can be validated using a command-line tool ``validate_batches_config`` provided by this package. If the configuration is valid, it will exit without error. Note this only checks for type validation of the configuration entries, and does not test that the data referenced actually exists and is without errors.
 
 .. code-block:: bash
@@ -42,6 +44,23 @@ Configuration files for batches data can be validated using a command-line tool 
 
    optional arguments:
    -h, --help  show this help message and exit
+
+
+Command-line downloading
+------------------------
+
+This package also provides a command-line tool for downloading batches based on a BatchesLoader yaml configuration file to a local directory of netCDF files.
+
+.. argparse::
+   :module: loaders.batches.save
+   :func: get_parser
+   :prog: python3 -m loaders.batches.save
+
+
+API Reference
+-------------
+
+Loaders provides
 
 .. automodule:: loaders
    :imported-members:

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -2,6 +2,11 @@ import argparse
 from loaders._config import BatchesLoader
 import yaml
 import os.path
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -28,13 +33,25 @@ def main(data_config: str, output_path: str):
     with open(data_config, "r") as f:
         config = yaml.safe_load(f)
     loader = BatchesLoader.from_dict(config)
+    logger.info("configuration loaded, creating batches object")
+    print(1)
     batches = loader.load_batches()
+    n_batches = len(batches)
+    logger.info(f"batches object created, saving {n_batches} batches")
     for i, batch in enumerate(batches):
         out_filename = os.path.join(output_path, f"{i:05}.nc")
+        logger.info(f"saving batch {i}")
         batch.to_netcdf(out_filename, engine="h5netcdf")
 
 
 if __name__ == "__main__":
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(name)s %(asctime)s: %(module)s/L%(lineno)d %(message)s")
+    )
+    handler.setLevel(logging.INFO)
+    logging.basicConfig(handlers=[handler], level=logging.INFO)
+
     parser = get_parser()
     args = parser.parse_args()
     main(data_config=args.data_config, output_path=args.output_path)

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -1,0 +1,40 @@
+import argparse
+from loaders._config import BatchesLoader
+import yaml
+import os.path
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Save a BatchesLoader configuration locally "
+            "as a directory of netCDF files."
+        )
+    )
+    parser.add_argument(
+        "data_config",
+        type=str,
+        help="path of loaders.BatchesLoader training data yaml file",
+    )
+    parser.add_argument(
+        "output_path",
+        type=str,
+        help="local directory to save data as numbered netCDF files",
+    )
+    return parser
+
+
+def main(data_config: str, output_path: str):
+    with open(data_config, "r") as f:
+        config = yaml.safe_load(f)
+    loader = BatchesLoader.from_dict(config)
+    batches = loader.load_batches()
+    for i, batch in enumerate(batches):
+        out_filename = os.path.join(output_path, f"{i:05}.nc")
+        batch.to_netcdf(out_filename, engine="h5netcdf")
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    main(data_config=args.data_config, output_path=args.output_path)

--- a/external/loaders/loaders/testing.py
+++ b/external/loaders/loaders/testing.py
@@ -1,0 +1,62 @@
+from loaders import _config
+import contextlib
+import xarray as xr
+import unittest.mock
+
+
+@contextlib.contextmanager
+def registration_context(registration_dict):
+    """
+    A context manager that provides a clean slate for registering functions,
+    and restores the registration state when exiting.
+    """
+    original_functions = {}
+    original_functions.update(registration_dict)
+    registration_dict.clear()
+    try:
+        yield
+    finally:
+        registration_dict.clear()
+        registration_dict.update(original_functions)
+
+
+@contextlib.contextmanager
+def mapper_context():
+    """
+    A context manager that provides a clean slate for registering mapper functions,
+    and restores the registration state when exiting.
+    """
+    with registration_context(_config.mapper_functions):
+        mock_mapper = {"key": xr.Dataset()}
+        mock_mapper_function = unittest.mock.MagicMock(return_value=mock_mapper)
+        mock_mapper_function.__name__ = "mock_mapper_function"
+        _config.mapper_functions.register(mock_mapper_function)
+        yield mock_mapper_function
+
+
+@contextlib.contextmanager
+def batches_context():
+    """
+    A context manager that provides a clean slate for registering batches functions,
+    and restores the registration state when exiting.
+    """
+    with registration_context(_config.batches_functions):
+        mock_batches = [xr.Dataset()]
+        mock_batches_function = unittest.mock.MagicMock(return_value=mock_batches)
+        mock_batches_function.__name__ = "mock_batches_function"
+        _config.batches_functions.register(mock_batches_function)
+        yield mock_batches_function
+
+
+@contextlib.contextmanager
+def batches_from_mapper_context():
+    """
+    A context manager that provides a clean slate for registering
+    batches from mapper functions, and restores the registration state when exiting.
+    """
+    with registration_context(_config.batches_from_mapper_functions):
+        mock_batches = [xr.Dataset()]
+        mock_batches_function = unittest.mock.MagicMock(return_value=mock_batches)
+        mock_batches_function.__name__ = "mock_batches_function"
+        _config.batches_from_mapper_functions.register(mock_batches_function)
+        yield mock_batches_function

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -1,58 +1,12 @@
 import pytest
 import unittest.mock
 import loaders
-import contextlib
 import xarray as xr
 import tempfile
 import os
 import yaml
 import dataclasses
-
-
-@contextlib.contextmanager
-def registration_context(registration_dict):
-    """
-    A context manager that provides a clean slate for registering functions,
-    and restores the registration state when exiting.
-    """
-    original_functions = {}
-    original_functions.update(registration_dict)
-    registration_dict.clear()
-    try:
-        yield
-    finally:
-        registration_dict.clear()
-        registration_dict.update(original_functions)
-
-
-@contextlib.contextmanager
-def mapper_context():
-    with registration_context(loaders._config.mapper_functions):
-        mock_mapper = {"key": xr.Dataset()}
-        mock_mapper_function = unittest.mock.MagicMock(return_value=mock_mapper)
-        mock_mapper_function.__name__ = "mock_mapper_function"
-        loaders._config.mapper_functions.register(mock_mapper_function)
-        yield mock_mapper_function
-
-
-@contextlib.contextmanager
-def batches_context():
-    with registration_context(loaders._config.batches_functions):
-        mock_batches = [xr.Dataset()]
-        mock_batches_function = unittest.mock.MagicMock(return_value=mock_batches)
-        mock_batches_function.__name__ = "mock_batches_function"
-        loaders._config.batches_functions.register(mock_batches_function)
-        yield mock_batches_function
-
-
-@contextlib.contextmanager
-def batches_from_mapper_context():
-    with registration_context(loaders._config.batches_from_mapper_functions):
-        mock_batches = [xr.Dataset()]
-        mock_batches_function = unittest.mock.MagicMock(return_value=mock_batches)
-        mock_batches_function.__name__ = "mock_batches_function"
-        loaders._config.batches_from_mapper_functions.register(mock_batches_function)
-        yield mock_batches_function
+from loaders.testing import mapper_context, batches_context, batches_from_mapper_context
 
 
 def test_load_mapper():

--- a/external/loaders/tests/test_batches_save.py
+++ b/external/loaders/tests/test_batches_save.py
@@ -1,0 +1,39 @@
+import loaders
+import unittest.mock
+from loaders.testing import mapper_context, batches_from_mapper_context
+from loaders.batches import save
+import tempfile
+import yaml
+import xarray as xr
+
+
+def test_save(tmpdir):
+    """
+    Test that the batches described by the config have .to_netcdf(filename)
+    called on each of them, with the expected filenames.
+    """
+    mock_batches = [unittest.mock.MagicMock(spec=xr.Dataset) for _ in range(3)]
+    filenames = [f"{tmpdir}/00000.nc", f"{tmpdir}/00001.nc", f"{tmpdir}/00002.nc"]
+    with mapper_context(), batches_from_mapper_context():
+
+        @loaders._config.mapper_functions.register
+        def mock_mapper():
+            return None
+
+        @loaders._config.batches_from_mapper_functions.register
+        def mock_batches_from_mapper(
+            mapping_function, variable_names, mapping_kwargs=None,
+        ):
+            return mock_batches
+
+        config_dict = {
+            "function": "mock_batches_from_mapper",
+            "mapper_config": {"function": "mock_mapper", "kwargs": {}},
+            "kwargs": {},
+        }
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with open(tmpfile.name, "w") as f:
+                yaml.dump(config_dict, f)
+            save.main(data_config=tmpfile.name, output_path=tmpdir)
+        for filename, batch in zip(filenames, mock_batches):
+            batch.to_netcdf.assert_called_once_with(filename, engine="h5netcdf")

--- a/external/vcm/vcm/xarray_loaders.py
+++ b/external/vcm/vcm/xarray_loaders.py
@@ -3,6 +3,7 @@ import io
 import tempfile
 import os
 import shutil
+from typing import BinaryIO
 
 import dask.array as da
 import numpy as np
@@ -103,7 +104,7 @@ def open_delayed(delayed_dataset, schema: xr.Dataset) -> xr.Dataset:
     return xr.Dataset(data_vars, coords=schema.coords, attrs=schema.attrs)
 
 
-def dump_nc(ds: xr.Dataset, f):
+def dump_nc(ds: xr.Dataset, f: BinaryIO):
     # to_netcdf closes file, which will delete the buffer
     # need to use a buffer since seek doesn't work with GCSFS file objects
     with tempfile.TemporaryDirectory() as dirname:


### PR DESCRIPTION
This PR adds a CLI endpoint to preprocess data through BatchesLoader configuration, by saving the output in netCDF files.

Added public API:
- Added `loaders.batches.save` which can be used to save a directory of netCDF files from a given BatchesLoader configuration file.

Internal changes:
- moved some context managers for loaders testing into `loaders.testing` so they can be re-used in multiple test files

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
