### PR TITLE
Add batches_from_netcdf loading function

### DIFF
--- a/external/loaders/loaders/__init__.py
+++ b/external/loaders/loaders/__init__.py
@@ -21,6 +21,7 @@ from ._config import (
 from loaders.batches import (
     batches_from_geodata,
     batches_from_mapper,
+    batches_from_netcdf,
     batches_from_serialized,
     diagnostic_batches_from_geodata,
 )

--- a/external/loaders/loaders/batches/__init__.py
+++ b/external/loaders/loaders/batches/__init__.py
@@ -1,6 +1,7 @@
 from ._batch import (
     batches_from_geodata,
     batches_from_mapper,
+    batches_from_netcdf,
     batches_from_serialized,
     diagnostic_batches_from_geodata,
 )

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -267,3 +267,20 @@ def test_batches_from_mapper_subsample(subsample_ratio: float):
     for i in range(10):
         sample_counts.append(np.sum(data == i))
     assert not all(count == sample_counts[0] for count in sample_counts)
+
+
+def test_batches_from_netcdf(tmpdir):
+    saved_batches = []
+    for i in range(5):
+        ds = xr.Dataset(
+            data_vars={
+                "a": xr.DataArray(
+                    np.random.uniform(size=[2, 3, 4]), dims=["dim0", "dim1", "dim2"],
+                )
+            }
+        )
+        ds.to_netcdf(os.path.join(tmpdir, f"{i}.nc"))
+        saved_batches.append(ds)
+    loaded_batches = loaders.batches_from_netcdf(path=str(tmpdir))
+    for ds_saved, ds_loaded in zip(saved_batches, loaded_batches):
+        xr.testing.assert_equal(ds_saved, ds_loaded)

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -127,6 +127,7 @@ def test_expected_batches_functions_exist():
         "batches_from_geodata",
         "batches_from_serialized",
         "diagnostic_batches_from_geodata",
+        "batches_from_netcdf",
     )
     for expected in expected_functions:
         assert expected in loaders._config.batches_functions


### PR DESCRIPTION
This PR adds a batches function for loading netCDF files from disk.

This can be used to load pre-cached data, e.g. as would be generated from the CLI tool in #1634 .

Added public API:
- added batches_from_netcdf batches function to loaders

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
