### PR TITLE
fv3fit: filter small values when fitting scaled-transform

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/__init__.py
@@ -3,4 +3,10 @@ from .factories import (
     ConditionallyScaled,
     TransformedVariableConfig,
 )
-from .transforms import ComposedTransform, Identity, LogTransform, TensorTransform
+from .transforms import (
+    ComposedTransform,
+    Difference,
+    Identity,
+    LogTransform,
+    TensorTransform,
+)

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -84,7 +84,7 @@ class ConditionallyScaled(TransformFactory):
         source: The variable to be normalized.
         min_scale: the minimium scale to normalize by. Used when the scale might
             be 0.
-        filter_magnitude: if provided, any values with
+        fit_filter_magnitude: if provided, any values with
             |source| < filter_magnitude are removed from the standard
             deviation/mean calculation.
 
@@ -95,7 +95,7 @@ class ConditionallyScaled(TransformFactory):
     source: str
     bins: int
     min_scale: float = 0.0
-    filter_magnitude: Optional[float] = None
+    fit_filter_magnitude: Optional[float] = None
 
     def backward_names(self, requested_names: Set[str]) -> Set[str]:
         """List the names needed to compute ``self.to``"""
@@ -106,8 +106,8 @@ class ConditionallyScaled(TransformFactory):
 
     def build(self, sample: TensorDict) -> ConditionallyScaledTransform:
 
-        if self.filter_magnitude is not None:
-            mask = tf.abs(sample[self.source]) > self.filter_magnitude
+        if self.fit_filter_magnitude is not None:
+            mask = tf.abs(sample[self.source]) > self.fit_filter_magnitude
         else:
             mask = ...
 

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -71,8 +71,7 @@ def fit_conditional(
 class ConditionallyScaled(TransformFactory):
     """Conditionally scaled transformation
 
-    Scales the output-input difference of ``source`` by conditional standard
-    deviation and mean::
+    Scales ``source`` by conditional standard deviation and mean::
 
                   source - E[source|on]
         to =  --------------------------------

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -71,23 +71,22 @@ def fit_conditional(
 class ConditionallyScaled(TransformFactory):
     """Conditionally scaled transformation
 
-    Scales the output-input difference of ``field`` by conditional standard
+    Scales the output-input difference of ``source`` by conditional standard
     deviation and mean::
 
-                  d field - E[d field|on]
+                  source - E[source|on]
         to =  --------------------------------
-               max[Std[d field|on], min_scale]
+               max[Std[source|on], min_scale]
 
     Attributes:
         to: name of the transformed variable.
         condition_on: the variable to condition on
         bins: the number of bins
-        field: the prognostic variable spec. The difference between input and
-            output data (``d field``) is normalized.
+        source: The variable to be normalized.
         min_scale: the minimium scale to normalize by. Used when the scale might
             be 0.
         filter_magnitude: if provided, any values with
-            |to-field| < filter_magnitude are removed from the standard
+            |source| < filter_magnitude are removed from the standard
             deviation/mean calculation.
 
     """

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -20,6 +20,11 @@ class Difference(TensorTransform):
 
         to = after - before
 
+    Notes:
+        This class is its own factory (i.e. includes the .build and
+        .backwards_names methods). This is only possible because it doesn't
+        depend on data and can be represented directly in yaml.
+
     """
 
     to: str

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -87,16 +87,14 @@ class ConditionallyScaledTransform(TensorTransform):
     def __init__(
         self,
         to: str,
-        input_name: str,
-        output_name: str,
+        source: str,
         on: str,
         scale: Callable[[tf.Tensor], tf.Tensor],
         center: Callable[[tf.Tensor], tf.Tensor],
         min_scale: float = 0.0,
     ) -> None:
         self.to = to
-        self.input_name = input_name
-        self.output_name = output_name
+        self.source = source
         self.on = on
         self.scale = scale
         self.center = center
@@ -107,17 +105,15 @@ class ConditionallyScaledTransform(TensorTransform):
 
     def forward(self, x: TensorDict) -> TensorDict:
         out = {**x}
-        out[self.to] = (
-            x[self.output_name] - x[self.input_name] - self.center(x[self.on])
-        ) / self._limited_scale(x[self.on])
+        out[self.to] = (x[self.source] - self.center(x[self.on])) / self._limited_scale(
+            x[self.on]
+        )
         return out
 
     def backward(self, y: TensorDict) -> TensorDict:
         out = {**y}
-        out[self.output_name] = (
-            y[self.to] * self._limited_scale(y[self.on])
-            + y[self.input_name]
-            + self.center(y[self.on])
+        out[self.source] = y[self.to] * self._limited_scale(y[self.on]) + self.center(
+            y[self.on]
         )
         return out
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -32,6 +32,7 @@ from fv3fit.emulation.losses import CustomLoss
 from fv3fit.emulation.models import transform_model
 from fv3fit.emulation.transforms import (
     ComposedTransformFactory,
+    Difference,
     TensorTransform,
     TransformedVariableConfig,
 )
@@ -93,7 +94,7 @@ class TrainConfig:
     out_url: str
     transform: TransformConfig = field(default_factory=TransformConfig)
     tensor_transform: List[
-        Union[TransformedVariableConfig, ConditionallyScaled]
+        Union[TransformedVariableConfig, ConditionallyScaled, Difference]
     ] = field(default_factory=list)
     model: Optional[models.MicrophysicsConfig] = None
     conservative_model: Optional[models.ConservativeWaterConfig] = None

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -258,7 +258,7 @@ def test_ConditionallyScaled_applies_mask(monkeypatch, filter_magnitude):
         to=to,
         bins=1,
         condition_on=on,
-        filter_magnitude=filter_magnitude,
+        fit_filter_magnitude=filter_magnitude,
     )
 
     factory.build(data)


### PR DESCRIPTION
The temperature scaling is current fit including samples that are identically zero. This causes unstable training (See microphysics emulation slides).

* Add option `filter_magnitude` to remove these samples from the fit
* refactor differencing to new object for improved composability