### PR TITLE
Allow composing transforms

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -119,5 +119,10 @@ class ComposedTransformFactory(TransformFactory):
         self.factories = factories
 
     def build(self, sample: TensorDict) -> ComposedTransform:
-        transforms = [factory.build(sample) for factory in self.factories]
+        transforms = []
+        sample = {**sample}
+        for factory in self.factories:
+            transform = factory.build(sample)
+            sample.update(transform.forward(sample))
+            transforms.append(transform)
         return ComposedTransform(transforms)

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Callable, List, Set
+from typing import Callable, List
 
 import tensorflow as tf
 from typing_extensions import Protocol
@@ -21,19 +21,15 @@ class Difference(TensorTransform):
         to = after - before
 
     Notes:
-        This class is its own factory (i.e. includes the .build and
-        .backwards_names methods). This is only possible because it doesn't
-        depend on data and can be represented directly in yaml.
+        This class is its own factory (i.e. includes the .build method). This is
+        only possible because it doesn't depend on data and can be represented
+        directly in yaml.
 
     """
 
     to: str
     before: str
     after: str
-
-    def backward_names(self, requested_names: Set[str]) -> Set[str]:
-        new_names = {self.before, self.after} if self.to in requested_names else set()
-        return requested_names.union(new_names)
 
     def build(self, sample: TensorDict) -> TensorTransform:
         return self

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -178,26 +178,25 @@ def test_TrainConfig_from_args_sysargv(monkeypatch, default_yml):
 )
 def test_rnn_v1_cache_disable(arch_key, expected_cache):
 
-    default = _get_test_config()
-    d = asdict(default)
-    d["cache"] = True
-    d["model"]["architecture"]["name"] = arch_key
-    config = TrainConfig.from_dict(d)
-
+    config = TrainConfig(
+        ".",
+        ".",
+        ".",
+        cache=True,
+        model=MicrophysicsConfig(architecture=ArchitectureConfig(name=arch_key)),
+    )
     assert config.cache == expected_cache
 
 
 @pytest.mark.regression
 def test_training_entry_integration(tmp_path):
 
-    config_dict = asdict(_get_test_config())
-    config_dict["out_url"] = str(tmp_path)
-    config_dict["use_wandb"] = False
-    config_dict["nfiles"] = 4
-    config_dict["nfiles_valid"] = 4
-    config_dict["epochs"] = 1
-
-    config = TrainConfig.from_dict(config_dict)
+    config = _get_test_config()
+    config.out_url = str(tmp_path)
+    config.use_wandb = False
+    config.nfiles = 4
+    config.nfiles_valid = 4
+    config.epochs = 1
 
     main(config)
 

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -68,27 +68,6 @@ def test_per_variable_transform_round_trip():
         _assert_scalar_approx(x[key], y[key])
 
 
-def test_per_variable_transform_backward_names():
-    transform = ComposedTransformFactory(
-        [TransformedVariableConfig("a", "b", LogTransform())]
-    )
-    assert transform.backward_names({"b"}) == {"a"}
-    assert transform.backward_names({"b", "random"}) == {"a", "random"}
-
-
-def test_composed_transform_backward_names_sequence():
-    """intermediate names produced by one transform should not be listed in the
-    required_names
-    """
-    transform = ComposedTransformFactory(
-        [
-            TransformedVariableConfig("a", "b", LogTransform()),
-            TransformedVariableConfig("b", "c", LogTransform()),
-        ]
-    )
-    assert transform.backward_names({"c"}) == {"a", "c"}
-
-
 def test_ComposedTransform_forward_backward_on_sequential_transforms():
     # some transforms could be mutually dependent
 
@@ -186,16 +165,6 @@ def test_ConditionallyScaledTransform_backward(min_scale: float):
         np.testing.assert_array_almost_equal(data[key], round_tripped[key])
 
 
-def test_ConditionallyScaled_backward_names():
-    factory = ConditionallyScaled(source="in", to="z", bins=10, condition_on="T")
-    assert factory.backward_names({"z"}) == {"z", "T", "in"}
-
-
-def test_ConditionallyScaled_backward_names_output_not_in_request():
-    factory = ConditionallyScaled(source="in", to="z", bins=10, condition_on="T")
-    assert factory.backward_names({"a", "b"}) == {"a", "b"}
-
-
 def test_ConditionallyScaled_build():
     tf.random.set_seed(0)
     out_name = "x_out"
@@ -212,12 +181,6 @@ def test_ConditionallyScaled_build():
 
     assert tf.reduce_mean(out[to]).numpy() == pytest.approx(0.0, abs=0.1)
     assert tf.reduce_mean(out[to] ** 2).numpy() == pytest.approx(1.0, abs=0.1)
-
-
-def test_Difference_backward_names():
-    diff = Difference("diff", "before", "after")
-    assert diff.backward_names({"diff"}) == {"before", "after", "diff"}
-    assert diff.backward_names({"not in a"}) == {"not in a"}
 
 
 def test_Difference_build():

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -76,6 +76,19 @@ def test_per_variable_transform_backward_names():
     assert transform.backward_names({"b", "random"}) == {"a", "random"}
 
 
+def test_composed_transform_backward_names_sequence():
+    """intermediate names produced by one transform should not be listed in the
+    required_names
+    """
+    transform = ComposedTransformFactory(
+        [
+            TransformedVariableConfig("a", "b", LogTransform()),
+            TransformedVariableConfig("b", "c", LogTransform()),
+        ]
+    )
+    assert transform.backward_names({"c"}) == {"a", "c"}
+
+
 def test_ComposedTransform_forward_backward_on_sequential_transforms():
     # some transforms could be mutually dependent
 

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -242,3 +242,26 @@ def test_ConditionallyScaled_applies_mask(monkeypatch, filter_magnitude):
     # assert that fit_conditional was passed arrays of the expected size
     fit_conditional_x_arg = fit_conditional.call_args[0][0]
     assert fit_conditional_x_arg.shape == expected_shape
+
+
+def test_ComposedTransform_with_build():
+    """Check that composed transform works if an earlier transform produces an
+    output need by the .build of a later one"""
+
+    class MockTransform:
+        def forward(self, x):
+            return {"b": x["a"]}
+
+    factory1 = Mock()
+    factory1.build.return_value = MockTransform()
+
+    factory2 = Mock()
+    factory2.build.return_value = MockTransform()
+
+    data = {"a": 0}
+
+    ComposedTransformFactory([factory1, factory2]).build(data)
+
+    # mock2.build is called with the "b" variable outputted by mock1
+    (build_sample_for_second_mock,) = factory2.build.call_args[0]
+    assert build_sample_for_second_mock == {"b": 0, "a": 0}


### PR DESCRIPTION
#1641 split the temperature-scaling transform into two parts(e.g. Difference and ConditionalScaling). However, for several reasons I was unable to compose two transformations. With the fixes in this PR, I can train a precipitation-difference only model with these changes: https://wandb.ai/ai2cm/microphysics-emulation/runs/19h3235r?workspace=user-nbrenowitz

I suggest reviewing commit-by-commit.

API Changes:
- user must list all the variables to be loaded from the netCDFs (or computed by vcm.DerivedMapping) in `TrainConfig.data_variables`
- user must list the input variables used for the saved ML model in `TrainConfig.input_variables`

The code to infer these variables automatically was not general enough for composed transformations...and generalizing it felt like over-engineering. 