### PR TITLE
Reset index before saving in loaders.batches.save

### DIFF
--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -1,5 +1,6 @@
 import argparse
 from loaders._config import BatchesLoader
+from loaders._utils import SAMPLE_DIM_NAME
 import yaml
 import os.path
 import logging
@@ -40,7 +41,12 @@ def main(data_config: str, output_path: str):
     for i, batch in enumerate(batches):
         out_filename = os.path.join(output_path, f"{i:05}.nc")
         logger.info(f"saving batch {i}")
-        batch.to_netcdf(out_filename, engine="h5netcdf")
+        try:
+            batch.to_netcdf(out_filename, engine="h5netcdf")
+        except NotImplementedError:
+            batch.reset_index(dims_or_levels=[SAMPLE_DIM_NAME]).to_netcdf(
+                out_filename, engine="h5netcdf"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a bug where batches with a sample MultiIndex from stacking could not be saved with loaders.batches.save by removing the MultiIndex before saving.

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
