### PR TITLE
Allow composing transforms

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -159,5 +159,10 @@ class ComposedTransformFactory(TransformFactory):
         return out
 
     def build(self, sample: TensorDict) -> ComposedTransform:
-        transforms = [factory.build(sample) for factory in self.factories]
+        transforms = []
+        sample = {**sample}
+        for factory in self.factories:
+            transform = factory.build(sample)
+            sample.update(transform.forward(sample))
+            transforms.append(transform)
         return ComposedTransform(transforms)

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -76,6 +76,19 @@ def test_per_variable_transform_backward_names():
     assert transform.backward_names({"b", "random"}) == {"a", "random"}
 
 
+def test_composed_transform_backward_names_sequence():
+    """intermediate names produced by one transform should not be listed in the
+    required_names
+    """
+    transform = ComposedTransformFactory(
+        [
+            TransformedVariableConfig("a", "b", LogTransform()),
+            TransformedVariableConfig("b", "c", LogTransform()),
+        ]
+    )
+    assert transform.backward_names({"c"}) == {"a", "c"}
+
+
 def test_ComposedTransform_forward_backward_on_sequential_transforms():
     # some transforms could be mutually dependent
 

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -86,7 +86,7 @@ def test_composed_transform_backward_names_sequence():
             TransformedVariableConfig("b", "c", LogTransform()),
         ]
     )
-    assert transform.backward_names({"c"}) == {"a", "c"}
+    assert transform.backward_names({"c"}) == {"a"}
 
 
 def test_ComposedTransform_forward_backward_on_sequential_transforms():


### PR DESCRIPTION
#1641 split the temperature-scaling transform into two parts(e.g. Difference and ConditionalScaling). However, for several reasons I was unable to compose two transformations. With the fixes in this PR, I can train a precipitation-difference only model with these changes: https://wandb.ai/ai2cm/microphysics-emulation/runs/16g3d9lv
