### PR TITLE
Use netcdf files for local file caching

### DIFF
--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import os
-from typing import Sequence
+from typing import Optional, Tuple
 from fv3fit._shared.config import get_arg_updated_config_dict
 import yaml
 import dataclasses
@@ -10,11 +10,14 @@ import fsspec
 import fv3fit.keras
 import fv3fit.sklearn
 import fv3fit
-import xarray as xr
 import loaders
+import loaders.typing
 import tempfile
+from loaders.batches.save import main as save_main
 
 from vcm.cloud import copy
+
+logger = logging.getLogger(__name__)
 
 
 def get_parser():
@@ -42,10 +45,8 @@ def get_parser():
     parser.add_argument(
         "--local-download-path",
         type=str,
-        help=(
-            "optional path for downloading data before training, "
-            "can greatly increase training speed"
-        ),
+        default=None,
+        help=("path for downloading data before training"),
     )
     return parser
 
@@ -53,6 +54,64 @@ def get_parser():
 def dump_dataclass(obj, yaml_filename):
     with fsspec.open(yaml_filename, "w") as f:
         yaml.safe_dump(dataclasses.asdict(obj), f)
+
+
+def get_data(
+    training_data_config: str,
+    validation_data_config: Optional[str],
+    local_download_path: Optional[str],
+) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
+    if local_download_path is None:
+        return get_uncached_data(
+            training_data_config=training_data_config,
+            validation_data_config=validation_data_config,
+        )
+    else:
+        return get_cached_data(
+            training_data_config=training_data_config,
+            validation_data_config=validation_data_config,
+            local_download_path=local_download_path,
+        )
+
+
+def get_uncached_data(
+    training_data_config: str, validation_data_config: Optional[str],
+) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
+    with open(training_data_config, "r") as f:
+        config = yaml.safe_load(f)
+    loader = loaders.BatchesLoader.from_dict(config)
+    logger.info("configuration loaded, creating batches object")
+    train_batches = loader.load_batches()
+    if validation_data_config is not None:
+        with open(training_data_config, "r") as f:
+            config = yaml.safe_load(f)
+        loader = loaders.BatchesLoader.from_dict(config)
+        logger.info("configuration loaded, creating batches object")
+        val_batches = loader.load_batches()
+    else:
+        val_batches = []
+    return train_batches, val_batches
+
+
+def get_cached_data(
+    training_data_config: str,
+    validation_data_config: Optional[str],
+    local_download_path: str,
+) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
+    train_data_path = os.path.join(local_download_path, "train_data")
+    logger.info("saving training data to %s", train_data_path)
+    os.makedirs(train_data_path, exist_ok=True)
+    save_main(data_config=training_data_config, output_path=train_data_path)
+    train_batches = loaders.batches_from_netcdf(path=train_data_path)
+    if validation_data_config is not None:
+        validation_data_path = os.path.join(local_download_path, "validation_data")
+        logger.info("saving validation data to %s", validation_data_path)
+        os.makedirs(validation_data_path, exist_ok=True)
+        save_main(data_config=validation_data_config, output_path=validation_data_path)
+        val_batches = loaders.batches_from_netcdf(path=train_data_path)
+    else:
+        val_batches = []
+    return train_batches, val_batches
 
 
 def main(args, unknown_args=None):
@@ -74,32 +133,13 @@ def main(args, unknown_args=None):
         training_data_config, os.path.join(args.output_path, "training_data.yaml")
     )
 
-    train_batches: loaders.typing.Batches = training_data_config.load_batches(
-        variables=training_config.variables
+    train_batches, val_batches = get_data(
+        args.training_data_config, args.validation_data_config, args.local_download_path
     )
-    if args.validation_data_config is not None:
-        with open(args.validation_data_config, "r") as f:
-            validation_data_config = loaders.BatchesLoader.from_dict(yaml.safe_load(f))
-        dump_dataclass(
-            validation_data_config,
-            os.path.join(args.output_path, "validation_data.yaml"),
-        )
-        val_batches = validation_data_config.load_batches(
-            variables=training_config.variables
-        )
-    else:
-        val_batches: Sequence[xr.Dataset] = []
-
-    if args.local_download_path:
-        train_batches = loaders.to_local(
-            train_batches, os.path.join(args.local_download_path, "train")
-        )
-        val_batches = loaders.to_local(
-            val_batches, os.path.join(args.local_download_path, "validation")
-        )
 
     train = fv3fit.get_training_function(training_config.model_type)
 
+    logger.info("calling train function")
     model = train(
         hyperparameters=training_config.hyperparameters,
         train_batches=train_batches,
@@ -111,7 +151,7 @@ def main(args, unknown_args=None):
 
 
 if __name__ == "__main__":
-
+    logger.setLevel(logging.INFO)
     parser = get_parser()
     args, unknown_args = parser.parse_known_args()
     with tempfile.NamedTemporaryFile() as temp_log:

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -88,7 +88,7 @@ def get_uncached_data(
     logger.info("configuration loaded, creating batches object")
     train_batches = loader.load_batches(variables=variable_names)
     if validation_data_config is not None:
-        with open(training_data_config, "r") as f:
+        with open(validation_data_config, "r") as f:
             config = yaml.safe_load(f)
         loader = loaders.BatchesLoader.from_dict(config)
         logger.info("configuration loaded, creating batches object")
@@ -122,7 +122,7 @@ def get_cached_data(
             output_path=validation_data_path,
             variable_names=variable_names,
         )
-        val_batches = loaders.batches_from_netcdf(path=train_data_path)
+        val_batches = loaders.batches_from_netcdf(path=validation_data_path)
     else:
         val_batches = []
     return train_batches, val_batches

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -154,10 +154,10 @@ def test_main_calls_load_batches_correctly(
     Test of fv3fit.train main function only, using mocks for training function
     and data loading.
     """
-    call_main(
+    artifacts = call_main(
         tmpdir, mock_load_batches, derived_output_variables, use_validation_data,
     )
-    mock_load_batches.assert_called_with()
+    mock_load_batches.assert_called_with(variables=artifacts.variables)
     if use_validation_data:
         assert (
             mock_load_batches.call_args_list[0] == mock_load_batches.call_args_list[1]

--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -272,9 +272,7 @@ def _get_batch(
 
 @curry
 def _open_dataset(fs: fsspec.AbstractFileSystem, filename):
-    return xr.open_dataset(
-        fs.open(filename), engine="h5netcdf", chunks={"sample": "auto"}
-    )
+    return xr.open_dataset(fs.open(filename), engine="h5netcdf")
 
 
 @batches_functions.register

--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -272,7 +272,9 @@ def _get_batch(
 
 @curry
 def _open_dataset(fs: fsspec.AbstractFileSystem, filename):
-    return xr.open_dataset(fs.open(filename), engine="h5netcdf")
+    return xr.open_dataset(
+        fs.open(filename), engine="h5netcdf", chunks={"sample": "auto"}
+    )
 
 
 @batches_functions.register

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Sequence
 from loaders._config import BatchesLoader
 from loaders._utils import SAMPLE_DIM_NAME
 import yaml
@@ -27,15 +28,16 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         help="local directory to save data as numbered netCDF files",
     )
+    parser.add_argument("-n", "--variable-names", nargs="+", default=[])
     return parser
 
 
-def main(data_config: str, output_path: str):
+def main(data_config: str, output_path: str, variable_names: Sequence[str]):
     with open(data_config, "r") as f:
         config = yaml.safe_load(f)
     loader = BatchesLoader.from_dict(config)
     logger.info("configuration loaded, creating batches object")
-    batches = loader.load_batches()
+    batches = loader.load_batches(variables=variable_names)
     n_batches = len(batches)
     logger.info(f"batches object created, saving {n_batches} batches")
     for i, batch in enumerate(batches):
@@ -59,4 +61,8 @@ if __name__ == "__main__":
 
     parser = get_parser()
     args = parser.parse_args()
-    main(data_config=args.data_config, output_path=args.output_path)
+    main(
+        data_config=args.data_config,
+        output_path=args.output_path,
+        variable_names=args.variable_names,
+    )

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -6,6 +6,7 @@ import yaml
 import os.path
 import logging
 import sys
+import os
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -48,7 +49,8 @@ def main(data_config: str, output_path: str, variable_names: Sequence[str]):
     logger.info("configuration loaded, creating batches object")
     batches = loader.load_batches(variables=variable_names)
     n_batches = len(batches)
-    logger.info(f"batches object created, saving {n_batches} batches")
+    logger.info(f"batches object created, saving {n_batches} batches to {output_path}")
+    os.makedirs(output_path, exist_ok=True)
     for i, batch in enumerate(batches):
         out_filename = os.path.join(output_path, f"{i:05}.nc")
         logger.info(f"saving batch {i}")

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -28,7 +28,16 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         help="local directory to save data as numbered netCDF files",
     )
-    parser.add_argument("-n", "--variable-names", nargs="+", default=[])
+    parser.add_argument(
+        "-n",
+        "--variable-names",
+        nargs="+",
+        default=[],
+        help=(
+            "variable names to include in saved file, "
+            "passed to BatchesLoader.load_batches"
+        ),
+    )
     return parser
 
 

--- a/external/loaders/tests/test_batches_save.py
+++ b/external/loaders/tests/test_batches_save.py
@@ -6,6 +6,8 @@ import tempfile
 import yaml
 import xarray as xr
 import numpy as np
+import os
+import pytest
 
 
 def test_save(tmpdir):
@@ -35,7 +37,7 @@ def test_save(tmpdir):
         with tempfile.NamedTemporaryFile() as tmpfile:
             with open(tmpfile.name, "w") as f:
                 yaml.dump(config_dict, f)
-            save.main(data_config=tmpfile.name, output_path=tmpdir)
+            save.main(data_config=tmpfile.name, output_path=tmpdir, variable_names=[])
         for filename, batch in zip(filenames, mock_batches):
             batch.to_netcdf.assert_called_once_with(filename, engine="h5netcdf")
 
@@ -69,4 +71,42 @@ def test_save_stacked_data(tmpdir):
                 yaml.dump(config_dict, f)
             # only need to test a lack of crash for stacked data,
             # batch.to_netcdf being called is checked in another test
-            save.main(data_config=tmpfile.name, output_path=tmpdir)
+            save.main(data_config=tmpfile.name, output_path=tmpdir, variable_names=[])
+            ds = xr.open_dataset(os.path.join(str(tmpdir), "00000.nc"))
+            assert "a" in ds.data_vars
+            assert ds.a.dims == ("_fv3net_sample", "z")
+
+
+def test_save_raises_on_missing_variable(tmpdir):
+    with mapper_context(), batches_from_mapper_context():
+
+        @loaders._config.mapper_functions.register
+        def mock_mapper():
+            return {
+                "0": xr.Dataset(
+                    data_vars={
+                        "a": xr.DataArray(
+                            np.zeros([10, 5, 5, 7]), dims=["dim0", "dim1", "dim2", "z"]
+                        )
+                    }
+                )
+            }
+
+        loaders._config.batches_from_mapper_functions.register(
+            loaders.batches_from_mapper
+        )
+
+        config_dict = {
+            "function": "batches_from_mapper",
+            "mapper_config": {"function": "mock_mapper", "kwargs": {}},
+            "kwargs": {"unstacked_dims": ["z"], "variable_names": ["a"]},
+        }
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with open(tmpfile.name, "w") as f:
+                yaml.dump(config_dict, f)
+            # only need to test a lack of crash for stacked data,
+            # batch.to_netcdf being called is checked in another test
+            with pytest.raises(KeyError):
+                save.main(
+                    data_config=tmpfile.name, output_path=tmpdir, variable_names=["b"]
+                )


### PR DESCRIPTION
This PR replaces the use of `Local` in fv3fit training with loaders.batches.save and the netCDF loader.

Refactored public API:
- The format of saved data when fv3fit.train is called with local_download_path has changed.
- Some logging has been added to fv3fit.train.
- The output directory is now created if it does not exist for loaders.batches.save

Significant internal changes:
- Locally-cached batches now use the netCDF loader instead of Local.

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
