### PR TITLE
Recursive dependency check for ordered transforms

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/__init__.py
@@ -2,10 +2,11 @@ from .factories import (
     ComposedTransformFactory,
     ConditionallyScaled,
     TransformedVariableConfig,
+    Difference,
 )
 from .transforms import (
     ComposedTransform,
-    Difference,
+    DifferenceTransform,
     Identity,
     LogTransform,
     TensorTransform,

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -27,7 +27,7 @@ class TransformFactory(Protocol):
 
     """
 
-    to: str = ""
+    to: str
 
     def backward_names(self, requested_names: Set[str]) -> Set[str]:
         pass
@@ -178,3 +178,18 @@ def _get_required_inputs(
         requested_names -= available_from_transform
 
     return set()
+
+
+def _get_dependencies(name: str, factories: Sequence[TransformFactory]):
+
+    deps = set()
+    for i, factory in enumerate(factories[::-1], 1):
+
+        if factory.to == name:
+            for dep_name in sorted(factory.required_names):
+                deps |= _get_dependencies(dep_name, factories[:-i])
+            break
+    else:
+        return {name}
+
+    return deps

--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -183,13 +183,18 @@ def _get_required_inputs(
 def _get_dependencies(name: str, factories: Sequence[TransformFactory]):
 
     deps = set()
+    intermediate_deps = set()
+
     for i, factory in enumerate(factories[::-1], 1):
 
         if factory.to == name:
+            intermediate_deps |= factory.required_names
             for dep_name in sorted(factory.required_names):
-                deps |= _get_dependencies(dep_name, factories[:-i])
+                new_deps, intermediate = _get_dependencies(dep_name, factories[:-i])
+                deps |= new_deps
+                intermediate_deps |= intermediate
             break
     else:
-        return {name}
+        return {name}, set()
 
-    return deps
+    return deps, intermediate_deps - deps

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -35,6 +35,10 @@ class Difference(TensorTransform):
         new_names = {self.before, self.after} if self.to in requested_names else set()
         return requested_names.union(new_names)
 
+    @property
+    def required_names(self) -> Set[str]:
+        return {self.before, self.after}
+
     def build(self, sample: TensorDict) -> TensorTransform:
         return self
 

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Callable, List, Set
+from typing import Callable, List
 
 import tensorflow as tf
 from typing_extensions import Protocol
@@ -15,32 +15,16 @@ class TensorTransform(Protocol):
 
 
 @dataclasses.dataclass
-class Difference(TensorTransform):
+class DifferenceTransform(TensorTransform):
     """A difference variable::
 
         to = after - before
-
-    Notes:
-        This class is its own factory (i.e. includes the .build and
-        .backwards_names methods). This is only possible because it doesn't
-        depend on data and can be represented directly in yaml.
-
     """
 
-    to: str
-    before: str
-    after: str
-
-    def backward_names(self, requested_names: Set[str]) -> Set[str]:
-        new_names = {self.before, self.after} if self.to in requested_names else set()
-        return requested_names.union(new_names)
-
-    @property
-    def required_names(self) -> Set[str]:
-        return {self.before, self.after}
-
-    def build(self, sample: TensorDict) -> TensorTransform:
-        return self
+    def __init__(self, to: str, before: str, after: str):
+        self.to = to
+        self.before = before
+        self.after = after
 
     def forward(self, x: TensorDict) -> TensorDict:
         x = {**x}

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -152,7 +152,7 @@ class TrainConfig:
     @property
     def input_variables(self) -> Sequence:
         return list(
-            self.transform_factory.backward_names(set(self._model.input_variables))
+            self.transform_factory.get_required_inputs(set(self._model.input_variables))
         )
 
     @classmethod
@@ -245,7 +245,7 @@ class TrainConfig:
 
     @property
     def model_variables(self) -> Set[str]:
-        return self.transform_factory.backward_names(
+        return self.transform_factory.get_required_inputs(
             set(self._model.input_variables) | set(self._model.output_variables)
         )
 

--- a/external/fv3fit/tests/emulation/test_transform_deps.py
+++ b/external/fv3fit/tests/emulation/test_transform_deps.py
@@ -20,7 +20,7 @@ def test_cycle():
     factories = [DummyFactory("b", deps={"a"}), DummyFactory("a", deps={"b"})]
 
     result = _get_dependencies("a", factories)
-    assert result == ({"a"}, {"b"})
+    assert result == {"a"}
 
 
 def test_intermediate_blend():
@@ -31,7 +31,7 @@ def test_intermediate_blend():
     ]
 
     result = _get_dependencies("d", factories)
-    assert result == ({"a", "b"}, {"c"})
+    assert result == {"a", "b"}
 
 
 def test_cycle_with_passthrough():
@@ -43,7 +43,7 @@ def test_cycle_with_passthrough():
     ]
 
     result = _get_dependencies("a", factories)
-    assert result == ({"a"}, {"b"})
+    assert result == {"a"}
 
 
 def test_only_get_requested():
@@ -54,4 +54,4 @@ def test_only_get_requested():
     ]
 
     result = _get_dependencies("d", factories)
-    assert result == ({"c"}, set())
+    assert result == {"c"}

--- a/external/fv3fit/tests/emulation/test_transform_deps.py
+++ b/external/fv3fit/tests/emulation/test_transform_deps.py
@@ -20,10 +20,10 @@ def test_cycle():
     factories = [DummyFactory("b", deps={"a"}), DummyFactory("a", deps={"b"})]
 
     result = _get_dependencies("a", factories)
-    assert result == {"a"}
+    assert result == ({"a"}, {"b"})
 
 
-def test_intermediate():
+def test_intermediate_blend():
 
     factories = [
         DummyFactory("c", deps={"a", "b"}),
@@ -31,10 +31,22 @@ def test_intermediate():
     ]
 
     result = _get_dependencies("d", factories)
-    assert result == {"a", "b"}
+    assert result == ({"a", "b"}, {"c"})
 
 
-def test_only_requested():
+def test_cycle_with_passthrough():
+
+    factories = [
+        DummyFactory("b", deps={"a"}),
+        DummyFactory("a", deps={"b"}),
+        DummyFactory("a", deps={"a"}),
+    ]
+
+    result = _get_dependencies("a", factories)
+    assert result == ({"a"}, {"b"})
+
+
+def test_only_get_requested():
 
     factories = [
         DummyFactory("b", deps={"a"}),
@@ -42,4 +54,4 @@ def test_only_requested():
     ]
 
     result = _get_dependencies("d", factories)
-    assert result == {"c"}
+    assert result == ({"c"}, set())

--- a/external/fv3fit/tests/emulation/test_transform_deps.py
+++ b/external/fv3fit/tests/emulation/test_transform_deps.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Set
+
+from fv3fit.emulation.transforms.factories import TransformFactory, _get_dependencies
+
+
+@dataclass
+class DummyFactory(TransformFactory):
+
+    to: str
+    deps: Set[str]
+
+    @property
+    def required_names(self) -> Set[str]:
+        return self.deps
+
+
+def test_cycle():
+
+    factories = [DummyFactory("b", deps={"a"}), DummyFactory("a", deps={"b"})]
+
+    result = _get_dependencies("a", factories)
+    assert result == {"a"}
+
+
+def test_intermediate():
+
+    factories = [
+        DummyFactory("c", deps={"a", "b"}),
+        DummyFactory("d", deps={"b", "c"}),
+    ]
+
+    result = _get_dependencies("d", factories)
+    assert result == {"a", "b"}
+
+
+def test_only_requested():
+
+    factories = [
+        DummyFactory("b", deps={"a"}),
+        DummyFactory("d", deps={"c"}),
+    ]
+
+    result = _get_dependencies("d", factories)
+    assert result == {"c"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,8 @@ norecursedirs =
     build
     external/fv3config
     external/artifacts
-    external/fv3fit
+    ; external/fv3fit
+    workflows/diagnostics/tests/prognostic
     external/fv3gfs-wrapper
     external/fv3gfs-fortran
     external/fv3kube


### PR DESCRIPTION
A different design for transform dependency tracking that allows for cyclical naming, e.g., A -> B -> A or A -> A just requires A.  Tradeoff here is that it assumes transforms are correctly ordered, which is true since they're currently defined by the user.


Added public API:


Refactored public API:


Significant internal changes:

- [ ] Tests added
