### PR TITLE
emulation: simplify input name resolution

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -135,13 +135,6 @@ class ComposedTransformFactory(TransformFactory):
     def __init__(self, factories: Sequence[TransformFactory]):
         self.factories = factories
 
-    def _get_first_order_dependencies(self, name: str) -> Set[str]:
-        deps: Set[str] = set()
-        for factory in self.factories:
-            deps_of_name = factory.backward_names({name}) - {name}
-            deps = deps.union(deps_of_name)
-        return deps
-
     def backward_names(self, requested_names: Set[str]) -> Set[str]:
         for factory in self.factories[::-1]:
             requested_names = factory.backward_names(requested_names)

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -89,15 +89,15 @@ def test_composed_transform_backward_names_sequence():
     assert transform.backward_names({"c"}) == {"a"}
 
 
-def test_composed_transform_errors_on_circular_dep():
+def test_composed_transform_with_circular_dep():
     factory = ComposedTransformFactory(
         [
             TransformedVariableConfig("a", "b", LogTransform()),
             TransformedVariableConfig("b", "a", LogTransform()),
         ]
     )
-    with pytest.raises(ValueError):
-        return factory.backward_names({"a"})
+
+    assert factory.backward_names({"a"}) == {"a"}
 
 
 def test_composed_transform_ok_with_repeated_dep():


### PR DESCRIPTION
@frodre  was right to point out that some issues with #1647.

The DAG based logic of the ComposedTransformFactory isn't necessary and imposed unneeded constraints e.g. around circular dependencies of names. Since the compositions happen in a specific order, the solution is actually much simpler.

We can restore this logic if we ever make a DAG transform without this ordering.