### PR TITLE
Fix end of epoch loss logging bug 

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
@@ -26,11 +26,11 @@ class TrainingLoopLossHistory:
         self.val_loss_all = []
 
     def callback(self, epoch_result: EpochResult):
+        self.train_loss_end_of_epoch += epoch_result.history[-1].history["loss"]
+        self.val_loss_end_of_epoch += epoch_result.history[-1].history.get(
+            "val_loss", [np.nan]
+        )
         for batch in epoch_result.history:
-            self.train_loss_end_of_epoch.append(batch.history["loss"][-1])
-            self.val_loss_end_of_epoch.append(
-                batch.history.get("val_loss", [np.nan])[-1]
-            )
             self.train_loss_all += batch.history["loss"]
             self.val_loss_all += batch.history.get("val_loss", [])
 

--- a/external/fv3fit/tests/keras/test_callback.py
+++ b/external/fv3fit/tests/keras/test_callback.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+from fv3fit.keras._models.shared.callbacks import TrainingLoopLossHistory
+
+
+@dataclass
+class KerasHistoryMock:
+    history: Mapping[str, Sequence[float]]
+
+
+@dataclass
+class EpochResultMock:
+    history: Sequence[KerasHistoryMock]
+
+
+def _epoch_history(train_losses, val_losses):
+    history_over_batches = [
+        KerasHistoryMock(history={"loss": [train_loss], "val_loss": [val_loss]})
+        for train_loss, val_loss in zip(train_losses, val_losses)
+    ]
+    return EpochResultMock(history=tuple(history_over_batches))
+
+
+def test_TrainingLoopLossHistory_callback():
+    train_losses = [[1.0, 2.0], [3.0, 4.0]]
+    val_losses = [[-1.0, -2.0], [-3.0, -4.0]]
+
+    loss_history = TrainingLoopLossHistory()
+    for epoch_train_losses, epoch_val_losses in zip(train_losses, val_losses):
+        loss_history.callback(_epoch_history(epoch_train_losses, epoch_val_losses))
+
+    assert loss_history.train_loss_end_of_epoch == [2.0, 4.0]
+    assert loss_history.val_loss_end_of_epoch == [-2.0, -4.0]
+    assert loss_history.train_loss_all == [1.0, 2.0, 3.0, 4.0]
+    assert loss_history.val_loss_all == [-1.0, -2.0, -3.0, -4.0]


### PR DESCRIPTION
Fixes bug where the training loop callback logged the losses at each timesteps batch step instead of just the end of the epoch.

