### PR TITLE
Add cpu parameter to training argo workflow

### DIFF
--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -188,6 +188,7 @@ This workflow trains machine learning models.
 | `times`                | JSON-encoded list of timestamps to use for test data |
 | `offline-diags-output` | Where to save offline diagnostics                    |
 | `report-output`        | Where to save report                                 |
+| `cpu`                  | (optional) # cpu for workflow. Defaults to 1.        |
 | `memory`               | (optional) memory for workflow. Defaults to 6Gi.     |
 
 #### Command line interfaces used by workflow
@@ -257,6 +258,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `segment-count`         | (optional) `segment-count` for `prognostic-run` workflow; default "1" |
 | `cpu-prog`              | (optional) `cpu` for `prognostic-run` workflow; default "6"           |
 | `memory-prog`           | (optional) `memory` for `prognostic-run` workflow; default 6Gi        |
+| `cpu-training`          | (optional) `cpu` for `training` workflow; default "1"                 |
 | `memory-training`       | (optional) `memory` for `training` workflow; default 6Gi              |
 | `memory-offline-diags`  | (optional) `memory` for `offline-diags` workflow; default 6Gi         |
 | `training-flags`        | (optional) `flags` for `training` workflow                            |

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -31,6 +31,7 @@ spec:
       - {name: segment-count, value: "1"}
       - {name: cpu-prog, value: "6"}
       - {name: memory-prog, value: 6Gi}
+      - {name: cpu-training, value: "1"}
       - {name: memory-training, value: 6Gi}
       - {name: memory-offline-diags, value: 10Gi}
       - {name: training-flags, value: " "}
@@ -66,6 +67,8 @@ spec:
               value: "{{inputs.parameters.validation-data-config}}"
             - name: output
               value: "{{tasks.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
+            - name: cpu
+              value: "{{inputs.parameters.cpu-training}}"
             - name: memory
               value: "{{inputs.parameters.memory-training}}"
             - name: flags

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -20,6 +20,7 @@ spec:
           - name: training_data_config
           - name: validation_data_config
           - name: output
+          - {name: cpu, value: 1000m}
           - {name: memory, value: 6Gi}
           - {name: flags, value: " "}
       container:
@@ -72,8 +73,8 @@ spec:
           - name: main
             resources:
               limits:
-                cpu: "1000m"
+                cpu: "{{inputs.parameters.cpu}}"
                 memory: "{{inputs.parameters.memory}}"
               requests:
-                cpu: "1000m"
+                cpu: "{{inputs.parameters.cpu}}"
                 memory: "{{inputs.parameters.memory}}"


### PR DESCRIPTION
This allows training ML models with more than one cpu using kubernetes. In some cases this can greatly speed training.

Added public API:
- `cpu` parameter to `training` argo workflow
- `training-cpu` parameter to end-to-end argo workflow