### PR TITLE
Remove StackedBatches from random forest training

### DIFF
--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -42,6 +42,13 @@ def train_random_forest(
     train_batches: Sequence[xr.Dataset],
     validation_batches: Sequence[xr.Dataset],
 ):
+    """
+    Args:
+        hyperparameters: configuration for training
+        train_batches: batched data for training, must be stacked
+            with at most one non-sample dimension
+        validation_batches: ignored in this function
+    """
     model = RandomForest(
         hyperparameters.input_variables,
         hyperparameters.output_variables,

--- a/external/fv3fit/tests/_regtest_outputs/test_sklearn_wrapper.test_predict_is_deterministic.out
+++ b/external/fv3fit/tests/_regtest_outputs/test_sklearn_wrapper.test_predict_is_deterministic.out
@@ -1,1 +1,1 @@
-fe1edd06a4cdb3bbca2652fc980a4d65
+273a665be05e39e82dab9a7e42ae85d1

--- a/external/fv3fit/tests/test_pack.py
+++ b/external/fv3fit/tests/test_pack.py
@@ -57,6 +57,19 @@ def test_roundtrip(
         np.testing.assert_array_equal(unpacked[name].values, ds[name].values)
 
 
+def test_pack_2d_and_3d():
+    ds = xr.Dataset(
+        data_vars={
+            "surface": xr.DataArray(np.zeros([100]), dims=["sample"]),
+            "vertically_resolved": xr.DataArray(
+                np.zeros([100, 10]), dims=["sample", "z"]
+            ),
+        }
+    )
+    packed, _ = pack(data=ds, sample_dims=["sample"])
+    assert packed.shape == (100, 11)
+
+
 @pytest.mark.parametrize(
     "base_dims, base_shape, feature_dim, n_features",
     (

--- a/external/fv3fit/tests/test_sklearn_wrapper.py
+++ b/external/fv3fit/tests/test_sklearn_wrapper.py
@@ -187,12 +187,20 @@ def fit_wrapper_with_columnar_data():
         input_variables=["a"], output_variables=["b"], model=model,
     )
 
-    dims = ["x", "y", "z"]
-    shape = (2, 2, nz)
+    dims = ["sample", "z"]
+    shape = (4, nz)
     arr = np.arange(np.prod(shape)).reshape(shape)
     input_data = xr.Dataset({"a": (dims, arr), "b": (dims, arr + 1)})
     wrapper.fit([input_data])
     return input_data, wrapper
+
+
+def get_unstacked_data():
+    dims = ["x", "y", "z"]
+    shape = (2, 2, 2)
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    input_data = xr.Dataset({"a": (dims, arr), "b": (dims, arr + 1)})
+    return input_data
 
 
 def test_predict_is_deterministic(regtest):
@@ -207,8 +215,8 @@ def test_predict_is_deterministic(regtest):
 
 def test_predict_returns_unstacked_dims():
     # 2D output dims same as input dims
-    input_data, wrapper = fit_wrapper_with_columnar_data()
-    assert len(input_data.dims) > 2
+    _, wrapper = fit_wrapper_with_columnar_data()
+    input_data = get_unstacked_data()
     prediction = wrapper.predict(input_data)
     assert prediction.dims == input_data.dims
 
@@ -226,11 +234,11 @@ def test_SklearnWrapper_fit_predict_with_clipped_input_data():
         packer_config=PackerConfig({"a": {"z": SliceConfig(2, None)}}),
     )
 
-    dims = ["x", "y", "z"]
-    shape = (2, 2, nz)
+    dims = ["sample", "z"]
+    shape = (4, nz)
     arr = np.arange(np.prod(shape)).reshape(shape)
     input_data = xr.Dataset(
-        {"a": (dims, arr), "b": (dims[:-1], arr[:, :, 0]), "c": (dims, arr + 1)}
+        {"a": (dims, arr), "b": (dims[:-1], arr[:, 0]), "c": (dims, arr + 1)}
     )
     wrapper.fit([input_data])
     wrapper.predict(input_data)


### PR DESCRIPTION
This PR removes the use of StackedBatches from random forest training, requiring the user configure stacking in the input data configuration.

Refactored public API:
- When using "sklearn_random_forest" training, the user must supply a data configuration that provides pre-stacked batches. If the first input has more than 2 dimensions, they will get a ValueError explaining this limitation.

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
