### PR TITLE
Update integration test config to stack training data

### DIFF
--- a/tests/end_to_end_integration/.gitignore
+++ b/tests/end_to_end_integration/.gitignore
@@ -1,3 +1,4 @@
 config.yaml
 kustomization.yaml
 training-data-config-compiled.yaml
+test-data-config-compiled.yaml

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -379,6 +379,8 @@ spec:
             value: "--local-download-path train-data-download-dir"
           - name: validation-data-config
             value: "{{workflow.parameters.validation-data-config}}"
+          - name: test-data-config
+            value: "{{workflow.parameters.test-data-config}}"
           - name: prognostic-run-config
             value: "{{workflow.parameters.prognostic-run-config}}"
           - name: public-report-output

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -375,6 +375,8 @@ spec:
             value: "{{workflow.parameters.training-configs}}"
           - name: training-data-config
             value: "{{workflow.parameters.training-data-config}}"
+          - name: training-flags
+            value: "--local-download-path train-data-download-dir"
           - name: validation-data-config
             value: "{{workflow.parameters.validation-data-config}}"
           - name: prognostic-run-config

--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -92,10 +92,16 @@ yq -y --arg data_path $n2fDataPath '.mapper_config.kwargs.data_path|=$data_path'
     training-data-config.yaml > \
     training-data-config-compiled.yaml
 
+yq -y --arg data_path $n2fDataPath '.mapper_config.kwargs.data_path|=$data_path' \
+    test-data-config.yaml > \
+    test-data-config-compiled.yaml
+
+
 deployWorkflows "$registry" "$commit"
 argo submit argo.yaml -p bucket="${bucket}" -p project="${project}" \
     -p training-data-config="$(< training-data-config-compiled.yaml)" \
     -p validation-data-config="$(< training-data-config-compiled.yaml)" \
+    -p test-data-config="$(< test-data-config-compiled.yaml)" \
     -p tag="${tag}" --name "$name"
 
 trap "argo logs \"$name\" | tail -n 100" EXIT

--- a/tests/end_to_end_integration/test-data-config.yaml
+++ b/tests/end_to_end_integration/test-data-config.yaml
@@ -1,0 +1,18 @@
+mapper_config:
+  function: open_nudge_to_fine
+  kwargs:
+    data_path: placeholder
+    nudging_variables:
+      - air_temperature
+      - specific_humidity
+      - x_wind
+      - y_wind
+      - pressure_thickness_of_atmospheric_layer
+function: batches_from_mapper
+kwargs:
+  # note this differs from the training config in that
+  # there is no unstacked_dims arg here
+  timesteps_per_batch: 2
+  timesteps:
+    - "20160801.004500"
+    - "20160801.011500"

--- a/tests/end_to_end_integration/training-data-config.yaml
+++ b/tests/end_to_end_integration/training-data-config.yaml
@@ -10,6 +10,7 @@ mapper_config:
       - pressure_thickness_of_atmospheric_layer
 function: batches_from_mapper
 kwargs:
+  unstacked_dims: z
   timesteps_per_batch: 2
   timesteps:
     - "20160801.004500"

--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -20,7 +20,7 @@ spec:
           - name: ml-model
           - name: training_config
           - name: training_data_config
-          - name: validation_data_config
+          - name: test_data_config
           - name: offline-diags-output
           - name: report-output
           - {name: memory, value: 10Gi}
@@ -41,13 +41,13 @@ spec:
 
             gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 
-            cat << EOF > validation_data.yaml
-            {{inputs.parameters.validation_data_config}}
+            cat << EOF > test_data.yaml
+            {{inputs.parameters.test_data_config}}
             EOF
 
             python -m fv3net.diagnostics.offline.compute \
               {{inputs.parameters.ml-model}} \
-              validation_data.yaml \
+              test_data.yaml \
               {{inputs.parameters.offline-diags-output}}
 
             cat << EOF > training.yaml

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -21,7 +21,7 @@ spec:
       - name: tag
       - name: training-configs  # used in withParam
       - name: training-data-config
-      - {name: validation-data-config: value: " "}
+      - {name: validation-data-config, value: " "}
       - name: test-data-config
       - name: prognostic-run-config
       - name: flags

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -21,7 +21,8 @@ spec:
       - name: tag
       - name: training-configs  # used in withParam
       - name: training-data-config
-      - name: validation-data-config
+      - {name: validation-data-config: value: " "}
+      - name: test-data-config
       - name: prognostic-run-config
       - name: flags
         value: " "
@@ -87,8 +88,8 @@ spec:
                 value: "{{item.config}}"
               - name: training_data_config
                 value: "{{inputs.parameters.training-data-config}}"
-              - name: validation_data_config
-                value: "{{inputs.parameters.validation-data-config}}"
+              - name: test_data_config
+                value: "{{inputs.parameters.test-data-config}}"
               - name: offline-diags-output
                 value: "{{tasks.resolve-output-url.outputs.result}}/offline_diags/{{item.name}}"
               - name: report-output

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -18,7 +18,7 @@ spec:
         parameters:
           - name: training_config
           - name: training_data_config
-          - name: validation_data_config
+          - {name: validation_data_config, value: " "}
           - name: output
           - {name: cpu, value: 1000m}
           - {name: memory, value: 6Gi}
@@ -56,12 +56,18 @@ spec:
             echo "Validation Data Configuration:"
             cat validation_data.yaml
 
+            if grep -q '[^[:space:]]' "validation_data.yaml";
+            then
+                validation_arg="--validation-data-config validation_data.yaml"
+            else
+                validation_arg=" "
+            fi
+
             python3 -m fv3fit.train \
               training_config.yaml \
               training_data.yaml \
               {{inputs.parameters.output}} \
-              --validation-data-config \
-              validation_data.yaml \
+              $validation_arg \
               {{inputs.parameters.flags}}
       tolerations:
       - key: "dedicated"


### PR DESCRIPTION
The previous PR https://github.com/ai2cm/fv3net/pull/1655 changed the RF training to take in stacked data. The integration test config needs to be updated to stack the training data. It also needs to use a cache directory when training to avoid errors that occur when trying to stack data that is already stacked with a multi index. The latter issue will be resolved in the future when tf datasets are used in training.

Breaking change:
Since our current train-diags-prog argo workflow currently uses the same configuration file for validation during training and offline diags, there'd have to be a new distinction between the validation-config.yaml passed to the training workflow vs the test data config passed to the offline diags. 

This isn't that big of a deal as the using validation data in training can be optional, but it'd be a breaking change in the sense the parameter formerly known as validation-data-config would now be optional and only be used for training time validation, and a new parameter test-data-config would have to be provided for the offline diags.

If this is approved, I'll make those changes to vcm-workflow-control as well.