### PR TITLE
Add LRUCache option to n2f mapper

### DIFF
--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -125,7 +125,7 @@ def open_nudge_to_fine(
         "nudging_tendencies.zarr",
         "state_after_timestep.zarr",
     ),
-    cache_size_mb: float = None,
+    cache_size_mb: Optional[float] = None,
 ) -> XarrayMapper:
     """
     Load nudge-to-fine data mapper for use with training. Merges
@@ -218,17 +218,13 @@ def _get_datasets(
     url: str,
     sources: Sequence[str],
     consolidated: bool = True,
-    cache_size_mb: float = None,
+    cache_size_mb: Optional[float] = None,
 ) -> MutableMapping[Hashable, xr.Dataset]:
     datasets: MutableMapping[Hashable, xr.Dataset] = {}
     for source in sources:
+        mapper = fsspec.get_mapper(os.path.join(url, f"{source}"))
         if cache_size_mb is not None:
-            mapper = zarr.LRUStoreCache(
-                fsspec.get_mapper(os.path.join(url, f"{source}")),
-                max_size=int(cache_size_mb * 1e6),
-            )
-        else:
-            mapper = fsspec.get_mapper(os.path.join(url, f"{source}"))
+            mapper = zarr.LRUStoreCache(mapper, max_size=int(cache_size_mb * 1e6),)
         ds = xr.open_zarr(mapper, consolidated=consolidated)
         datasets[source] = ds
     return datasets

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -1,6 +1,5 @@
 import logging
 import xarray as xr
-import intake
 import os
 from typing import Hashable, Sequence, Mapping, Optional, Any, MutableMapping
 import fsspec
@@ -228,10 +227,8 @@ def _get_datasets(
                 fsspec.get_mapper(os.path.join(url, f"{source}")),
                 max_size=int(cache_size_mb * 1e6),
             )
-            ds = xr.open_zarr(mapper, consolidated=consolidated)
         else:
-            ds = intake.open_zarr(
-                os.path.join(url, f"{source}"), consolidated=consolidated
-            ).to_dask()
+            mapper = fsspec.get_mapper(os.path.join(url, f"{source}"))
+        ds = xr.open_zarr(mapper, consolidated=consolidated)
         datasets[source] = ds
     return datasets


### PR DESCRIPTION
This adds the option to use LRU caches when using the nudge to fine mapper. This may or may not speed up your usage of the mapper, depending on your chunking and the sequence in which you are accessing the various chunks. Testing this in a not-cache-size-limited case for opening 3 batches of 2 timesteps each in the same chunk, using the cache was about 40% faster than without and avoided repeated downloads.


Added public API:
- Optional arg `cache_size_mb` for `open_nudge_to_fine`, if provided will create a `zarr.storage.LRUCache` of this size for each zarr dataset that the mapper has to open. By default this is `None`, which reproduces the current behavior.
