### PR TITLE
Ordered subsample option for batches

### DIFF
--- a/external/loaders/loaders/_utils.py
+++ b/external/loaders/loaders/_utils.py
@@ -71,7 +71,6 @@ def stack(unstacked_dims: Sequence[str], ds: xr.Dataset) -> xr.Dataset:
     return ds_stacked.transpose(SAMPLE_DIM_NAME, *unstacked_dims)
 
 
-@curry
 def sort_by_time(ds: xr.Dataset) -> xr.Dataset:
     return ds.sortby("time")
 

--- a/external/loaders/loaders/_utils.py
+++ b/external/loaders/loaders/_utils.py
@@ -71,6 +71,18 @@ def stack(unstacked_dims: Sequence[str], ds: xr.Dataset) -> xr.Dataset:
     return ds_stacked.transpose(SAMPLE_DIM_NAME, *unstacked_dims)
 
 
+@curry
+def select_random_ordered_subset(fraction: float, ds: xr.Dataset) -> xr.Dataset:
+    if fraction == 1.0:
+        out = ds
+    else:
+        n_samples = len(ds[SAMPLE_DIM_NAME])
+        n_samples_keep = int(fraction * n_samples)
+        sample_indices = sorted(np.random.choice(n_samples, n_samples_keep))
+        out = ds.isel({SAMPLE_DIM_NAME: sample_indices})
+    return out
+
+
 def shuffle(ds: xr.Dataset) -> xr.Dataset:
     shuffled_indices = np.arange(len(ds[SAMPLE_DIM_NAME]), dtype=int)
     np.random.shuffle(shuffled_indices)

--- a/external/loaders/loaders/_utils.py
+++ b/external/loaders/loaders/_utils.py
@@ -72,13 +72,21 @@ def stack(unstacked_dims: Sequence[str], ds: xr.Dataset) -> xr.Dataset:
 
 
 @curry
-def select_random_ordered_subset(fraction: float, ds: xr.Dataset) -> xr.Dataset:
+def sort_by_time(ds: xr.Dataset) -> xr.Dataset:
+    return ds.sortby("time")
+
+
+@curry
+def select_fraction(fraction: float, ds: xr.Dataset) -> xr.Dataset:
+    # subselects a random fraction of samples, preserving original order.
     if fraction == 1.0:
         out = ds
     else:
         n_samples = len(ds[SAMPLE_DIM_NAME])
         n_samples_keep = int(fraction * n_samples)
-        sample_indices = sorted(np.random.choice(n_samples, n_samples_keep))
+        sample_indices = sorted(
+            np.random.choice(n_samples, n_samples_keep, replace=False)
+        )
         out = ds.isel({SAMPLE_DIM_NAME: sample_indices})
     return out
 
@@ -97,21 +105,6 @@ def dropna(ds: xr.Dataset) -> xr.Dataset:
     if len(ds[SAMPLE_DIM_NAME]) == 0:
         raise ValueError("Check for NaN fields in the training data.")
     return ds
-
-
-@curry
-def select_first_samples(fraction: float, ds: xr.Dataset) -> xr.Dataset:
-    """
-    Return a dataset with only the given fraction of samples from the
-    input dataset, taking the first samples.
-    """
-    if fraction == 1.0:
-        out = ds
-    else:
-        n_samples = len(ds[SAMPLE_DIM_NAME])
-        n_samples_keep = int(fraction * n_samples)
-        out = ds.isel({SAMPLE_DIM_NAME: slice(0, n_samples_keep)})
-    return out
 
 
 @curry

--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -199,7 +199,7 @@ def batches_from_mapper(
     batch_func = compose_left(*transforms)
 
     seq = Map(batch_func, batched_timesteps)
-    seq.attrs["times"] = timesteps
+    seq.attrs["times"] = shuffled_times
 
     if in_memory:
         out_seq: Batches = tuple(ds.load() for ds in seq)

--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -123,7 +123,7 @@ def batches_from_mapper(
     subsample_ratio: float = 1.0,
     drop_nans: bool = False,
     shuffle_timesteps: bool = True,
-    shuffle_samples: bool = True,
+    shuffle_samples: bool = False,
 ) -> loaders.typing.Batches:
     """ The function returns a sequence of datasets that is later
     iterated over in  ..sklearn.train.

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -286,3 +286,22 @@ def test_batches_from_netcdf(tmpdir):
     )
     for ds_saved, ds_loaded in zip(saved_batches, loaded_batches):
         xr.testing.assert_equal(ds_saved, ds_loaded)
+
+
+def test_batches_from_mapper_stacked_data_is_not_shuffled():
+    mapper = get_mapper(n_keys=10, n_vars=1, n_dims=3)
+    unstacked_dims = ["dim_2"]
+    result = batches_from_mapper(
+        mapper,
+        variable_names=["var_0"],
+        unstacked_dims=unstacked_dims,
+        timesteps_per_batch=10,
+        keep_ordered_samples=True,
+    )
+    assert len(result) == 1
+    batch = result[0]
+    multiindex = batch._fv3net_sample.values
+    sample_times = [sample[0] for sample in multiindex]
+    sample_dim1 = [sample[2] for sample in multiindex[:5]]
+    assert sample_times == sorted(sample_times)
+    assert sample_dim1 == sorted(sample_dim1)

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -296,6 +296,7 @@ def test_batches_from_mapper_stacked_data_is_not_shuffled():
         variable_names=["var_0"],
         unstacked_dims=unstacked_dims,
         timesteps_per_batch=10,
+        shuffle_timesteps=False,
         shuffle_samples=False,
     )
     assert len(result) == 1

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -200,6 +200,7 @@ def test_batches_from_mapper_stacked_data_is_shuffled():
         variable_names=["var_0"],
         unstacked_dims=unstacked_dims,
         timesteps_per_batch=10,
+        shuffle_samples=True,
     )
     assert len(result) == 1
     batch = result[0]

--- a/external/loaders/tests/test__batch.py
+++ b/external/loaders/tests/test__batch.py
@@ -296,7 +296,7 @@ def test_batches_from_mapper_stacked_data_is_not_shuffled():
         variable_names=["var_0"],
         unstacked_dims=unstacked_dims,
         timesteps_per_batch=10,
-        keep_ordered_samples=True,
+        shuffle_samples=False,
     )
     assert len(result) == 1
     batch = result[0]

--- a/external/loaders/tests/test__utils.py
+++ b/external/loaders/tests/test__utils.py
@@ -3,7 +3,7 @@ from loaders._utils import (
     nonderived_variables,
     shuffle,
     SAMPLE_DIM_NAME,
-    select_first_samples,
+    select_fraction,
 )
 import xarray as xr
 import numpy as np
@@ -50,9 +50,7 @@ def test_shuffle_retains_values():
         pytest.param(20, 0.75, 15, id="discard_some"),
     ],
 )
-def test_select_first_samples(
-    input_samples: int, fraction: float, expected_samples: int
-):
+def test_select_fraction(input_samples: int, fraction: float, expected_samples: int):
     ds = xr.Dataset(
         data_vars={
             "a": xr.DataArray(
@@ -61,7 +59,6 @@ def test_select_first_samples(
             )
         }
     )
-    result = select_first_samples(fraction)(ds)
+    result = select_fraction(fraction)(ds)
     assert len(result[SAMPLE_DIM_NAME]) == expected_samples
-    assert result["a"].values.max() == expected_samples - 1
-    assert result["a"].values.min() == 0
+    assert np.array_equal(sorted(result[SAMPLE_DIM_NAME]), result[SAMPLE_DIM_NAME])

--- a/external/loaders/tests/test__utils.py
+++ b/external/loaders/tests/test__utils.py
@@ -61,4 +61,5 @@ def test_select_fraction(input_samples: int, fraction: float, expected_samples: 
     )
     result = select_fraction(fraction)(ds)
     assert len(result[SAMPLE_DIM_NAME]) == expected_samples
+    assert len(np.unique(result[SAMPLE_DIM_NAME].values)) == expected_samples
     assert np.array_equal(sorted(result[SAMPLE_DIM_NAME]), result[SAMPLE_DIM_NAME])


### PR DESCRIPTION
Adds a `keep_ordered_samples` option to `batches_from_mapper` to not shuffle samples within stacked batches. This can speed up loading by a lot, depending on the number of timesteps per batch and the data chunking. 
ex. preprocessing about half the timesteps in the PIRE dataset took >3-4 hrs, with this option enabled and using the LRUCache option for `batches_from_mapper` it takes about 20-25 min.

Adds the `in_memory` option to `batches_from_netcdf`. Existing copies of each batch aren't getting garbage collected after use, so memory usage builds up and eventually crashes during training. The future usage of tf dataset may fix this. In the meantime since I believe the preprocessed data should fit in memory, we can use this to speed up training and prevent OOM'ing.

(Delete unused sections)
Added public API:
- `keep_ordered_samples` option in `batches_from_mapper`. Defaults to False.
- `in_memory` option for `batches_from_netcdf`. Defaults to False.


Internal change:
- Deleted the `select_first_samples` function and replaced it with `select_fraction` so it could be used for either case of samples being shuffled/ not shuffled. `select_fraction` returns a random subset that can be drawn from the entire dataset, but keeps its original order.

- [x] Tests added
