### PR TITLE
Fix backwards names to remove intermediate variable

### DIFF
--- a/external/fv3fit/fv3fit/emulation/transforms/factories.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/factories.py
@@ -99,10 +99,12 @@ class ConditionallyScaled(TransformFactory):
 
     def backward_names(self, requested_names: Set[str]) -> Set[str]:
         """List the names needed to compute ``self.to``"""
-        new_names = (
-            {self.condition_on, self.source} if self.to in requested_names else set()
-        )
-        return requested_names.union(new_names)
+
+        if self.to in requested_names:
+            dependencies = {self.condition_on, self.source}
+            requested_names = (requested_names - {self.to}) | dependencies
+
+        return requested_names
 
     def build(self, sample: TensorDict) -> ConditionallyScaledTransform:
 

--- a/external/fv3fit/fv3fit/emulation/transforms/transforms.py
+++ b/external/fv3fit/fv3fit/emulation/transforms/transforms.py
@@ -32,8 +32,11 @@ class Difference(TensorTransform):
     after: str
 
     def backward_names(self, requested_names: Set[str]) -> Set[str]:
-        new_names = {self.before, self.after} if self.to in requested_names else set()
-        return requested_names.union(new_names)
+
+        if self.to in requested_names:
+            requested_names = (requested_names - {self.to}) | {self.before, self.after}
+
+        return requested_names
 
     def build(self, sample: TensorDict) -> TensorTransform:
         return self

--- a/external/fv3fit/tests/emulation/test_transform.py
+++ b/external/fv3fit/tests/emulation/test_transform.py
@@ -210,7 +210,7 @@ def test_ConditionallyScaledTransform_backward(min_scale: float):
 
 def test_ConditionallyScaled_backward_names():
     factory = ConditionallyScaled(source="in", to="z", bins=10, condition_on="T")
-    assert factory.backward_names({"z"}) == {"z", "T", "in"}
+    assert factory.backward_names({"z"}) == {"T", "in"}
 
 
 def test_ConditionallyScaled_backward_names_output_not_in_request():
@@ -238,7 +238,7 @@ def test_ConditionallyScaled_build():
 
 def test_Difference_backward_names():
     diff = Difference("diff", "before", "after")
-    assert diff.backward_names({"diff"}) == {"before", "after", "diff"}
+    assert diff.backward_names({"diff"}) == {"before", "after"}
     assert diff.backward_names({"not in a"}) == {"not in a"}
 
 


### PR DESCRIPTION
Some updates to the transform dependency tracking included intermediate variables in the output.  This PR reverts that behavior so we are correctly requesting the basic set of variables to fulfill all the specified transforms.

resolves #1658