### PR TITLE
fv3fit training: use data config's `in_memory` for cached data

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -52,6 +52,12 @@ def get_keras_model(name):
 
 
 @dataclasses.dataclass
+class CacheConfig:
+    local_download_path: Optional[str] = None
+    in_memory: bool = False
+
+
+@dataclasses.dataclass
 class TrainingConfig:
     """Convenience wrapper for model training parameters and file info
 
@@ -71,6 +77,7 @@ class TrainingConfig:
     sample_dim_name: str = "sample"
     random_seed: Union[float, int] = 0
     derived_output_variables: List[str] = dataclasses.field(default_factory=list)
+    cache: CacheConfig = dataclasses.field(default_factory=lambda: CacheConfig())
 
     @property
     def variables(self):

--- a/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
@@ -6,7 +6,7 @@ import numpy as np
 from .sequences import ThreadedSequencePreLoader
 from loaders.batches import shuffle
 import logging
-
+import gc
 
 logger = logging.getLogger(__name__)
 
@@ -74,5 +74,8 @@ class TrainingLoopConfig:
                         batch_size=self.batch_size,
                     )
                 )
+            # for some reason, garbage collection was not happening automatically, and
+            # training on large datasets would OOM after multiple epochs.
+            gc.collect()
             for callback in callbacks:
                 callback(EpochResult(epoch=i_epoch, history=tuple(history)))

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -57,6 +57,19 @@ def get_data(
     variable_names: Sequence[str],
     in_memory: bool = False,
 ) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
+    """
+    Args:
+        training_data_config: configuration of training data
+        validation_data_config:  if provided, configuration of validation data. If None,
+            an empty list will be returned for validation data.
+        local_download_path: if provided, cache data locally at this path
+        variable_names: names of variables to include when loading data
+        in_memory: if True and local_download_path is also set, batches will be
+            returned as a tuple of eagerly-loaded Datasets. Has no effect if
+            local_download_path is not set.
+    Returns:
+        Training and validation data batches
+    """
     if local_download_path is None:
         return get_uncached_data(
             training_data_config=training_data_config,

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -61,6 +61,7 @@ def get_data(
     validation_data_config: Optional[str],
     local_download_path: Optional[str],
     variable_names: Sequence[str],
+    in_memory: bool = False,
 ) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
     if local_download_path is None:
         return get_uncached_data(
@@ -74,6 +75,7 @@ def get_data(
             validation_data_config=validation_data_config,
             local_download_path=local_download_path,
             variable_names=variable_names,
+            in_memory=in_memory,
         )
 
 
@@ -103,6 +105,7 @@ def get_cached_data(
     validation_data_config: Optional[str],
     local_download_path: str,
     variable_names: Sequence[str],
+    in_memory: bool,
 ) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
     train_data_path = os.path.join(local_download_path, "train_data")
     logger.info("saving training data to %s", train_data_path)
@@ -113,7 +116,7 @@ def get_cached_data(
         variable_names=variable_names,
     )
     train_batches = loaders.batches_from_netcdf(
-        path=train_data_path, variable_names=variable_names
+        path=train_data_path, variable_names=variable_names, in_memory=in_memory
     )
     if validation_data_config is not None:
         validation_data_path = os.path.join(local_download_path, "validation_data")
@@ -125,7 +128,9 @@ def get_cached_data(
             variable_names=variable_names,
         )
         val_batches = loaders.batches_from_netcdf(
-            path=validation_data_path, variable_names=variable_names
+            path=validation_data_path,
+            variable_names=variable_names,
+            in_memory=in_memory,
         )
     else:
         val_batches = []
@@ -156,6 +161,7 @@ def main(args, unknown_args=None):
         args.validation_data_config,
         args.local_download_path,
         variable_names=training_config.variables,
+        in_memory=training_data_config.kwargs.get("in_memory", False),
     )
 
     train = fv3fit.get_training_function(training_config.model_type)

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -42,12 +42,6 @@ def get_parser():
             "by default an empty sequence is used"
         ),
     )
-    parser.add_argument(
-        "--local-download-path",
-        type=str,
-        default=None,
-        help=("path for downloading data before training"),
-    )
     return parser
 
 
@@ -160,9 +154,9 @@ def main(args, unknown_args=None):
     train_batches, val_batches = get_data(
         args.training_data_config,
         args.validation_data_config,
-        args.local_download_path,
+        training_config.cache.local_download_path,
         variable_names=training_config.variables,
-        in_memory=training_data_config.kwargs.get("in_memory", False),
+        in_memory=training_config.cache.in_memory,
     )
 
     train = fv3fit.get_training_function(training_config.model_type)

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -109,6 +109,7 @@ def get_cached_data(
 ) -> Tuple[loaders.typing.Batches, loaders.typing.Batches]:
     train_data_path = os.path.join(local_download_path, "train_data")
     logger.info("saving training data to %s", train_data_path)
+    logger.info(f"using in_memory={in_memory} for cached training data")
     os.makedirs(train_data_path, exist_ok=True)
     save_main(
         data_config=training_data_config,

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -379,7 +379,7 @@ def cli_main(args: MainArgs):
     if args.local_download_path is None:
         local_download_args = []
     else:
-        local_download_args = ["--cache.local_download_path, args.local_download_path"]
+        local_download_args = ["--cache.local_download_path", args.local_download_path]
     subprocess.check_call(
         [
             "python",

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -379,7 +379,7 @@ def cli_main(args: MainArgs):
     if args.local_download_path is None:
         local_download_args = []
     else:
-        local_download_args = ["--local-download-path", args.local_download_path]
+        local_download_args = ["--cache.local_download_path, args.local_download_path"]
     subprocess.check_call(
         [
             "python",

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -132,11 +132,16 @@ def call_main(
         unstacked_dims=["z"],
     )
     mock_load_batches.return_value = [config.mock_dataset for _ in range(6)]
+    if use_local_download_path is True:
+        local_download_path_arg = [
+            "--cache.local_download_path",
+            config.args.local_download_path,
+        ]
     with mock.patch("fv3fit.DerivedModel") as MockDerivedModel:
         MockDerivedModel.return_value = mock.MagicMock(
             name="derived_model_return", spec=fv3fit.Predictor
         )
-        fv3fit.train.main(config.args)
+        fv3fit.train.main(config.args, unknown_args=local_download_path_arg)
     return CallArtifacts(
         config.output_path, config.variables, MockDerivedModel, config.hyperparameters,
     )

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -137,6 +137,8 @@ def call_main(
             "--cache.local_download_path",
             config.args.local_download_path,
         ]
+    else:
+        local_download_path_arg = []
     with mock.patch("fv3fit.DerivedModel") as MockDerivedModel:
         MockDerivedModel.return_value = mock.MagicMock(
             name="derived_model_return", spec=fv3fit.Predictor


### PR DESCRIPTION
~The last PR that added an `in_memory` arg to the batches from netcdf loader to address a memory usage issue in training, in which garbage collection does not delete existing batches when reopening the netcdfs.~ Edit- this was not the cause of the memory issue, see below comment about garbage collection.

However, the value of this arg in the config didn't actually get passed to the call to `batches_from_netcdf` within `get_cached_data`. This PR adds a config field `cache` to the `TrainingConfig`, ex.
```
cache:
    in_memory: True
    local_download_path: some_dir
```
**Breaking change**: The command line arg `--local-download-path` is removed, and the training config field `cache.local_download_path` is used instead to provide this information. It can still be provided via the command line, e.g. `--cache.local_download_path your_download_dir`. I will update the vcm-workflow-config repo to reflect this.



It turned out that even with the data loaded into memory, jobs would crash with OOM errors multiple epochs into the training with memory usage accumulating steadily. (ignore the "used" value, the cursor is hovering over a time range outside the training job)
![image](https://user-images.githubusercontent.com/16710132/156272233-e41235b7-6175-44fa-8b72-f0ac915296f4.png)


I don't know why the garbage collection was not freeing up memory in the training loop, but when I added a call to `gc.collect()` at the end of each epoch in the training loop the memory usage remains constant over epochs.
![image](https://user-images.githubusercontent.com/16710132/156272309-cc2b9422-f506-49b2-a4ac-0e20f99eea93.png)
