### PR TITLE
add duration_seconds wandb metric for prognostic runs

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -146,6 +146,15 @@ def open_segmented_logs(url: str) -> vcm.fv3.logs.FV3Log:
     return vcm.fv3.logs.concatenate(logs)
 
 
+def open_segmented_logs_as_strings(url: str) -> List[str]:
+    """Open the logs from each segment of a segmented run as strings
+    """
+    fs = vcm.get_fs(url)
+    logfiles = sorted(fs.glob(f"{url}/**/logs.txt"))
+    logs = [fs.cat(url).decode() for url in logfiles]
+    return logs
+
+
 class Simulation(Protocol):
     @property
     def data_2d(self) -> xr.Dataset:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/logs.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/logs.py
@@ -1,0 +1,17 @@
+from typing import List
+import re
+import json
+import datetime
+
+
+def parse_duration(logs: List[str]) -> datetime.timedelta:
+    log = "".join(logs)
+    profile_info = re.findall(r"INFO:profiles:(.*)", log)
+    profile_json = [json.loads(s) for s in profile_info]
+    profile_time = sorted(
+        set([datetime.datetime.fromisoformat(data["time"]) for data in profile_json])
+    )
+    last_time = profile_time[-1]
+    initial_time = profile_time[0] - (profile_time[1] - profile_time[0])
+    duration = last_time - initial_time
+    return duration

--- a/workflows/diagnostics/tests/prognostic/rundir/artifacts/20200101.000000/logs.txt
+++ b/workflows/diagnostics/tests/prognostic/rundir/artifacts/20200101.000000/logs.txt
@@ -1,0 +1,1 @@
+some text

--- a/workflows/diagnostics/tests/prognostic/test_load_diag_data.py
+++ b/workflows/diagnostics/tests/prognostic/test_load_diag_data.py
@@ -1,3 +1,4 @@
+import pathlib
 import cftime
 import pytest
 import xarray as xr
@@ -97,3 +98,8 @@ def test_Simulations(regtest, simulation):
     with regtest:
         simulation.data_3d.info()
         simulation.data_2d.info()
+
+
+def test_open_segmented_logs_as_strings():
+    path = pathlib.Path(__file__).parent / "rundir"
+    assert 1 == len(load_diags.open_segmented_logs_as_strings(path.as_posix()))

--- a/workflows/diagnostics/tests/prognostic/test_logs.py
+++ b/workflows/diagnostics/tests/prognostic/test_logs.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+from fv3net.diagnostics.prognostic_run.logs import parse_duration
+
+
+def test_parse_duration():
+    logs = [
+        """
+INFO:profiles:{"time": "2016-06-20T00:15:00"}
+DEBUG:runtime.loop:Dynamics Step
+DEBUG:runtime.loop:Applying prephysics state updates for: []
+DEBUG:runtime.loop:Physics Step (compute)
+INFO:profiles:{"time": "2016-06-20T00:30:00"}
+INFO:profiles:{"time": "2016-06-20T00:45:00"}
+DEBUG:runtime.loop:Dynamics Step
+DEBUG:runtime.loop:Applying prephysics state updates for: []
+        """
+    ]
+    assert timedelta(minutes=45) == parse_duration(logs)


### PR DESCRIPTION
This is the most important scalar metric we evaluate, but we didn't have it in wandb yet.

See this example: https://wandb.ai/ai2cm/microphysics-emulation/runs/3ar6kqen/overview?workspace=user-nbrenowitz