### PR TITLE
Increase default run length to 30 days

### DIFF
--- a/projects/microphysics/argo/prog-run-and-eval.yaml
+++ b/projects/microphysics/argo/prog-run-and-eval.yaml
@@ -11,7 +11,6 @@ spec:
     parameters:
       - name: tag
       - name: config
-      - name: tf_model
       - name: image_tag
         value: 811d4a88b8b8f29d727f2d61f46f96b770c8ab47
   volumes:
@@ -30,8 +29,6 @@ spec:
               value: "{{workflow.parameters.tag}}-offline"
             - name: config
               value:  "{{workflow.parameters.config}}"
-            - name: tf_model
-              value: "{{workflow.parameters.tf_model}}"
             - name: on_off_flag
               value: --offline
         - name: run-online
@@ -42,8 +39,6 @@ spec:
               value: "{{workflow.parameters.tag}}-online"
             - name: config
               value:  "{{workflow.parameters.config}}"
-            - name: tf_model
-              value: "{{workflow.parameters.tf_model}}"
             - name: on_off_flag
               value: --online
         - name: piggy-online
@@ -74,7 +69,6 @@ spec:
       parameters:
       - name: tag
       - name: config
-      - name: tf_model
       - name: on_off_flag
     tolerations:
     - key: "dedicated"
@@ -110,7 +104,6 @@ spec:
         python3 scripts/prognostic_run.py \
           --tag "{{inputs.parameters.tag}}" \
           --config-path fv3config.yaml \
-          --model "{{inputs.parameters.tf_model}}" \
           "{{inputs.parameters.on_off_flag}}"
   - name: piggyback-diags
     inputs:

--- a/projects/microphysics/argo/prog-run-and-eval.yaml
+++ b/projects/microphysics/argo/prog-run-and-eval.yaml
@@ -81,10 +81,10 @@ spec:
       workingDir: "/fv3net/projects/microphysics"
       resources:
         requests:
-          memory: "6Gi"
+          memory: "16Gi"
           cpu: "7500m"
         limits:
-          memory: "8Gi"
+          memory: "16Gi"
           cpu: "7500m"
       envFrom:
       - secretRef:

--- a/projects/microphysics/argo/run
+++ b/projects/microphysics/argo/run
@@ -12,4 +12,4 @@ argo submit prog-run-and-eval.yaml \
     --name "$tag" \
     -p image_tag="$image" \
     -p tag=$tag \
-    -p config=$(base64 --wrap 0 config.yaml) | tee -a submitted-jobs.txt
+    -p config=$(base64 --wrap 0 config.yaml) | grep -v 'config:' | tee -a submitted-jobs.txt

--- a/projects/microphysics/argo/run
+++ b/projects/microphysics/argo/run
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+url=gs://vcm-ml-experiments/microphysics-emulation/2022-01-27/rnn-gscond-cloudtdep-cbfc4a/model.tf
+tag=rnn-gscond-cloudtdep-cbfc4a-30d-v1
+image=latest
+
+yq  --arg url "$url" '.zhao_carr_emulation.model.path |= $url' ../configs/default.yaml > config.yaml
+trap 'rm config.yaml' EXIT
+
+
+argo submit prog-run-and-eval.yaml \
+    --name "$tag" \
+    -p image_tag="$image" \
+    -p tag=$tag \
+    -p config=$(base64 --wrap 0 config.yaml) | tee -a submitted-jobs.txt

--- a/projects/microphysics/argo/run_gscond_only
+++ b/projects/microphysics/argo/run_gscond_only
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-url=gs://vcm-ml-experiments/microphysics-emulation/2022-02-22/2ngq1xkl/model.tf
-tag=gscond-only-pressure-in-f88c1b-30d-v1
+url=gs://vcm-ml-experiments/microphysics-emulation/2022-01-27/rnn-gscond-cloudtdep-cbfc4a/model.tf
+tag=rnn-gscond-cloudtdep-cbfc4a-30d-gscond-only
 image=latest
 
 yq  --arg url "$url" '.zhao_carr_emulation.gscond.path |= $url' ../configs/default.yaml > config.yaml

--- a/projects/microphysics/argo/run_gscond_only
+++ b/projects/microphysics/argo/run_gscond_only
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+url=gs://vcm-ml-experiments/microphysics-emulation/2022-02-22/2ngq1xkl/model.tf
+tag=gscond-only-pressure-in-f88c1b-30d
+image=latest
+
+yq  --arg url "$url" '.zhao_carr_emulation.gscond.path |= $url' ../configs/default.yaml > config.yaml
+trap 'rm config.yaml' EXIT
+
+
+argo submit prog-run-and-eval.yaml \
+    --name "$tag" \
+    -p image_tag="$image" \
+    -p tag=$tag \
+    -p config=$(base64 --wrap 0 config.yaml) | tee -a submitted-jobs.txt

--- a/projects/microphysics/argo/run_gscond_only
+++ b/projects/microphysics/argo/run_gscond_only
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-url=gs://vcm-ml-experiments/microphysics-emulation/2022-01-27/rnn-gscond-cloudtdep-cbfc4a/model.tf
-tag=rnn-gscond-cloudtdep-cbfc4a-30d-gscond-only
+url=gs://vcm-ml-experiments/microphysics-emulation/2022-02-22/2ngq1xkl/model.tf
+tag=gscond-only-pressure-in-f88c1b-30d-v2
 image=latest
 
-yq  --arg url "$url" '.zhao_carr_emulation.gscond.path |= $url' ../configs/default.yaml > config.yaml
+yq  --arg url "$url" '
+.zhao_carr_emulation.gscond.path = $url
+| .namelist.gfs_physics_nml.emulate_gscond_only = true
+' ../configs/default.yaml  > config.yaml
 trap 'rm config.yaml' EXIT
-
 
 argo submit prog-run-and-eval.yaml \
     --name "$tag" \

--- a/projects/microphysics/argo/run_gscond_only
+++ b/projects/microphysics/argo/run_gscond_only
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 url=gs://vcm-ml-experiments/microphysics-emulation/2022-02-22/2ngq1xkl/model.tf
-tag=gscond-only-pressure-in-f88c1b-30d
+tag=gscond-only-pressure-in-f88c1b-30d-v1
 image=latest
 
 yq  --arg url "$url" '.zhao_carr_emulation.gscond.path |= $url' ../configs/default.yaml > config.yaml
@@ -12,4 +12,4 @@ argo submit prog-run-and-eval.yaml \
     --name "$tag" \
     -p image_tag="$image" \
     -p tag=$tag \
-    -p config=$(base64 --wrap 0 config.yaml) | tee -a submitted-jobs.txt
+    -p config=$(base64 --wrap 0 config.yaml) | grep -v 'config:' | tee -a submitted-jobs.txt

--- a/projects/microphysics/configs/default.yaml
+++ b/projects/microphysics/configs/default.yaml
@@ -1,6 +1,6 @@
 base_version: v0.5
 data_table: default
-duration: "10d"
+duration: "30d"
 initial_conditions: "gs://vcm-ml-experiments/online-emulator/2021-08-09/gfs-initialized-baseline-06/fv3gfs_run/artifacts/20160601.000000/RESTART"
 fortran_diagnostics:
 - name: piggy.zarr


### PR DESCRIPTION
Some of our configurations complete the 10 day simulations, so we need an upper
bound on how long they run.

* add scripts for convenient running ./run and ./run_gscond_only
* remove tf-model argo parameter in favor of yq modification of config
* Submit argo jobs
