### PR TITLE
Integration test: fix cache download arg

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -376,7 +376,7 @@ spec:
           - name: training-data-config
             value: "{{workflow.parameters.training-data-config}}"
           - name: training-flags
-            value: "--local-download-path train-data-download-dir"
+            value: "--cache.local_download_path train-data-download-dir"
           - name: validation-data-config
             value: "{{workflow.parameters.validation-data-config}}"
           - name: test-data-config


### PR DESCRIPTION
I forgot to update this arg in the last PR, which removed the `--local-download-path` training command line arg (it is now set in `TrainingConfig.cache.local_download_path`).

