### PR TITLE
loaders: delete unnecessary `batches_from_geodata`, `diagnostic_batches_from_geodata`

### DIFF
--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -101,7 +101,9 @@ def mock_train_dense_model():
 @pytest.fixture
 def mock_load_batches():
     magic_load_mock = mock.MagicMock(name="load_batches")
-    with mock.patch.object(loaders.BatchesConfig, "load_batches", magic_load_mock):
+    with mock.patch.object(
+        loaders.BatchesFromMapperConfig, "load_batches", magic_load_mock
+    ):
         yield magic_load_mock
 
 

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -283,31 +283,29 @@ def get_config(
     data_path = os.path.join(base_dir, "data")
     mock_dataset.to_zarr(data_path, consolidated=True)
     train_data_config = loaders.BatchesConfig(
-        function="batches_from_geodata",
+        function="batches_from_mapper",
         kwargs=dict(
-            data_path=data_path,
             variable_names=all_variables,
-            mapping_function="open_zarr",
             timesteps=train_times,
             needs_grid=False,
             res="c8_random_values",
             timesteps_per_batch=3,
             unstacked_dims=unstacked_dims,
         ),
+        mapper_config=dict(function="open_zarr", kwargs=dict(data_path=data_path)),
     )
     if use_validation_data:
         validation_data_config = loaders.BatchesConfig(
-            function="batches_from_geodata",
+            function="batches_from_mapper",
             kwargs=dict(
-                data_path=data_path,
                 variable_names=all_variables,
-                mapping_function="open_zarr",
                 timesteps=validation_times,
                 needs_grid=False,
                 res="c8_random_values",
                 timesteps_per_batch=3,
                 unstacked_dims=unstacked_dims,
             ),
+            mapper_config=dict(function="open_zarr", kwargs=dict(data_path=data_path)),
         )
         validation_data_filename = os.path.join(base_dir, "validation_data.yaml")
         with open(validation_data_filename, "w") as f:

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -282,7 +282,7 @@ def get_config(
     # instead of reading from disk, for CLI tests where we can't mock
     data_path = os.path.join(base_dir, "data")
     mock_dataset.to_zarr(data_path, consolidated=True)
-    train_data_config = loaders.BatchesConfig(
+    train_data_config = loaders.BatchesFromMapperConfig(
         function="batches_from_mapper",
         kwargs=dict(
             variable_names=all_variables,
@@ -295,7 +295,7 @@ def get_config(
         mapper_config=dict(function="open_zarr", kwargs=dict(data_path=data_path)),
     )
     if use_validation_data:
-        validation_data_config = loaders.BatchesConfig(
+        validation_data_config = loaders.BatchesFromMapperConfig(
             function="batches_from_mapper",
             kwargs=dict(
                 variable_names=all_variables,

--- a/external/loaders/loaders/__init__.py
+++ b/external/loaders/loaders/__init__.py
@@ -19,11 +19,9 @@ from ._config import (
     batches_from_mapper_functions,
 )
 from loaders.batches import (
-    batches_from_geodata,
     batches_from_mapper,
     batches_from_netcdf,
     batches_from_serialized,
-    diagnostic_batches_from_geodata,
 )
 from loaders.mappers import (
     open_nudge_to_fine,

--- a/external/loaders/loaders/batches/__init__.py
+++ b/external/loaders/loaders/batches/__init__.py
@@ -1,9 +1,7 @@
 from ._batch import (
-    batches_from_geodata,
     batches_from_mapper,
     batches_from_netcdf,
     batches_from_serialized,
-    diagnostic_batches_from_geodata,
 )
 
 from ._sequences import BaseSequence, Local, Take, shuffle

--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -6,7 +6,6 @@ from typing import (
     Iterable,
     Sequence,
     Mapping,
-    Any,
     Optional,
     Union,
 )
@@ -38,13 +37,6 @@ import vcm
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def _create_mapper(
-    data_path, mapping_func_name: str, mapping_kwargs: Mapping[str, Any]
-) -> Mapping[str, xr.Dataset]:
-    mapping_func = getattr(loaders.mappers, mapping_func_name)
-    return mapping_func(data_path, **mapping_kwargs)
 
 
 @batches_from_mapper_functions.register

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -227,12 +227,30 @@ def test_batches_loader_from_dict(data, expected_class):
     assert type(result) is expected_class
 
 
-def test_safe_dump_data_config():
+def test_safe_dump_BatchesFromMapperConfig():
+    """
+    Test that dataclass.asdict and pyyaml can be used to save BatchesFromMapperConfig.
+    """
+    config = loaders.BatchesFromMapperConfig(
+        function="batches_from_mapper",
+        kwargs={"timesteps": ["1", "2", "3"]},
+        mapper_config={},
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "config.yaml")
+        with open(filename, "w") as f:
+            as_dict = dataclasses.asdict(config)
+            yaml.safe_dump(as_dict, f)
+        from_dict = loaders.BatchesFromMapperConfig(**as_dict)
+        assert config == from_dict
+
+
+def test_safe_dump_BatchesConfig():
     """
     Test that dataclass.asdict and pyyaml can be used to save BatchesConfig.
     """
     config = loaders.BatchesConfig(
-        function="batches_from_mapper", kwargs={"timesteps": ["1", "2", "2"]},
+        function="batches_from_netcdf", kwargs={"path": "abc"},
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "config.yaml")

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -220,6 +220,11 @@ def test_load_batches_from_mapper_raises_if_registered_with_wrong_decorator():
             loaders._config.BatchesFromMapperConfig,
             id="batches_from_mapper_config",
         ),
+        pytest.param(
+            {"function": "batches_from_netcdf", "kwargs": {"path": "mock/data/path"}},
+            loaders._config.BatchesConfig,
+            id="batches_config",
+        ),
     ],
 )
 def test_batches_loader_from_dict(data, expected_class):

--- a/external/loaders/tests/test__config.py
+++ b/external/loaders/tests/test__config.py
@@ -78,9 +78,7 @@ def test_expected_batches_functions_exist():
     # currently use in configs, if you are deleting an option we no longer use
     # you can delete it here
     expected_functions = (
-        "batches_from_geodata",
         "batches_from_serialized",
-        "diagnostic_batches_from_geodata",
         "batches_from_netcdf",
     )
     for expected in expected_functions:
@@ -212,14 +210,6 @@ def test_load_batches_from_mapper_raises_if_registered_with_wrong_decorator():
     [
         pytest.param(
             {
-                "function": "batches_from_geodata",
-                "kwargs": {"data_path": "mock/data/path"},
-            },
-            loaders._config.BatchesConfig,
-            id="batches_config",
-        ),
-        pytest.param(
-            {
                 "mapper_config": {
                     "function": "open_zarr",
                     "kwargs": {"data_path": "mock/data/path"},
@@ -242,8 +232,7 @@ def test_safe_dump_data_config():
     Test that dataclass.asdict and pyyaml can be used to save BatchesConfig.
     """
     config = loaders.BatchesConfig(
-        function="batches_from_geodata",
-        kwargs={"data_path": "/my/path", "key": "value"},
+        function="batches_from_mapper", kwargs={"timesteps": ["1", "2", "2"]},
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "config.yaml")

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -245,9 +245,6 @@ def _get_predict_function(predictor, variables, grid):
 def _get_data_mapper_if_exists(config):
     if isinstance(config, loaders.BatchesFromMapperConfig):
         return config.load_mapper()
-    elif isinstance(config, loaders.BatchesConfig):
-        if config.kwargs.get("mapping_function") == "open_zarr":
-            return loaders.open_zarr(config.kwargs.get("data_path"))
     else:
         return None
 


### PR DESCRIPTION
See issue https://github.com/ai2cm/fv3net/issues/1430

`loaders._batches` is cluttered with a lot of code for functions that we no longer use (`batches_from_geodata, diagnostic_batches_from_geodata`). This PR removes them. These were originally written because `batches_from_mapper` only returned stacked data, and the offline diagnostics used unstacked data. This is no longer the case since the `unstacked_dims` arg for `batches_from_mapper` allows the data to be either stacked or unstacked. 

Potential breaking change: There may still be some usages around of `batches_from_geodata` where the `open_zarr` function is used. However, `batches_from_mapper` can also open zarr data using `open_zarr`, so these data configurations can easily be edited to use `batches_from_mapper` instead.


