### PR TITLE
`train.py`: CLI can update any TrainingConfig field

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -230,6 +230,17 @@ def to_nested_dict(d: dict):
     return new_config
 
 
+# Small modification to the arg parser so that the error raised by
+# providing invalid args is clearer.
+class ArgumentError(Exception):
+    pass
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ArgumentError(message)
+
+
 def get_arg_updated_config_dict(args: Sequence[str], config_dict: Dict[str, Any]):
     """
     Update a configuration dictionary with keyword arguments through an ArgParser.
@@ -242,15 +253,16 @@ def get_arg_updated_config_dict(args: Sequence[str], config_dict: Dict[str, Any]
         args: a list of argument strings to parse
         config_dict: the configuration to update
     """
-
     config = _to_flat_dict(config_dict)
-    parser = argparse.ArgumentParser()
+    parser = ArgumentParser()
     _add_items_to_parser_arguments(config, parser)
-    updates = parser.parse_args(args)
+    try:
+        updates = parser.parse_args(args)
+    except ArgumentError as e:
+        raise e
+
     update_dict = vars(updates)
-
     config.update(update_dict)
-
     return to_nested_dict(config)
 
 

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -231,7 +231,8 @@ def to_nested_dict(d: dict):
 
 
 # Small modification to the arg parser so that the error raised by
-# providing invalid args is clearer.
+# providing invalid args is clearer and does not print a confusing
+# system exit error.
 class ArgumentError(Exception):
     pass
 

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -149,6 +149,11 @@ def main(args, unknown_args=None):
     with open(args.training_config, "r") as f:
         config_dict = yaml.safe_load(f)
         if unknown_args is not None:
+            # converting to TrainingConfig and then back to dict allows command line to
+            # update fields that are not present in original configuration file
+            config_dict = dataclasses.asdict(
+                fv3fit.TrainingConfig.from_dict(config_dict)
+            )
             config_dict = get_arg_updated_config_dict(
                 args=unknown_args, config_dict=config_dict
             )


### PR DESCRIPTION
Previously, the CLI interface for updating the training configuration could only update args that already existing in the configuration, i.e. fields that were not specified in the config could not be changed from their default values. It would be convenient though to be able to do so. This PR allows `TrainingConfig` entries to be updated through the CLI even if they are not in the original file.

This should also fix the currently failing integration test, as it is failing because it tries to set `TrainingConfig.cache.local_download_path` through the CLI but that field is not in the config file.