### PR TITLE
Fix prognostic run docker-compose build

### DIFF
--- a/workflows/prognostic_c48_run/docker-compose.yml
+++ b/workflows/prognostic_c48_run/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       dockerfile: "docker/prognostic_run/Dockerfile"
       target: bld
       args:
-        # the tag doesn't matter since we bind-mount over these sources anyways
-        FORTRAN_IMAGE: us.gcr.io/vcm-ml/fv3gfs-fortran-fv3net:409d6cb28057dc6b700b3b009855710899194e71
+        BASE_IMAGE: ubuntu:20.04
     image: us.gcr.io/vcm-ml/prognostic_run
     entrypoint: []
     command: [ls]


### PR DESCRIPTION
Since #1572, calling `make build` within `workflows/prognostic_c48_run` results in an error because the `BASE_IMAGE` arg is not defined. This PR defines the `BASE_IMAGE` as `ubuntu:20.04` in the `docker-compose.yaml`.