### PR TITLE
improve piggy-back diags

### DIFF
--- a/projects/microphysics/argo/prog-run-and-eval.yaml
+++ b/projects/microphysics/argo/prog-run-and-eval.yaml
@@ -18,6 +18,26 @@ spec:
     secret:
       secretName: gcp-key
   templates:
+  - name: diagnostics
+    inputs:
+      parameters:
+        - {name: baseline_tag}
+        - {name: tag}
+    steps:
+      - - name: piggy
+          template: piggyback-diags
+          arguments:
+            parameters:
+            - name: tag
+              value: "{{workflow.parameters.tag}}"
+        - name: prognostic-diags
+          dependencies: [run-offline, run-online]
+          arguments:
+            parameters:
+            - name: tag
+              value: "{{inputs.parameters.tag}}"
+            - name: baseline_tag
+              value: "{{inputs.parameters.baseline_tag}}"
   - name: prognostic-run
     dag:
       tasks:

--- a/projects/microphysics/argo/prog-run-and-eval.yaml
+++ b/projects/microphysics/argo/prog-run-and-eval.yaml
@@ -18,26 +18,6 @@ spec:
     secret:
       secretName: gcp-key
   templates:
-  - name: diagnostics
-    inputs:
-      parameters:
-        - {name: baseline_tag}
-        - {name: tag}
-    steps:
-      - - name: piggy
-          template: piggyback-diags
-          arguments:
-            parameters:
-            - name: tag
-              value: "{{workflow.parameters.tag}}"
-        - name: prognostic-diags
-          dependencies: [run-offline, run-online]
-          arguments:
-            parameters:
-            - name: tag
-              value: "{{inputs.parameters.tag}}"
-            - name: baseline_tag
-              value: "{{inputs.parameters.baseline_tag}}"
   - name: prognostic-run
     dag:
       tasks:

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -83,7 +83,9 @@ config_dict = config.to_fv3config()
 
 url = resolve_url(BUCKET, job.project, tag)
 
-wandb.config.update({"config": config_dict, "rundir": url})
+wandb.config.update(
+    {"config": config_dict, "rundir": url, "env": {os.getenv("COMMIT_SHA", "")}}
+)
 
 api.create(url, config_dict)
 for i in range(args.segments):

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -4,13 +4,11 @@ import logging
 import os
 from pathlib import Path
 import dacite
-import warnings
 
 import wandb
 import yaml
 from runtime.segmented_run import api
 from runtime.segmented_run.prepare_config import HighLevelConfig
-import emulation
 
 from fv3net.artifacts.resolve_url import resolve_url
 
@@ -22,12 +20,6 @@ logging.basicConfig(level=logging.INFO)
 CONFIG_PATH = Path(__file__).parent.parent / "configs" / "default.yaml"
 
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--model",
-    type=str,
-    default="",
-    help="path to microphysics emulation model...should probably end with .tf",
-)
 parser.add_argument(
     "--tag",
     type=str,
@@ -68,16 +60,6 @@ with args.config_path.open() as f:
 
 config = dacite.from_dict(HighLevelConfig, config)
 config.namelist["gfs_physics_nml"]["emulate_zc_microphysics"] = args.online
-
-if args.model:
-    if config.zhao_carr_emulation.model is not None:
-        warnings.warn(
-            UserWarning(
-                f"Overiding .zhao_carr_emulation.model.path configuration in yaml "
-                "with {args.model}."
-            )
-        )
-    config.zhao_carr_emulation.model = emulation.ModelConfig(path=args.model)
 
 config_dict = config.to_fv3config()
 

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -91,5 +91,5 @@ for i in range(args.segments):
     api.append(url)
 
 artifact = wandb.Artifact(tag, type="prognostic-run")
-artifact.add_reference(url)
+artifact.add_reference(url, checksum=False)
 wandb.log_artifact(artifact)

--- a/projects/microphysics/scripts/prognostic_run.py
+++ b/projects/microphysics/scripts/prognostic_run.py
@@ -24,11 +24,15 @@ def run_from_config_dict(config: dict):
     # pop orchestration related args
     config = {**config}
     tag = config.pop("tag")
-    segments = config.pop("segments")
+    segments = config.pop("segments", 1)
 
     url = resolve_url(BUCKET, job.project, tag)
     wandb.config.update(
-        {"config": config, "rundir": url, "env": {os.getenv("COMMIT_SHA", "")}}
+        {
+            "config": config,
+            "rundir": url,
+            "env": {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")},
+        }
     )
     config = dacite.from_dict(HighLevelConfig, config)
     config_dict = config.to_fv3config()

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/cli.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from fv3net.diagnostics.prognostic_run import metrics, compute
 from fv3net.diagnostics.prognostic_run.views import movies, static_report
 from fv3net.diagnostics.prognostic_run.apps import log_viewer
@@ -13,6 +14,7 @@ def dissoc(namespace, key):
 
 def get_parser():
     parser = argparse.ArgumentParser(description="Prognostic run diagnostics")
+    parser.add_argument("--log-level", type=str, default="INFO")
     subparsers = parser.add_subparsers(
         help="Prognostic run diagnostics", required=True, dest="command"
     )
@@ -25,6 +27,11 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
+
+    if args.log_level:
+        level = getattr(logging, args.log_level)
+        logging.getLogger("gcsfs").setLevel(level)
+        logging.basicConfig(level=level)
 
     # need to remove the 'func' entry since some of these scripts save these
     # arguments in netCDF attributes

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -86,9 +86,14 @@ def plot_histogram_begin_end(ds):
     return {"cloud_histogram": _get_image()}
 
 
+def _plot_cloud_time_vs_z(cloud: xr.DataArray):
+    cloud.plot(vmin=-2e-5, vmax=2e-5, cmap="RdBu_r", y="z", yincrease=True)
+
+
 @register_log
 def plot_cloud_weighted_average(ds):
-    vcm.weighted_average(ds.cloud_water_mixing_ratio, ds.area).plot()
+    global_cloud = vcm.weighted_average(ds.cloud_water_mixing_ratio, ds.area)
+    _plot_cloud_time_vs_z(global_cloud)
     plt.title("Global average cloud water")
     return {"global_average_cloud": _get_image()}
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -100,7 +100,6 @@ def plot_cloud_weighted_average(ds):
 
 @register_log
 def plot_cloud_maps(ds):
-    ds = ds.dropna("time")
     ds = ds.assign(z=ds.z)
     fig = fv3viz.plot_cube(
         ds.isel(time=[0, -1], z=[20, 43]),

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -321,14 +321,19 @@ def upload_diagnostics_for_rundir(url):
         wandb.summary[key] = val
 
 
-def main(args):
-
-    wandb.init(
+def upload_diagnostics_for_tag(tag: str):
+    run = wandb.init(
         job_type="piggy-back",
         project=WANDB_PROJECT,
         entity=WANDB_ENTITY,
-        group=args.tag,
-        tags=[args.tag],
+        group=tag,
+        tags=[tag],
+        reinit=True,
     )
-    url = get_rundir_from_prognostic_run(get_prognostic_run_from_tag(args.tag))
-    upload_diagnostics_for_rundir(url)
+    with run:
+        url = get_rundir_from_prognostic_run(get_prognostic_run_from_tag(tag))
+        upload_diagnostics_for_rundir(url)
+
+
+def main(args):
+    return upload_diagnostics_for_tag(args.tag)

--- a/workflows/diagnostics/tests/prognostic/emulation/test_single_run.py
+++ b/workflows/diagnostics/tests/prognostic/emulation/test_single_run.py
@@ -269,3 +269,14 @@ def test_compute_summaries(regtest):
     ds = vcm.cdl_to_dataset(cdl)
     output = single_run.compute_summaries(ds)
     print(sorted(output), file=regtest)
+
+
+# xfail this tests since it requires internet access...still is useful for
+# integration testing
+@pytest.mark.xfail
+def test_get_url_from_tag():
+    tag = "rnn-gscond-cloudtdep-cbfc4a-30d-v2-online"
+    run = single_run.get_prognostic_run_from_tag(tag=tag)
+    assert run.group == tag
+    rundir = single_run.get_rundir_from_prognostic_run(run)
+    assert rundir.startswith("gs://")


### PR DESCRIPTION
Need to generate piggy-back diagnostics for the runs that failed to complete (probably died during wandb stuff). I also improved the performance and plots in the report. This PR is a bit of hodge-podge, so I'd review the commit log for more info.
