### PR TITLE
Replace predict_columnwise instances with predict

### DIFF
--- a/external/fv3fit/fv3fit/_shared/predictor.py
+++ b/external/fv3fit/fv3fit/_shared/predictor.py
@@ -1,8 +1,7 @@
 import xarray as xr
 import abc
-from typing import Hashable, Iterable, Sequence
+from typing import Hashable, Iterable
 import logging
-import warnings
 
 from .input_sensitivity import InputSensitivity
 
@@ -55,35 +54,6 @@ class Predictor(abc.ABC):
     def load(cls, path: str) -> "Predictor":
         """Load a serialized model from a directory."""
         pass
-
-    def predict_columnwise(
-        self,
-        X: xr.Dataset,
-        sample_dims: Sequence[Hashable] = (),
-        feature_dim: Hashable = None,
-    ) -> xr.Dataset:
-        """
-        Deprecated after models' .predict changed to take unstacked data.
-        Will be removed in a following PR.
-
-        Predict on an unstacked xarray dataset
-
-        Args:
-            X: the input data
-            sample_dims: A list of dimensions over which samples are taken
-            feature_dim: If provided, the sample_dims will be inferred from this
-                value
-
-        Returns:
-            the predictions defined on the same dimensions as X
-        """
-        warnings.warn(
-            "The predict_columnwise method is now deprecated since predictors' "
-            "predict methods now work on unstacked data. This will be removed "
-            "in the near future.",
-            DeprecationWarning,
-        )
-        return self.predict(X)
 
     def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
         """Calculate sensitivity to input features."""

--- a/external/fv3fit/tests/test__shared.py
+++ b/external/fv3fit/tests/test__shared.py
@@ -40,35 +40,35 @@ class InOutPredictor(Predictor):
 
 
 @pytest.mark.parametrize("sample_dims", [("x", "y"), ("y", "x")])
-def test__Predictor_predict_columnwise_dims_same_order(sample_dims):
+def test__Predictor_predict_dims_same_order(sample_dims):
     model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((3, 4, 5)))})
-    ans = model.predict_columnwise(X, sample_dims=sample_dims)
+    ans = model.predict(X)
     assert ans.a.dims == ("x", "y", "z")
 
 
 @pytest.mark.parametrize("sample_dims", [("x", "y"), ("y", "x")])
-def test__Predictor_predict_columnwise_dims_same_order_InOutPredictor(sample_dims):
+def test__Predictor_predict_dims_same_order_InOutPredictor(sample_dims):
     model = InOutPredictor.create()
     shape = (3, 4, 5)
     ds = xr.Dataset({"in": (["z", "y", "x"], np.ones(shape))})
-    output = model.predict_columnwise(ds, sample_dims=sample_dims)
+    output = model.predict(ds)
     assert output.out.dims == ("z", "y", "x")
 
 
-def test__Predictor_predict_columnwise_dims_same_order_2d_output():
+def test__Predictor_predict_dims_same_order_2d_output():
     model = IdentityPredictor2D(["a", "b"], ["b"])
     X = xr.Dataset(
         {"a": (["x", "y", "z"], np.ones((3, 4, 5))), "b": (["x", "y"], np.ones((3, 4)))}
     )
-    ans = model.predict_columnwise(X, sample_dims=["x", "y"])
+    ans = model.predict(X)
     assert ans.b.dims == ("x", "y")
 
 
-def test__Predictor_predict_columnwise_dims_infers_feature_dim():
+def test__Predictor_predict_dims_infers_feature_dim():
     model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((3, 4, 5)))})
-    ans = model.predict_columnwise(X, feature_dim=["z"])
+    ans = model.predict(X)
     assert ans.a.dims == X.a.dims
 
 
@@ -83,24 +83,23 @@ nx, ny, nz = 3, 4, 5
         {"x": np.arange(nx), "y": np.arange(ny), "z": np.arange(nz)},
     ],
 )
-def test__Predictor_predict_columnwise_coordinates_same(coords,):
+def test__Predictor_predict_coordinates_same(coords,):
     model = IdentityPredictor2D(["a"], ["a"])
     X = xr.Dataset({"a": (["x", "y", "z"], np.ones((nx, ny, nz)))}, coords=coords)
-    ans = model.predict_columnwise(X, sample_dims=["x", "y"])
+    ans = model.predict(X)
     for coord in ans.coords:
         xr.testing.assert_equal(ans.coords[coord], X.coords[coord])
 
 
-def test__Predictor_predict_columnwise_broadcast_dataset_dim_in_input():
+def test__Predictor_predict_broadcast_dataset_dim_in_input():
     model = IdentityPredictor2D(["a", "b"], ["a"])
-    sample_dims = ("x", "y", DATASET_DIM_NAME)
     X = xr.Dataset(
         {
             "a": (["x", "y", DATASET_DIM_NAME, "z"], np.ones((2, 3, 4, 5))),
             "b": (["x", "y", "z"], np.ones((2, 3, 5))),
         }
     )
-    ans = model.predict_columnwise(X, sample_dims=sample_dims)
+    ans = model.predict(X)
     assert ans.a.dims == ("x", "y", DATASET_DIM_NAME, "z")
 
 

--- a/external/fv3fit/tests/test_ensemble.py
+++ b/external/fv3fit/tests/test_ensemble.py
@@ -22,7 +22,7 @@ def test_ensemble_model_median(values, reduction, output):
     ds_in = xr.Dataset(
         data_vars={"input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"],)}
     )
-    ds_out = ensemble.predict_columnwise(ds_in, feature_dim="z")
+    ds_out = ensemble.predict(ds_in)
     assert len(ds_out.data_vars) == 1
     assert "output" in ds_out.data_vars
     np.testing.assert_almost_equal(ds_out["output"].values, output)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -234,9 +234,7 @@ def _get_predict_function(predictor, variables, grid):
         )
         derived_mapping = DerivedMapping(ds)
         ds_derived = derived_mapping.dataset(variables)
-        ds_prediction = predictor.predict_columnwise(
-            safe.get_variables(ds_derived, variables), feature_dim="z"
-        )
+        ds_prediction = predictor.predict(safe.get_variables(ds_derived, variables))
         return insert_prediction(ds_derived, ds_prediction)
 
     return transform

--- a/workflows/diagnostics/tests/offline/test__ml_prediction.py
+++ b/workflows/diagnostics/tests/offline/test__ml_prediction.py
@@ -43,10 +43,7 @@ class MockPredictor(fv3fit.Predictor):
         self.output_ds = output_ds
         self.call_datasets = []
 
-    def predict(self, X: xr.Dataset):
-        raise NotImplementedError()
-
-    def predict_columnwise(self, X: xr.Dataset, *args, **kwargs) -> xr.Dataset:
+    def predict(self, X: xr.Dataset, *args, **kwargs) -> xr.Dataset:
         self.call_datasets.append(X)
         return self.output_ds
 

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -108,9 +108,9 @@ class RenamingAdapter:
         invert_rename_in = _invert_dict(self.rename_in)
         return {invert_rename_in.get(var, var) for var in self.model.input_variables}
 
-    def predict_columnwise(self, arg: xr.Dataset, **kwargs) -> xr.Dataset:
+    def predict(self, arg: xr.Dataset) -> xr.Dataset:
         input_ = self._rename_inputs(arg)
-        prediction = self.model.predict_columnwise(input_, **kwargs)
+        prediction = self.model.predict(input_)
         return self._rename_outputs(prediction)
 
 
@@ -123,10 +123,10 @@ class MultiModelAdapter:
         vars = [model.input_variables for model in self.models]
         return {var for model_vars in vars for var in model_vars}
 
-    def predict_columnwise(self, arg: xr.Dataset, **kwargs) -> xr.Dataset:
+    def predict(self, arg: xr.Dataset) -> xr.Dataset:
         predictions = []
         for model in self.models:
-            predictions.append(model.predict_columnwise(arg, **kwargs))
+            predictions.append(model.predict(arg))
         return xr.merge(predictions)
 
 
@@ -158,7 +158,7 @@ def predict(model: MultiModelAdapter, state: State) -> State:
     """Given ML model and state, return prediction"""
     state_loaded = {key: state[key] for key in model.input_variables}
     ds = xr.Dataset(state_loaded)  # type: ignore
-    output = model.predict_columnwise(ds, feature_dim="z")
+    output = model.predict(ds)
     return {key: cast(xr.DataArray, output[key]) for key in output.data_vars}
 
 

--- a/workflows/prognostic_c48_run/tests/test_adapters.py
+++ b/workflows/prognostic_c48_run/tests/test_adapters.py
@@ -22,7 +22,7 @@ class MockPredictor:
         self.output_variables = output_variables or ["rename_output"]
         self.output_scaling = output_scaling
 
-    def predict_columnwise(self, x, sample_dims=None):
+    def predict(self, x):
         in_ = x[self.input_variables[0]] * self.output_scaling
         return xr.Dataset({self.output_variables[0]: in_})
 
@@ -34,7 +34,7 @@ def test_RenamingAdapter_predict_inputs_and_outputs_renamed():
     model = RenamingAdapter(
         MockPredictor(), {"x": "renamed_input"}, {"y": "rename_output"}
     )
-    out = model.predict_columnwise(ds)
+    out = model.predict(ds)
     assert "y" in out.data_vars
 
 
@@ -52,7 +52,7 @@ def test_RenamingAdapter_predict_renames_dims_correctly(
     m = MockPredictor()
     ds = xr.Dataset({m.input_variables[0]: (original_dims, np.ones((5, 10)))})
     model = RenamingAdapter(m, rename_dims)
-    out = model.predict_columnwise(ds)
+    out = model.predict(ds)
     output_array = out[m.output_variables[0]]
     assert list(output_array.dims) == expected
 
@@ -67,7 +67,7 @@ def test_MultiModelAdapter_combines_predictions():
     model0 = MockPredictor(output_variables=["y0"], input_variables=["x"])
     model1 = MockPredictor(output_variables=["y1"], input_variables=["x"])
     combined_model = MultiModelAdapter([model0, model1])
-    out = combined_model.predict_columnwise(ds)
+    out = combined_model.predict(ds)
     assert "y0" in out.data_vars and "y1" in out.data_vars
 
 
@@ -79,4 +79,4 @@ def test_MultiModelAdapter_exception_on_output_overlap():
     )
     combined_model = MultiModelAdapter([model0, model1])
     with pytest.raises(xr.MergeError):
-        combined_model.predict_columnwise(ds)
+        combined_model.predict(ds)

--- a/workflows/prognostic_c48_run/tests/test_machine_learning.py
+++ b/workflows/prognostic_c48_run/tests/test_machine_learning.py
@@ -32,7 +32,7 @@ def ml_stepper(model_output_type):
 @pytest.mark.parametrize("output_type", ["tendencies", "rad_fluxes"])
 def test_mock_predictor_checksum(output_type, state, regtest):
     mock_model = get_mock_predictor(output_type)
-    predicted = mock_model.predict_columnwise(state, feature_dim="z")
+    predicted = mock_model.predict(state)
     test_state_regression(predicted, regtest)
 
 


### PR DESCRIPTION
The `predict_columnwise` method on the `Predictor` class has been deprecated for 7 months. This PR removes this method (which is currently just a wrapper around `.predict`) and changes all of its uses to directly use the `predict` method.