### PR TITLE
Prognostic run: run-fv3gfs choose node pool

### DIFF
--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -23,6 +23,11 @@ spec:
             artifacts:
               - name: fv3config
                 from: "{{inputs.artifacts.fv3config}}"
+      - - name: choose-node-pool
+          template: choose-node-pool
+          arguments:
+            parameters:
+            - {name: cpu:, value: "{{inputs.parameters.cpu}}"}
       # loop over segments implemented through recursion so that a failed segment will
       # terminate the workflow. Argo loops by default run in parallel and do not fail fast.
       - - name: run-first-segment
@@ -32,6 +37,7 @@ spec:
             - {name: output-url, value: "{{inputs.parameters.output-url}}"}
             - {name: cpu, value: "{{inputs.parameters.cpu}}"}
             - {name: memory, value: "{{inputs.parameters.memory}}"}
+            - {name: node-pool, value: "{{steps.choose-node-pool.outputs.result}}"}
             - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
             - {name: segment, value: 0}
   - name: run-all-segments
@@ -40,6 +46,7 @@ spec:
         - name: output-url
         - name: cpu
         - name: memory
+        - name: node-pool
         - name: segment-count
         - name: segment
     steps:
@@ -50,6 +57,7 @@ spec:
               - {name: runURL, value: "{{inputs.parameters.output-url}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}
+              - {name: node-pool, value: "{{inputs.parameters.node-pool}}"}
       - - name: increment-segment
           template: increment-count
           arguments:
@@ -63,6 +71,7 @@ spec:
             - {name: output-url, value: "{{inputs.parameters.output-url}}"}
             - {name: cpu, value: "{{inputs.parameters.cpu}}"}
             - {name: memory, value: "{{inputs.parameters.memory}}"}
+            - {name: node-pool, value: "{{inputs.parameters.node-pool}}"}
             - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
             - {name: segment, value: "{{steps.increment-segment.outputs.result}}"}
   - name: create-run
@@ -96,16 +105,32 @@ spec:
         - name: gcp-key-secret
           mountPath: /secret/gcp-credentials
           readOnly: true
+  - name: choose-node-pool
+    inputs:
+      parameters:
+        - name: cpu_request
+        - name: cpu_cutoff
+    script:
+      image: python:alpine3.6
+      command: [python]
+      source: |
+        node_pool = (
+            'climate-sim-pool'
+            if {{inputs.parameters.cpu_request}} <= {{inputs.parameters.cpu_cutoff}}
+            else 'ultra-sim-pool'
+        )
+        print(node_pool)
   - name: append-segment
     inputs:
       parameters:
         - name: cpu
         - name: memory
         - name: runURL
+        - name: node-pool
     tolerations:
     - key: "dedicated"
       operator: "Equal"
-      value: "climate-sim-pool"
+      value: "{{inputs.parameters.node-pool}}"
       effect: "NoSchedule"
     podSpecPatch: |
       containers:

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -27,7 +27,8 @@ spec:
           template: choose-node-pool
           arguments:
             parameters:
-            - {name: cpu:, value: "{{inputs.parameters.cpu}}"}
+            - {name: cpu-request, value: "{{inputs.parameters.cpu}}"}
+            - {name: cpu-cutoff, value: "24"}
       # loop over segments implemented through recursion so that a failed segment will
       # terminate the workflow. Argo loops by default run in parallel and do not fail fast.
       - - name: run-first-segment
@@ -108,15 +109,15 @@ spec:
   - name: choose-node-pool
     inputs:
       parameters:
-        - name: cpu_request
-        - name: cpu_cutoff
+        - name: cpu-request
+        - name: cpu-cutoff
     script:
       image: python:alpine3.6
       command: [python]
       source: |
         node_pool = (
             'climate-sim-pool'
-            if {{inputs.parameters.cpu_request}} <= {{inputs.parameters.cpu_cutoff}}
+            if {{inputs.parameters.cpu-request}} <= {{inputs.parameters.cpu-cutoff}}
             else 'ultra-sim-pool'
         )
         print(node_pool)

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -23,7 +23,7 @@ spec:
             artifacts:
               - name: fv3config
                 from: "{{inputs.artifacts.fv3config}}"
-      - - name: choose-node-pool
+        - name: choose-node-pool
           template: choose-node-pool
           arguments:
             parameters:


### PR DESCRIPTION
This PR selects either `climate-sim-pool` or `ultra-sim-pool` for running fv3 segments in the `run-fv3gfs` workflow template depending on the request cpus. Any and only requests of greater than 24 CPUs (i.e., for greater than 2x2 tile layout processes) get sent to the `ultra-sim-pool`.

Significant internal changes:
- The `run-fv3gfs` workflow has an additional internal step to choose the node pool based on cpu.