### PR TITLE
Prognostic run: choose node pool handle milli-cpu

### DIFF
--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -116,10 +116,10 @@ spec:
       command: [python]
       source: |
         cpu_request = "{{inputs.parameters.cpu-request}}"
-        if isinstance(cpu_request, str) and cpu_request.endswith('m'):
+        if cpu_request.endswith('m'):
             cpus = float(cpu_request[:-1])/1000.0
         else:
-            cpus = int(cpu_request)
+            cpus = float(cpu_request)
         node_pool = 'climate-sim-pool' if cpus <= {{inputs.parameters.cpu-cutoff}} else 'ultra-sim-pool'
         print(node_pool)
   - name: append-segment

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -115,11 +115,12 @@ spec:
       image: python:alpine3.6
       command: [python]
       source: |
-        node_pool = (
-            'climate-sim-pool'
-            if {{inputs.parameters.cpu-request}} <= {{inputs.parameters.cpu-cutoff}}
-            else 'ultra-sim-pool'
-        )
+        cpu_request = "{{inputs.parameters.cpu-request}}"
+        if isinstance(cpu_request, str) and cpu_request.endswith('m'):
+            cpus = float(cpu_request[:-1])/1000.0
+        else:
+            cpus = int(cpu_request)
+        node_pool = 'climate-sim-pool' if cpus <= {{inputs.parameters.cpu-cutoff}} else 'ultra-sim-pool'
         print(node_pool)
   - name: append-segment
     inputs:


### PR DESCRIPTION
#1684 did not support milli-cpu requests that are used by the end to end integration test and perhaps elsewhere. This fixes that and allows either milli-cpu or integer/float cpu requests to the `run-fv3gfs` template.

Significant internal changes:
- milli-cpu requests (eg , 6000m) can be handled by the `choose-node-pool` step within `run-fv3gfs`
