### PR TITLE
Modify ClipConfig API to remove dimension, always clip last dim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 external/vcm/vcm/mappm.*.so*
 
+**/.data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -332,10 +332,12 @@ class SliceConfig:
 class PackerConfig:
     """
     Configuration for packing.
+
     Attributes:
         clip: a mapping from variable name to configuration for the slice of
             the feature (last) dimension of that variable we want to retain.
-            Used to exclude data (e.g. at start or end of dimension).
+            Used to exclude data (e.g. at start or end of dimension). User
+            must ensure the last dimension is the dimension they want to clip.
     """
 
     clip: Mapping[Hashable, SliceConfig] = dataclasses.field(default_factory=dict)

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -5,6 +5,7 @@ import os
 from typing import (
     Any,
     Callable,
+    Hashable,
     Mapping,
     Optional,
     Tuple,
@@ -14,7 +15,6 @@ from typing import (
     List,
     Type,
     Dict,
-    Hashable,
     MutableMapping,
 )
 from fv3fit.typing import Dataclass
@@ -328,12 +328,17 @@ class SliceConfig:
         return slice(self.start, self.stop, self.step)
 
 
-ClipDims = Mapping[Hashable, Mapping[str, SliceConfig]]
-
-
 @dataclasses.dataclass(frozen=True)
 class PackerConfig:
-    clip: ClipDims = dataclasses.field(default_factory=dict)
+    """
+    Configuration for packing.
+    Attributes:
+        clip: a mapping from variable name to configuration for the slice of
+            the feature (last) dimension of that variable we want to retain.
+            Used to exclude data (e.g. at start or end of dimension).
+    """
+
+    clip: Mapping[Hashable, SliceConfig] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -12,7 +12,7 @@ from typing import (
     Mapping,
 )
 
-from .config import PackerConfig, ClipDims
+from .config import PackerConfig, SliceConfig
 import dacite
 import dataclasses
 import numpy as np
@@ -90,15 +90,16 @@ def tuple_to_multiindex(d: tuple) -> pd.MultiIndex:
 
 
 def clip(
-    data: Union[xr.Dataset, Mapping[Hashable, xr.DataArray]], config: ClipDims,
+    data: Union[xr.Dataset, Mapping[Hashable, xr.DataArray]],
+    config: Mapping[Hashable, SliceConfig],
 ) -> Mapping[Hashable, xr.DataArray]:
     clipped_data = {}
     for variable in data:
         da = data[variable]
         da = _fill_empty_coords(da)
         if variable in config:
-            for dim in config[variable]:
-                da = da.isel({dim: config[variable][dim].slice})
+            dim = data[variable].dims[-1]
+            da = da.isel({dim: config[variable].slice})
         clipped_data[variable] = da
     return clipped_data
 

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -50,7 +50,7 @@ class DenseHyperparameters(Hyperparameters):
             each output variable.
         save_model_checkpoints: if True, save one model per epoch when
             dumping, under a 'model_checkpoints' subdirectory
-        clip_config: configuration of dataset packing.
+        clip_config: configuration of input and output clipping
         output_limit_config: configuration for limiting output values.
     """
 

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -50,7 +50,7 @@ class DenseHyperparameters(Hyperparameters):
             each output variable.
         save_model_checkpoints: if True, save one model per epoch when
             dumping, under a 'model_checkpoints' subdirectory
-        clip_config: configuration of input and output clipping
+        clip_config: configuration of input and output clipping of last dimension
         output_limit_config: configuration for limiting output values.
     """
 

--- a/external/fv3fit/fv3fit/keras/_models/shared/clip.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/clip.py
@@ -10,13 +10,10 @@ Clippable = Union[tf.Tensor, np.ndarray]
 @dataclasses.dataclass(frozen=True)
 class ClipConfig(PackerConfig):
     """Config class for implementing input and output clipping in keras models.
-    Assumes that there is only one clipped dimension (usually vertical) which is
-    the last dim.
+    Clips the last dimension, which the user must ensure is the correct dimension.
 
     Attributes:
-        clip: mapping of variable names to be clipped to a SliceConfig. Will raise
-            an error if initialized with a SliceConfig that has more than one
-            dimension to clip.
+        clip: slice of last dimension to retain when clipping, for the given variable
     """
 
     clip: Mapping[Hashable, SliceConfig] = dataclasses.field(default_factory=dict)

--- a/external/fv3fit/tests/test_clip.py
+++ b/external/fv3fit/tests/test_clip.py
@@ -6,31 +6,26 @@ from fv3fit.keras._models.shared.clip import ClipConfig
 from fv3fit._shared.config import SliceConfig
 
 
-def test_ClipConfig_only_single_clip_dims_allowed():
-    with pytest.raises(ValueError):
-        ClipConfig({"var": {"z": SliceConfig(8, None), "y": SliceConfig(None, 2)}})
-
-
 @pytest.mark.parametrize(
     "clip_config, expected",
     [
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(2, 6)}}),
+            ClipConfig({"var": SliceConfig(2, 6)}),
             np.array([2, 3, 4, 5]),
             id="clip_1d",
         ),
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(8, None)}}),
+            ClipConfig({"var": SliceConfig(8, None)}),
             np.array([8, 9]),
             id="clip_1d_no_stop",
         ),
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(None, 2)}}),
+            ClipConfig({"var": SliceConfig(None, 2)}),
             np.array([0, 1]),
             id="clip_1d_no_start",
         ),
         pytest.param(
-            ClipConfig({"var_": {"z": SliceConfig(8, None)}}),
+            ClipConfig({"var_": SliceConfig(8, None)}),
             np.arange(10),
             id="clip_var_not_in_config",
         ),
@@ -53,7 +48,7 @@ def test_ClipConfig_clip_along_last_dim_1d(clip_config, expected):
 def test_ClipConfig_clip_along_last_dim_2d():
     shape = (2, 10)
     layer = tf.keras.layers.Input(shape=shape)
-    clip_config = ClipConfig({"var": {"z": SliceConfig(2, 6)}})
+    clip_config = ClipConfig({"var": SliceConfig(2, 6)})
     clipped = clip_config.clip_along_last_dim(layer, "var")
     model = tf.keras.Model(inputs=layer, outputs=clipped)
     test_input = np.arange(20).reshape(1, *shape)
@@ -65,17 +60,17 @@ def test_ClipConfig_clip_along_last_dim_2d():
     "clip_config, expected",
     [
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(2, 5)}}),
+            ClipConfig({"var": SliceConfig(2, 5)}),
             np.array([0, 0, 2, 3, 4, 0]),
             id="clip_both_ends",
         ),
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(2, None)}}),
+            ClipConfig({"var": SliceConfig(2, None)}),
             np.array([0, 0, 2, 3, 4, 5]),
             id="clip_start",
         ),
         pytest.param(
-            ClipConfig({"var": {"z": SliceConfig(None, 5)}}),
+            ClipConfig({"var": SliceConfig(None, 5)}),
             np.array([0, 1, 2, 3, 4, 0]),
             id="clip_end",
         ),
@@ -92,7 +87,7 @@ def test_ClipConfig_zero_mask_clipped_layer_1d(clip_config, expected):
 
 
 def test_ClipConfig_zero_mask_clipped_layer_2d():
-    clip_config = ClipConfig({"var": {"z": SliceConfig(2, 5)}})
+    clip_config = ClipConfig({"var": SliceConfig(2, 5)})
     layer = tf.keras.layers.Input(shape=(2, 6))
     masked = clip_config.zero_mask_clipped_layer(layer, "var")
     model = tf.keras.Model(inputs=layer, outputs=masked)

--- a/external/fv3fit/tests/test_packer.py
+++ b/external/fv3fit/tests/test_packer.py
@@ -192,15 +192,14 @@ def test_sklearn_unpack(dataset: xr.Dataset):
 def test_sklearn_pack_unpack_with_clipping(dataset: xr.Dataset):
     name = list(dataset.data_vars)[0]
     if FEATURE_DIM in dataset[name].dims:
-        pack_config = PackerConfig({name: {FEATURE_DIM: SliceConfig(3, None)}})
+        pack_config = PackerConfig({name: SliceConfig(3, None)})
         packed_array, feature_index = pack(dataset, [SAMPLE_DIM], pack_config)
         unpacked_dataset = unpack(packed_array, [SAMPLE_DIM], feature_index)
         expected = {}
         for k in dataset:
             da = dataset[k].copy(deep=True)
-            indices = pack_config.clip.get(k, {})
-            for dim, slice_config in indices.items():
-                da = da.isel({dim: slice_config.slice})
+            slice_config = pack_config.clip.get(k, SliceConfig())
+            da = da.isel({da.dims[-1]: slice_config.slice})
             expected[k] = da
         xr.testing.assert_allclose(unpacked_dataset, xr.Dataset(expected))
 
@@ -208,13 +207,13 @@ def test_sklearn_pack_unpack_with_clipping(dataset: xr.Dataset):
 def test_clip(dataset: xr.Dataset):
     name = list(dataset.data_vars)[0]
     if FEATURE_DIM in dataset[name].dims:
-        indices = {name: {FEATURE_DIM: SliceConfig(4, 8)}}
+        indices = {name: SliceConfig(4, 8)}
         clipped_data = clip(dataset, indices)
-        expected_da = dataset[name].assign_coords(
+        da: xr.Dataset = dataset[name].assign_coords(
             {dim: range(dataset.sizes[dim]) for dim in dataset[name].dims}
         )
-        for dim, slice_config in indices[name].items():
-            expected_da = expected_da.isel({dim: slice_config.slice})
+        slice_config = indices[name]
+        expected_da = da.isel({da.dims[-1]: slice_config.slice})
         xr.testing.assert_identical(clipped_data[name], expected_da)
 
 
@@ -223,16 +222,16 @@ def test_clip_differing_slices():
         ["var1", "var2"], [[SAMPLE_DIM, FEATURE_DIM], [SAMPLE_DIM, FEATURE_DIM]]
     )
     clip_config = {
-        "var1": {FEATURE_DIM: SliceConfig(4, 8)},
-        "var2": {FEATURE_DIM: SliceConfig(None, 6, 2)},
+        "var1": SliceConfig(4, 8),
+        "var2": SliceConfig(None, 6, 2),
     }
     clipped_data = clip(ds, clip_config)
     for name in ds:
-        expected_da = ds[name].assign_coords(
+        da = ds[name].assign_coords(
             {dim: range(ds.sizes[dim]) for dim in ds[name].dims}
         )
-        for dim, slice_config in clip_config[name].items():
-            expected_da = expected_da.isel({dim: slice_config.slice})
+        slice_config = clip_config[name]
+        expected_da = da.isel({da.dims[-1]: slice_config.slice})
         xr.testing.assert_identical(clipped_data[name], expected_da)
 
 
@@ -261,7 +260,7 @@ def test_count_features():
 
 def test_array_packer_dump_and_load(tmpdir):
     dataset = get_dataset(["var1"], [[SAMPLE_DIM, FEATURE_DIM]])
-    packer_config = PackerConfig({"var1": {"z": SliceConfig(None, 2)}})
+    packer_config = PackerConfig({"var1": SliceConfig(None, 2)})
     packer = ArrayPacker(SAMPLE_DIM, list(dataset.data_vars), packer_config)
     packer.to_array(dataset)
     with open(str(tmpdir.join("packer.yaml")), "w") as f:

--- a/external/fv3fit/tests/test_sklearn_wrapper.py
+++ b/external/fv3fit/tests/test_sklearn_wrapper.py
@@ -231,7 +231,7 @@ def test_SklearnWrapper_fit_predict_with_clipped_input_data():
         input_variables=["a", "b"],
         output_variables=["c"],
         model=model,
-        packer_config=PackerConfig({"a": {"z": SliceConfig(2, None)}}),
+        packer_config=PackerConfig({"a": SliceConfig(2, None)}),
     )
 
     dims = ["sample", "z"]
@@ -255,5 +255,5 @@ def test_SklearnWrapper_raises_not_implemented_error_with_clipped_output_data():
             input_variables=["a", "b"],
             output_variables=["c"],
             model=model,
-            packer_config=PackerConfig({"c": {"z": SliceConfig(2, None)}}),
+            packer_config=PackerConfig({"c": SliceConfig(2, None)}),
         )

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -346,7 +346,7 @@ def test_train_dense_model_clipped_inputs_outputs():
         "dense", input_variables, output_variables
     )
     hyperparameters.clip_config = ClipConfig(
-        {"var_in_0": {"z": SliceConfig(2, 5)}, "var_out_0": {"z": SliceConfig(4, 8)}}
+        {"var_in_0": SliceConfig(2, 5), "var_out_0": SliceConfig(4, 8)}
     )
     model = train(hyperparameters, train_batches, val_batches,)
     prediction = model.predict(train_dataset)


### PR DESCRIPTION
When we move to tfdatasets, we do not have access to dimension names. In practice we always want to clip the last dimension of an array. This PR modifies clipping configuration to remove the dimension name, and always assume we are clipping the last dimension.

The only training function with more than one non-sample dimension which could possibly receive data with an incorrect dimension ordering is the convolutional model. This model already assumes incoming data has the correct dimensionality, so the clipping assumption of dimension ordering doesn't add any additional danger.

We may consider adding code later to enforce that loader functions return tfdatasets with data of the correct dimensionality.

Refactored public API:
- The `clip` attribute of `PackerConfig` and `ClipConfig` is now `Mapping[Hashable, SliceConfig]`, was `Mapping[Hashable, Mapping[str, SliceConfig]]`.

Significant internal changes:
- refactored clipping functionality to use configuration as `Mapping[Hashable, SliceConfig]`, was `Mapping[Hashable, Mapping[str, SliceConfig]]`.

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
