### PR TITLE
Add slow pytest marker for fv3fit tests > 1s

### DIFF
--- a/external/fv3fit/tests/conftest.py
+++ b/external/fv3fit/tests/conftest.py
@@ -13,3 +13,9 @@ def state(tmp_path_factory):
     lpath = tmp_path_factory.getbasetemp() / "input_data.nc"
     lpath.write_bytes(r.content)
     return xr.open_dataset(str(lpath))
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    )

--- a/external/fv3fit/tests/conftest.py
+++ b/external/fv3fit/tests/conftest.py
@@ -13,9 +13,3 @@ def state(tmp_path_factory):
     lpath = tmp_path_factory.getbasetemp() / "input_data.nc"
     lpath.write_bytes(r.content)
     return xr.open_dataset(str(lpath))
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
-    )

--- a/external/fv3fit/tests/emulation/test_models.py
+++ b/external/fv3fit/tests/emulation/test_models.py
@@ -136,6 +136,7 @@ def test_precip_conserving_extra_inputs():
 
 
 @pytest.mark.parametrize("arch", _ARCHITECTURE_KEYS)
+@pytest.mark.slow
 def test_MicrophysicConfig_model_save_reload(arch):
 
     config = MicrophysicsConfig(
@@ -163,6 +164,7 @@ def test_MicrophysicConfig_model_save_reload(arch):
     )
 
 
+@pytest.mark.slow
 def test_RNN_downward_dependence():
 
     config = MicrophysicsConfig(
@@ -239,6 +241,7 @@ def test_transform_model_input_names():
 
 
 @pytest.mark.xfail
+@pytest.mark.slow
 def test_saved_model_jacobian():
     """
     SimpleRNN saving prevents jacobian calculation due to some internal

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -147,6 +147,7 @@ def test_rnn_v1_cache_disable(arch_key, expected_cache):
 
 
 @pytest.mark.regression
+@pytest.mark.slow
 def test_training_entry_integration(tmp_path):
 
     config_dict = asdict(get_default_config())

--- a/external/fv3fit/tests/keras/test_sequences.py
+++ b/external/fv3fit/tests/keras/test_sequences.py
@@ -1,6 +1,8 @@
 from fv3fit.keras._models.shared import ThreadedSequencePreLoader
+import pytest
 
 
+@pytest.mark.slow
 def test__ThreadedSequencePreLoader():
     """ Check correctness of the pre-loaded sequence"""
     sequence = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/external/fv3fit/tests/test_bptt.py
+++ b/external/fv3fit/tests/test_bptt.py
@@ -89,6 +89,7 @@ def get_model(sample_dim_name, use_moisture_limiter):
     )
 
 
+@pytest.mark.slow
 def test_predict_model_gives_tendency_of_train_model(
     sample_dim_name, dt, use_moisture_limiter
 ):
@@ -125,6 +126,7 @@ def test_predict_model_gives_tendency_of_train_model(
     np.testing.assert_allclose(dQ2[:, 0, :], Q2_train_tendency, atol=1e-6)
 
 
+@pytest.mark.slow
 def test_fit_bptt_command_line(regtest, sample_dim_name, dt):
     config_text = """
 regularizer:
@@ -180,6 +182,7 @@ random_seed: 0
             assert isinstance(loaded_output, xr.Dataset)
 
 
+@pytest.mark.slow
 def test_train_model_uses_correct_given_tendency(sample_dim_name, dt):
     train_dataset = get_train_dataset(sample_dim_name, dt)
     np.random.seed(0)
@@ -246,6 +249,7 @@ def test_train_model_uses_correct_given_tendency(sample_dim_name, dt):
     )
 
 
+@pytest.mark.slow
 def test_predict_model_gives_different_tendencies(sample_dim_name, dt):
     train_dataset = get_train_dataset(sample_dim_name, dt)
     model = _BPTTTrainer(
@@ -264,6 +268,7 @@ def test_predict_model_gives_different_tendencies(sample_dim_name, dt):
     assert not np.all(tendency_ds["dQ1"].values == tendency_ds["dQ2"].values)
 
 
+@pytest.mark.slow
 def test_train_model_gives_different_outputs(sample_dim_name, dt):
     train_dataset = get_train_dataset(sample_dim_name, dt)
     model = _BPTTTrainer(
@@ -284,6 +289,7 @@ def test_train_model_gives_different_outputs(sample_dim_name, dt):
     assert not np.all(air_temperature == specific_humidity)
 
 
+@pytest.mark.slow
 def test_integrate_stepwise(sample_dim_name, dt):
     """
     We need an integrate_stepwise routine for scripts that evaluate the model
@@ -341,6 +347,7 @@ def test_integrate_stepwise(sample_dim_name, dt):
     assert not np.all(air_temperature == specific_humidity)
 
 
+@pytest.mark.slow
 def test_reloaded_model_gives_same_outputs(sample_dim_name, dt):
     train_dataset = get_train_dataset(sample_dim_name, dt)
     model = _BPTTTrainer(

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -421,6 +421,7 @@ def cli_main(args: MainArgs):
     "use_local_download_path, use_validation_data",
     [(False, False), (False, True), (True, False)],
 )
+@pytest.mark.slow
 def test_cli(
     tmpdir,
     use_local_download_path: bool,

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -181,6 +181,7 @@ def assert_can_learn_identity(
             print(result, file=regtest)
 
 
+@pytest.mark.slow
 def test_train_default_model_on_identity(model_type, regtest):
     """
     The model with default configuration options can learn the identity function,
@@ -196,6 +197,7 @@ def test_train_default_model_on_identity(model_type, regtest):
     )
 
 
+@pytest.mark.slow
 def test_default_convolutional_model_is_transpose_invariant():
     """
     The model with default configuration options can learn the identity function,
@@ -227,6 +229,7 @@ def test_default_convolutional_model_is_transpose_invariant():
     )
 
 
+@pytest.mark.slow
 def test_diffusive_convolutional_model_gives_bounded_output():
     """
     The model with diffusive enabled should give outputs in the range of the inputs.
@@ -258,6 +261,7 @@ def test_diffusive_convolutional_model_gives_bounded_output():
         assert np.all(data_array.values <= high), name
 
 
+@pytest.mark.slow
 def test_train_with_same_seed_gives_same_result(model_type):
     n_sample, n_tile, nx, ny, n_feature = 1, 6, 12, 12, 2
     fv3fit.set_random_seed(0)
@@ -273,6 +277,7 @@ def test_train_with_same_seed_gives_same_result(model_type):
     xr.testing.assert_equal(first_output, second_output)
 
 
+@pytest.mark.slow
 def test_predict_does_not_mutate_input(model_type):
     n_sample, n_tile, nx, ny, n_feature = 1, 6, 12, 12, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
@@ -298,6 +303,7 @@ def get_uniform_sample_func(size, low=0, high=1, seed=0):
     return sample_func
 
 
+@pytest.mark.slow
 def test_train_default_model_on_nonstandard_identity(model_type):
     """
     The model with default configuration options can learn the identity function,
@@ -315,6 +321,7 @@ def test_train_default_model_on_nonstandard_identity(model_type):
     )
 
 
+@pytest.mark.slow
 def test_dump_and_load_default_maintains_prediction(model_type):
     n_sample, n_tile, nx, ny, n_feature = 1, 6, 12, 12, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
@@ -328,6 +335,7 @@ def test_dump_and_load_default_maintains_prediction(model_type):
     xr.testing.assert_equal(loaded_result, original_result)
 
 
+@pytest.mark.slow
 def test_train_dense_model_clipped_inputs_outputs():
     da = xr.DataArray(
         np.arange(1500).reshape(6, 5, 5, 10) * 1.0, dims=["tile", "x", "y", "z"],

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,4 @@ norecursedirs =
 markers =
     regression: marks regression tests (deselect with '-m "not regression"')
     network: marks tests requiring network access
+    slow: marks tests as slow (approx >1s) (deselect with '-m "not slow"')


### PR DESCRIPTION
This PR adds a "slow" pytest mark to fv3fit tests that take more than 1 second to run. This enables running only fast tests using `pytest tests -m "not slow"`.

Significant internal changes:
- Added "slow" pytest mark to fv3fit tests that take longer than 1 second

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
