### PR TITLE
Remove output_metadata from PureKerasModel

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -16,7 +16,6 @@ import logging
 from fv3fit.keras._models.shared.utils import (
     standard_denormalize,
     full_standard_normalized_input,
-    get_stacked_metadata,
 )
 
 logger = logging.getLogger(__file__)
@@ -91,11 +90,6 @@ def train_convolutional_model(
         train_data = tuple(train_data)
     X, y = train_data[0]
     train_model, predict_model = build_model(hyperparameters, X=X, y=y)
-    output_metadata = get_stacked_metadata(
-        names=hyperparameters.output_variables,
-        ds=train_batches[0],
-        unstacked_dims=UNSTACKED_DIMS,
-    )
     del train_batches
     hyperparameters.training_loop.fit_loop(
         model=train_model, Xy=train_data, validation_data=validation_data
@@ -103,9 +97,8 @@ def train_convolutional_model(
     predictor = PureKerasModel(
         input_variables=hyperparameters.input_variables,
         output_variables=hyperparameters.output_variables,
-        output_metadata=output_metadata,
         model=predict_model,
-        unstacked_dims=("x", "y", "z", "z_interface"),
+        unstacked_dims=("x", "y", "z"),
         n_halo=n_halo,
     )
     return predictor

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -23,7 +23,6 @@ from fv3fit.keras._models.shared import (
 )
 from fv3fit.keras._models.shared.utils import (
     standard_denormalize,
-    get_stacked_metadata,
     full_standard_normalized_input,
 )
 from fv3fit.keras._models.shared.clip import clip_sequence
@@ -122,9 +121,6 @@ def train_dense_model(
         train_data = tuple(train_data)
 
     train_model, predict_model = build_model(hyperparameters, X=X, y=y)
-    output_metadata = get_stacked_metadata(
-        names=hyperparameters.output_variables, ds=train_batches[0], unstacked_dims="z",
-    )
     del train_batches
 
     loss_history = TrainingLoopLossHistory()
@@ -137,7 +133,6 @@ def train_dense_model(
     predictor = PureKerasModel(
         input_variables=hyperparameters.input_variables,
         output_variables=hyperparameters.output_variables,
-        output_metadata=output_metadata,
         model=predict_model,
         unstacked_dims=("z",),
         n_halo=0,

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -386,4 +386,5 @@ class PrecipitativeModel:
             # predictor has additional diagnostic outputs which were indirectly trained
             list(self.output_variables),
             self._predict_model,
+            unstacked_dims=("z",),
         )

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -131,21 +131,6 @@ def get_losses(
     return loss_list
 
 
-def get_output_metadata(packer, sample_dim_name):
-    """
-    Retrieve xarray metadata for a packer's values, assuming arrays are [sample(, z)].
-    """
-    metadata = []
-    for name in packer.pack_names:
-        n_features = packer.feature_counts[name]
-        if n_features == 1:
-            dims = [sample_dim_name]
-        else:
-            dims = [sample_dim_name, "z"]
-        metadata.append({"dims": dims, "units": "unknown"})
-    return tuple(metadata)
-
-
 @dataclasses.dataclass
 class PrecipitativeHyperparameters(Hyperparameters):
     """
@@ -400,6 +385,5 @@ class PrecipitativeModel:
             self.input_variables,
             # predictor has additional diagnostic outputs which were indirectly trained
             list(self.output_variables),
-            get_output_metadata(self.output_packer, SAMPLE_DIM_NAME),
             self._predict_model,
         )

--- a/external/fv3fit/fv3fit/keras/_models/recurrent.py
+++ b/external/fv3fit/fv3fit/keras/_models/recurrent.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Iterable, Optional, Sequence, Tuple, List, Hashable
+from typing import Iterable, Optional, Sequence, Tuple, Hashable
 import tensorflow as tf
 import xarray as xr
 from ..._shared import (
@@ -120,7 +120,6 @@ class _BPTTTrainer:
         self.predict_keras_model: Optional[tf.keras.Model] = None
         self.use_moisture_limiter = use_moisture_limiter
         self.state_noise = state_noise
-        self._stepwise_output_metadata: List[Dict[str, Any]] = []
         self._statistics_are_fit = False
 
     def fit_statistics(self, X: xr.Dataset):
@@ -153,13 +152,6 @@ class _BPTTTrainer:
         except AttributeError:  # time is datetime64 and has no total_seconds attribute
             time = time.astype(dtype="datetime64[s]")
             self._train_timestep_seconds = time[1].values.item() - time[0].values.item()
-        self._stepwise_output_metadata.clear()
-        for name in ("air_temperature", "specific_humidity"):
-            # remove time dimension from stepwise output metadata
-            dims = X[name].dims[:1] + X[name].dims[2:]
-            self._stepwise_output_metadata.append(
-                {"dims": dims, "units": X[name].units + " / s"}
-            )
         self._statistics_are_fit = True
 
     @property
@@ -436,7 +428,6 @@ class _BPTTTrainer:
             input_variables=tuple(self.input_packer.pack_names)
             + tuple(self.prognostic_packer.pack_names),
             output_variables=self.output_variables,
-            output_metadata=self._stepwise_output_metadata,
             model=self.predict_keras_model,
             sample_dim_name=self.sample_dim_name,
         )
@@ -553,11 +544,10 @@ class StepwiseModel(PureKerasModel):
         self,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
-        output_metadata: Iterable[Dict[str, Any]],
         model: tf.keras.Model,
         sample_dim_name: str,
     ):
-        super().__init__(input_variables, output_variables, output_metadata, model)
+        super().__init__(input_variables, output_variables, model)
         self.sample_dim_name = sample_dim_name
 
     def integrate_stepwise(self, ds: xr.Dataset) -> xr.Dataset:
@@ -616,7 +606,6 @@ class StepwiseModel(PureKerasModel):
             obj = cls(
                 config["input_variables"],
                 config["output_variables"],
-                config.get("output_metadata", None),
                 model,
                 config["sample_dim_name"],
             )
@@ -633,7 +622,6 @@ class StepwiseModel(PureKerasModel):
                         {
                             "input_variables": self.input_variables,
                             "output_variables": self.output_variables,
-                            "output_metadata": self._output_metadata,
                             "sample_dim_name": self.sample_dim_name,
                         }
                     )

--- a/external/fv3fit/fv3fit/keras/_models/recurrent.py
+++ b/external/fv3fit/fv3fit/keras/_models/recurrent.py
@@ -547,7 +547,9 @@ class StepwiseModel(PureKerasModel):
         model: tf.keras.Model,
         sample_dim_name: str,
     ):
-        super().__init__(input_variables, output_variables, model)
+        super().__init__(
+            input_variables, output_variables, model, unstacked_dims=("z",),
+        )
         self.sample_dim_name = sample_dim_name
 
     def integrate_stepwise(self, ds: xr.Dataset) -> xr.Dataset:

--- a/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
@@ -37,7 +37,7 @@ class PureKerasModel(Predictor):
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
         model: tf.keras.Model,
-        unstacked_dims: Sequence[str] = ("z",),
+        unstacked_dims: Sequence[str],
         n_halo: int = 0,
     ):
         """Initialize the predictor

--- a/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
@@ -5,14 +5,13 @@ from fv3fit._shared import (
     SAMPLE_DIM_NAME,
     stack,
 )
-from fv3fit._shared.stacking import Z_DIM_NAMES
 from fv3fit.keras.adapters import (
     ensure_dict_output,
     rename_dict_input,
     rename_dict_output,
 )
 import tensorflow as tf
-from typing import Any, Dict, Hashable, Iterable, Optional, Sequence, Mapping
+from typing import Any, Dict, Hashable, Iterable, Sequence, Mapping
 import xarray as xr
 import os
 from ...._shared import get_dir, put_dir, InputSensitivity
@@ -37,9 +36,8 @@ class PureKerasModel(Predictor):
         self,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
-        output_metadata: Iterable[Dict[str, Any]],
         model: tf.keras.Model,
-        unstacked_dims: Optional[Sequence[str]] = None,
+        unstacked_dims: Sequence[str] = ("z",),
         n_halo: int = 0,
     ):
         """Initialize the predictor
@@ -50,20 +48,15 @@ class PureKerasModel(Predictor):
             output_metadata: attributes and stacked dimension order for each variable
                 in output_variables
             model: keras model to wrap
-            unstacked_dims: if given, stacking should leave these dimensions in place.
-                by default uses z-dimension names from pace.util
+            unstacked_dims: non-sample dimensions of model output
             n_halo: number of halo points required in input data
         """
         super().__init__(input_variables, output_variables)
         self.input_variables = input_variables
         self.output_variables = output_variables
-        self._output_metadata = output_metadata
         self.model = model
         self._n_halo = n_halo
-        if unstacked_dims is None:
-            self._unstacked_dims: Sequence[str] = Z_DIM_NAMES
-        else:
-            self._unstacked_dims = unstacked_dims
+        self._unstacked_dims = unstacked_dims
 
     @classmethod
     def load(cls, path: str) -> "PureKerasModel":
@@ -78,7 +71,6 @@ class PureKerasModel(Predictor):
             obj = cls(
                 config["input_variables"],
                 config["output_variables"],
-                config.get("output_metadata", None),
                 model,
                 unstacked_dims=config.get("unstacked_dims", None),
                 n_halo=config.get("n_halo", 0),
@@ -86,23 +78,21 @@ class PureKerasModel(Predictor):
             return obj
 
     def _array_prediction_to_dataset(
-        self, names, outputs, stacked_output_metadata, stacked_coords
+        self, names, outputs, stacked_coords
     ) -> xr.Dataset:
         ds = xr.Dataset()
-        for name, output, metadata in zip(names, outputs, stacked_output_metadata):
-            scalar_output_as_singleton_dim = (
-                len(metadata["dims"]) == 1
-                and len(output.shape) == 2
-                and output.shape[1] == 1
+        for name, output in zip(names, outputs):
+            dims = [SAMPLE_DIM_NAME] + list(self._unstacked_dims)
+            scalar_singleton_dim = (
+                len(output.shape) == len(dims) and output.shape[-1] == 1
             )
-            if scalar_output_as_singleton_dim:
-                output = output[:, 0]  # remove singleton dimension
+            if scalar_singleton_dim:  # remove singleton dimension
+                output = output[..., 0]
+                dims = dims[:-1]
             da = xr.DataArray(
-                data=output,
-                dims=[SAMPLE_DIM_NAME] + list(metadata["dims"][1:]),
-                coords={SAMPLE_DIM_NAME: stacked_coords},
+                data=output, dims=dims, coords={SAMPLE_DIM_NAME: stacked_coords},
             ).unstack(SAMPLE_DIM_NAME)
-            dim_order = [dim for dim in metadata["dims"] if dim in da.dims]
+            dim_order = [dim for dim in self._unstacked_dims if dim in da.dims]
             ds[name] = da.transpose(*dim_order, ...)
         return ds
 
@@ -123,34 +113,9 @@ class PureKerasModel(Predictor):
         outputs = self.model.predict(inputs)
         if isinstance(outputs, np.ndarray):
             outputs = [outputs]
-        if self._output_metadata is not None:
-            return_ds = self._array_prediction_to_dataset(
-                self.output_variables,
-                outputs,
-                self._output_metadata,
-                X_stacked.coords[SAMPLE_DIM_NAME],
-            )
-        else:
-            # workaround for saved datasets which do not have output metadata
-            # from an initial version of the BPTT code. Can be removed
-            # eventually
-            dQ1, dQ2 = outputs
-            return_ds = xr.Dataset(
-                data_vars={
-                    "dQ1": xr.DataArray(
-                        dQ1,
-                        dims=X_stacked["air_temperature"].dims,
-                        coords=X_stacked["air_temperature"].coords,
-                        attrs={"units": X_stacked["air_temperature"].units + " / s"},
-                    ),
-                    "dQ2": xr.DataArray(
-                        dQ2,
-                        dims=X_stacked["specific_humidity"].dims,
-                        coords=X_stacked["specific_humidity"].coords,
-                        attrs={"units": X_stacked["specific_humidity"].units + " / s"},
-                    ),
-                }
-            ).unstack(SAMPLE_DIM_NAME)
+        return_ds = self._array_prediction_to_dataset(
+            self.output_variables, outputs, X_stacked.coords[SAMPLE_DIM_NAME],
+        )
         return match_prediction_to_input_coords(X, return_ds)
 
     def dump(self, path: str) -> None:
@@ -164,7 +129,6 @@ class PureKerasModel(Predictor):
                         {
                             "input_variables": self.input_variables,
                             "output_variables": self.output_variables,
-                            "output_metadata": self._output_metadata,
                             "unstacked_dims": self._unstacked_dims,
                             "n_halo": self._n_halo,
                         }

--- a/external/fv3fit/fv3fit/keras/_models/shared/utils.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/utils.py
@@ -1,28 +1,9 @@
 from fv3fit._shared.packer import ArrayPacker
 import tensorflow as tf
-from typing import List, Optional, Sequence, Type, Tuple, Dict, Any
-import xarray as xr
+from typing import List, Optional, Sequence, Type
 from fv3fit.emulation.layers import StandardNormLayer, StandardDenormLayer, NormLayer
-from fv3fit._shared.stacking import stack
 
 import numpy as np
-
-
-def get_stacked_metadata(
-    names, ds: xr.Dataset, unstacked_dims: Sequence[str]
-) -> Tuple[Dict[str, Any], ...]:
-    """
-    Retrieve xarray metadata for dataset after stacking.
-
-    Returns a dict containing "dims" and "units" for each name.
-    """
-    ds = stack(ds, unstacked_dims=unstacked_dims)
-    metadata = []
-    for name in names:
-        metadata.append(
-            {"dims": ds[name].dims, "units": ds[name].attrs.get("units", "unknown")}
-        )
-    return tuple(metadata)
 
 
 def get_input_vector(

--- a/external/fv3fit/tests/test_bptt.py
+++ b/external/fv3fit/tests/test_bptt.py
@@ -401,7 +401,9 @@ da_stacked = xr.DataArray(
 def test_pure_keras_predict_works_on_format(da):
     input_vars, output_vars = ["input"], ["output"]
     dummy_predictor = DummyPredictor("sample", input_vars, output_vars)
-    model = PureKerasModel(input_vars, output_vars, model=dummy_predictor,)
+    model = PureKerasModel(
+        input_vars, output_vars, model=dummy_predictor, unstacked_dims=("z",)
+    )
     ds = xr.Dataset({"input": da, "output": da})
     prediction = model.predict(ds)
     for dim in prediction.dims:

--- a/external/fv3fit/tests/test_bptt.py
+++ b/external/fv3fit/tests/test_bptt.py
@@ -401,15 +401,7 @@ da_stacked = xr.DataArray(
 def test_pure_keras_predict_works_on_format(da):
     input_vars, output_vars = ["input"], ["output"]
     dummy_predictor = DummyPredictor("sample", input_vars, output_vars)
-    model = PureKerasModel(
-        input_vars,
-        output_vars,
-        output_metadata=[
-            {"dims": ["sample", "z"], "units": ""},
-            {"dims": ["sample", "z"], "units": ""},
-        ],
-        model=dummy_predictor,
-    )
+    model = PureKerasModel(input_vars, output_vars, model=dummy_predictor,)
     ds = xr.Dataset({"input": da, "output": da})
     prediction = model.predict(ds)
     for dim in prediction.dims:


### PR DESCRIPTION
When moving to tfdatasets in fv3fit.train, we will no longer have access to xarray metadata during training. This PR modifies PureKerasModel to use the list of unstacked dimensions instead of output_metadata.

Refactored public API:
- output_metadata is removed as an argument to PureKerasModel
- unstacked_dims is now a required argument for PureKerasModel (previously optional)
- unstacked_dims argument to PureKerasModel has changed in meaning. Previously it accepted a list of all dimensions you would accept as unstacked dimensions, in any order. Now it must be exactly the list of dimensions used in outputs, where the last dimension (commonly the vertical dimension) may be excluded for some variables.

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
