### PR TITLE
Small changes to improve PureKerasModel serialization

### DIFF
--- a/external/fv3fit/fv3fit/emulation/layers/normalization.py
+++ b/external/fv3fit/fv3fit/emulation/layers/normalization.py
@@ -124,6 +124,9 @@ class StandardNormLayer(PerFeatureMean, PerFeatureStd):
         super().__init__(name=name)
         self.epsilon = epsilon
 
+    def get_config(self):
+        return {"epsilon": self.epsilon}
+
     def call(self, tensor):
         return (tensor - self.mean) / (self.sigma + self.epsilon)
 

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -37,6 +37,15 @@ Q_TENDENCY_NAME = "dQ2"
 
 class IntegratePrecipLayer(tf.keras.layers.Layer):
     def call(self, args) -> tf.Tensor:
+        """
+        Args:
+            dQ2: rate of change in moisture in kg/kg/s, negative corresponds
+                to condensation
+            delp: pressure thickness of atmospheric layer in Pa
+
+        Returns:
+            precipitation rate in kg/m^2/s
+        """
         dQ2, delp = args  # layers seem to take in a single argument
         # output should be kg/m^2/s
         return tf.math.scalar_mul(
@@ -49,6 +58,14 @@ class IntegratePrecipLayer(tf.keras.layers.Layer):
 
 class CondensationalHeatingLayer(tf.keras.layers.Layer):
     def call(self, dQ2: tf.Tensor) -> tf.Tensor:
+        """
+        Args:
+            dQ2: rate of change in moisture in kg/kg/s, negative corresponds
+                to condensation
+
+        Returns:
+            heating rate in degK/s
+        """
         return tf.math.scalar_mul(tf.constant(-LV / CPD, dtype=dQ2.dtype), dQ2)
 
 

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -35,27 +35,21 @@ T_TENDENCY_NAME = "dQ1"
 Q_TENDENCY_NAME = "dQ2"
 
 
-def integrate_precip(args):
-    dQ2, delp = args  # layers seem to take in a single argument
-    # output should be kg/m^2/s
-    return tf.math.scalar_mul(
-        # dQ2 * delp = s-1 * Pa = s^-1 * kg m-1 s-2 = kg m-1 s-3
-        # dQ2 * delp / g = kg m-1 s-3 / (m s-2) = kg/m^2/s
-        tf.constant(-1.0 / GRAVITY, dtype=dQ2.dtype),
-        tf.math.reduce_sum(tf.math.multiply(dQ2, delp), axis=-1),
-    )
+class IntegratePrecipLayer(tf.keras.layers.Layer):
+    def call(self, args) -> tf.Tensor:
+        dQ2, delp = args  # layers seem to take in a single argument
+        # output should be kg/m^2/s
+        return tf.math.scalar_mul(
+            # dQ2 * delp = s-1 * Pa = s^-1 * kg m-1 s-2 = kg m-1 s-3
+            # dQ2 * delp / g = kg m-1 s-3 / (m s-2) = kg/m^2/s
+            tf.constant(-1.0 / GRAVITY, dtype=dQ2.dtype),
+            tf.math.reduce_sum(tf.math.multiply(dQ2, delp), axis=-1),
+        )
 
 
-def condensational_heating(dQ2):
-    """
-    Args:
-        dQ2: rate of change in moisture in kg/kg/s, negative corresponds
-            to condensation
-
-    Returns:
-        heating rate in degK/s
-    """
-    return tf.math.scalar_mul(tf.constant(-LV / CPD, dtype=dQ2.dtype), dQ2)
+class CondensationalHeatingLayer(tf.keras.layers.Layer):
+    def call(self, dQ2: tf.Tensor) -> tf.Tensor:
+        return tf.math.scalar_mul(tf.constant(-LV / CPD, dtype=dQ2.dtype), dQ2)
 
 
 def multiply_loss_by_factor(original_loss, factor):
@@ -328,9 +322,7 @@ class PrecipitativeModel:
             norm_column_precip_vector
         )
         if self._couple_precip_to_dQ1_dQ2:
-            column_heating = tf.keras.layers.Lambda(condensational_heating)(
-                column_precip
-            )
+            column_heating = CondensationalHeatingLayer()(column_precip)
             T_tendency = tf.keras.layers.Add(name="T_tendency")(
                 [T_tendency, column_heating]
             )
@@ -343,9 +335,7 @@ class PrecipitativeModel:
         surface_precip = tf.keras.layers.Add(name="add_physics_precip")(
             [
                 physics_precip,
-                tf.keras.layers.Lambda(integrate_precip, name="surface_precip")(
-                    [column_precip, delp]
-                ),
+                IntegratePrecipLayer(name="surface_precip")([column_precip, delp]),
             ]
         )
         # This assertion is here to remind you that if you change the output variables


### PR DESCRIPTION
Two functions in the precipitative model are turned into layers, so that later I can look at the configuration of a save-loaded model and compare it to the configuration of starting model to ensure PureKerasModel is serializing correctly.

A get_config method is added to a normalization layer which takes an initialization argument, so it can be used within PureKerasModel. Without this method, keras complains it requires this method to serialize the layer.

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
