### PR TITLE
Use temporary directory for emulation cache during tests

### DIFF
--- a/external/fv3fit/tests/conftest.py
+++ b/external/fv3fit/tests/conftest.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 import requests
 import xarray as xr
+import unittest.mock
+import tempfile
 
 np.random.seed(0)
 
@@ -13,3 +15,10 @@ def state(tmp_path_factory):
     lpath = tmp_path_factory.getbasetemp() / "input_data.nc"
     lpath.write_bytes(r.content)
     return xr.open_dataset(str(lpath))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def emulation_cache_tmpdir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with unittest.mock.patch("fv3fit.emulation.data.io.CACHE_DIR", tmpdir):
+            yield


### PR DESCRIPTION
Currently running the fv3fit tests leaves a `.data` directory used for caching by the emulation code which does not get cleaned up. This PR modifies the fv3fit tests to use a temporary directory instead.

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
