### PR TITLE
Re-enable using multiple datasets in offline report

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -11,7 +11,7 @@ from vcm.cloud import gsutil
 from vcm.catalog import catalog
 
 DELP = "pressure_thickness_of_atmospheric_layer"
-
+DATASET_DIM_NAME = "dataset"
 
 UNITS = {
     "column_integrated_dq1": "[W/m2]",

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -58,7 +58,7 @@ def is_3d(da: xr.DataArray, vertical_dim: str = "z"):
 
 def _compute_r2(ds_metrics: xr.Dataset, tag: str = "_r2") -> xr.Dataset:
     """Compute r2 values from MSE and variance metrics.
-    
+
     The names of the resulting variables use the provided tag.
     """
     mse_vars = [var for var in ds_metrics if "_mse" in var]
@@ -72,7 +72,7 @@ def _compute_r2(ds_metrics: xr.Dataset, tag: str = "_r2") -> xr.Dataset:
 
 def insert_r2(ds_metrics: xr.Dataset) -> xr.Dataset:
     """Insert r2 fields into the metrics Dataset.
-    
+
     Fields given the "_r2" tag represent r2 values over all datasets. Fields
     given the "_per_dataset_r2" tag represent the r2 computed over each
     dataset present in the testing data.
@@ -94,7 +94,7 @@ def _rename_via_replace(ds: xr.Dataset, find: str, replace: str) -> xr.Dataset:
 
 def insert_aggregate_bias(ds_metrics: xr.Dataset) -> xr.Dataset:
     """Compute the aggregate bias over all datasets from the per dataset bias.
-    
+
     Renames the per dataset bias variables using the "per_dataset_bias" tag.  Only
     meant to be called on ds_metrics Datasets with a "dataset" dimension.
     """

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -58,7 +58,7 @@ def is_3d(da: xr.DataArray, vertical_dim: str = "z"):
 
 def _compute_r2(ds_metrics: xr.Dataset, tag: str = "_r2") -> xr.Dataset:
     """Compute r2 values from MSE and variance metrics.
-
+    
     The names of the resulting variables use the provided tag.
     """
     mse_vars = [var for var in ds_metrics if "_mse" in var]

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -58,7 +58,7 @@ def is_3d(da: xr.DataArray, vertical_dim: str = "z"):
 
 def _compute_r2(ds_metrics: xr.Dataset, tag: str = "_r2") -> xr.Dataset:
     """Compute r2 values from MSE and variance metrics.
-    
+
     The names of the resulting variables use the provided tag.
     """
     mse_vars = [var for var in ds_metrics if "_mse" in var]

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -5,6 +5,7 @@ import numpy as np
 import xarray as xr
 
 import fv3fit
+
 from ._helpers import DATASET_DIM_NAME
 
 logger = logging.getLogger(__name__)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 import fv3fit
-
+from ._helpers import DATASET_DIM_NAME
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -17,7 +17,11 @@ def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
         ds = ds.sel({"derivation": "predict"})
     if "time" in ds.dims:
         ds = ds.isel(time=0).squeeze(drop=True)
-    return ds.stack(sample=["tile", "x", "y"]).transpose("sample", ...)
+    if DATASET_DIM_NAME in ds.dims:
+        stack_dims = ["tile", "x", "y", DATASET_DIM_NAME]
+    else:
+        stack_dims = ["tile", "x", "y"]
+    return ds.stack(sample=stack_dims).transpose("sample", ...)
 
 
 def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -20,6 +20,7 @@ from .compute_diagnostics import compute_diagnostics
 from .derived_diagnostics import derived_registry
 from ._input_sensitivity import plot_input_sensitivity
 from ._helpers import (
+    DATASET_DIM_NAME
     load_grid_info,
     is_3d,
     insert_r2,
@@ -44,7 +45,6 @@ TRANSECT_NC_NAME = "transect_lon0.nc"
 METRICS_JSON_NAME = "scalar_metrics.json"
 METADATA_JSON_NAME = "metadata.json"
 
-DATASET_DIM_NAME = "dataset"
 DERIVATION_DIM_NAME = "derivation"
 DELP = "pressure_thickness_of_atmospheric_layer"
 PREDICT_COORD = "predict"
@@ -165,6 +165,8 @@ def _compute_diagnostics(
             prediction, target, grid, ds[DELP], n_jobs=n_jobs
         )
         ds_summary["time"] = ds["time"]
+        if DATASET_DIM_NAME in ds_summary.dims:
+            ds_summary = ds_summary.mean("dataset")
 
         batches_summary.append(ds_summary.load())
         del ds

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -23,8 +23,9 @@ from ._helpers import (
     DATASET_DIM_NAME,
     load_grid_info,
     is_3d,
-    insert_r2,
+    compute_r2,
     insert_aggregate_bias,
+    insert_aggregate_r2,
     insert_rmse,
     insert_column_integrated_vars,
 )
@@ -172,8 +173,9 @@ def _compute_diagnostics(
 
     # then average over the batches for each output
     ds_summary = xr.concat(batches_summary, dim="batch")
-    ds_summary = insert_r2(ds_summary)
+    ds_summary = ds_summary.merge(compute_r2(ds_summary))
     if DATASET_DIM_NAME in ds_summary.dims:
+        ds_summary = insert_aggregate_r2(ds_summary)
         ds_summary = insert_aggregate_bias(ds_summary)
     ds_diagnostics, ds_scalar_metrics = _consolidate_dimensioned_data(ds_summary)
     ds_diagnostics = ds_diagnostics.pipe(insert_rmse)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -24,7 +24,7 @@ from ._helpers import (
     load_grid_info,
     is_3d,
     insert_r2,
-    insert_global_bias_metrics,
+    insert_aggregate_bias,
     insert_rmse,
     insert_column_integrated_vars,
 )
@@ -173,7 +173,8 @@ def _compute_diagnostics(
     # then average over the batches for each output
     ds_summary = xr.concat(batches_summary, dim="batch")
     ds_summary = insert_r2(ds_summary)
-    ds_summary = insert_global_bias_metrics(ds_summary)
+    if DATASET_DIM_NAME in ds_summary.dims:
+        ds_summary = insert_aggregate_bias(ds_summary)
     ds_diagnostics, ds_scalar_metrics = _consolidate_dimensioned_data(ds_summary)
     ds_diagnostics = ds_diagnostics.pipe(insert_rmse)
     ds_diagnostics, ds_scalar_metrics = _standardize_names(

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -14,7 +14,6 @@ from typing import Sequence, Tuple, Dict, Union, Mapping, Optional
 import xarray as xr
 
 import vcm
-from ._helpers import DATASET_DIM_NAME
 from vcm import safe, weighted_average, local_time, histogram, histogram2d
 
 logger = logging.getLogger(__name__)
@@ -243,13 +242,6 @@ def weighted_mean(ds, weights, dims):
         return (ds * weights).sum(dims) / weights.sum(dims)
 
 
-def _maybe_average_over_dataset(ds: xr.Dataset) -> xr.Dataset:
-    if DATASET_DIM_NAME in ds.dims:
-        return ds.mean(DATASET_DIM_NAME)
-    else:
-        return ds
-
-
 def zonal_mean(
     ds: xr.Dataset, latitude: xr.DataArray, bins=np.arange(-90, 91, 2)
 ) -> xr.Dataset:
@@ -302,10 +294,9 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        mse_area_weighted_avg = weighted_mean(
+        return weighted_mean(
             (predicted - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(mse_area_weighted_avg)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -323,10 +314,9 @@ for mask_type in ["global", "sea", "land"]:
         logger.info(f"Preparing mean squared errors for 3D variables, {mask_type}")
         if len(predicted) == 0:
             return xr.Dataset()
-        mse_area_weighted_avg = weighted_mean(
+        return weighted_mean(
             (predicted - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(mse_area_weighted_avg)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -340,10 +330,9 @@ for mask_type in ["global", "sea", "land"]:
         mean = weighted_mean(target, weights=grid.area, dims=HORIZONTAL_DIMS).mean(
             "time"
         )
-        result = weighted_mean(
+        return weighted_mean(
             (mean - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(result)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -364,10 +353,9 @@ for mask_type in ["global", "sea", "land"]:
         mean = weighted_mean(target, weights=grid.area, dims=HORIZONTAL_DIMS).mean(
             "time"
         )
-        result = weighted_mean(
+        return weighted_mean(
             (mean - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(result)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -382,10 +370,9 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        biases_area_weighted_avg = weighted_mean(
+        return weighted_mean(
             predicted - target, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(biases_area_weighted_avg)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -403,10 +390,9 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        biases_area_weighted_avg = weighted_mean(
+        return weighted_mean(
             predicted - target, weights=grid.area, dims=HORIZONTAL_DIMS
         ).mean("time")
-        return _maybe_average_over_dataset(biases_area_weighted_avg)
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -421,8 +407,7 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        zonal_avg_bias = zonal_mean(predicted - target, grid.lat).mean("time")
-        return _maybe_average_over_dataset(zonal_avg_bias)
+        return zonal_mean(predicted - target, grid.lat).mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -440,8 +425,7 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        zonal_avg_bias = zonal_mean(predicted - target, grid.lat).mean("time")
-        return _maybe_average_over_dataset(zonal_avg_bias)
+        return zonal_mean(predicted - target, grid.lat).mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -459,8 +443,7 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        zonal_avg_mse = zonal_mean((predicted - target) ** 2, grid.lat).mean("time")
-        return _maybe_average_over_dataset(zonal_avg_mse)
+        return zonal_mean((predicted - target) ** 2, grid.lat).mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -482,8 +465,7 @@ for mask_type in ["global", "sea", "land"]:
         mean = weighted_mean(target, weights=grid.area, dims=HORIZONTAL_DIMS).mean(
             "time"
         )
-        zonal_avg_variance = zonal_mean((mean - target) ** 2, grid.lat).mean("time")
-        return _maybe_average_over_dataset(zonal_avg_variance)
+        return zonal_mean((mean - target) ** 2, grid.lat).mean("time")
 
 
 for mask_type in ["global", "land", "sea"]:
@@ -503,8 +485,7 @@ for mask_type in ["global", "land", "sea"]:
             dim=pd.Index(["predict", "target"], name=DERIVATION_DIM),
         )
         ds["lon"] = grid["lon"]
-        result = _calc_ds_diurnal_cycle(ds)
-        return _maybe_average_over_dataset(result)
+        return _calc_ds_diurnal_cycle(ds)
 
 
 for domain in ["positive_net_precipitation", "negative_net_precipitation"]:

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -294,9 +294,10 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        return weighted_mean(
+        mse_area_weighted_avg = weighted_mean(
             (predicted - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
-        ).mean("time")
+        )
+        return mse_area_weighted_avg.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -314,9 +315,10 @@ for mask_type in ["global", "sea", "land"]:
         logger.info(f"Preparing mean squared errors for 3D variables, {mask_type}")
         if len(predicted) == 0:
             return xr.Dataset()
-        return weighted_mean(
+        mse_area_weighted_avg = weighted_mean(
             (predicted - target) ** 2, weights=grid.area, dims=HORIZONTAL_DIMS
-        ).mean("time")
+        )
+        return mse_area_weighted_avg.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -370,9 +372,10 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        return weighted_mean(
+        biases_area_weighted_avg = weighted_mean(
             predicted - target, weights=grid.area, dims=HORIZONTAL_DIMS
-        ).mean("time")
+        )
+        return biases_area_weighted_avg.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -390,9 +393,10 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        return weighted_mean(
+        biases_area_weighted_avg = weighted_mean(
             predicted - target, weights=grid.area, dims=HORIZONTAL_DIMS
-        ).mean("time")
+        )
+        return biases_area_weighted_avg.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -407,7 +411,8 @@ for mask_type in ["global", "sea", "land"]:
             diag_arg.verification,
             diag_arg.grid,
         )
-        return zonal_mean(predicted - target, grid.lat).mean("time")
+        zonal_avg_bias = zonal_mean(predicted - target, grid.lat)
+        return zonal_avg_bias.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -425,7 +430,8 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        return zonal_mean(predicted - target, grid.lat).mean("time")
+        zonal_avg_bias = zonal_mean(predicted - target, grid.lat)
+        return zonal_avg_bias.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -443,7 +449,8 @@ for mask_type in ["global", "sea", "land"]:
         )
         if len(predicted) == 0:
             return xr.Dataset()
-        return zonal_mean((predicted - target) ** 2, grid.lat).mean("time")
+        zonal_avg_mse = zonal_mean((predicted - target) ** 2, grid.lat)
+        return zonal_avg_mse.mean("time")
 
 
 for mask_type in ["global", "sea", "land"]:
@@ -465,7 +472,8 @@ for mask_type in ["global", "sea", "land"]:
         mean = weighted_mean(target, weights=grid.area, dims=HORIZONTAL_DIMS).mean(
             "time"
         )
-        return zonal_mean((mean - target) ** 2, grid.lat).mean("time")
+        zonal_avg_variance = zonal_mean((mean - target) ** 2, grid.lat)
+        return zonal_avg_variance.mean("time")
 
 
 for mask_type in ["global", "land", "sea"]:

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -23,6 +23,7 @@ from fv3net.diagnostics.offline._helpers import (
 )
 from fv3net.diagnostics.offline._select import plot_transect
 from fv3net.diagnostics.offline.compute import (
+    DATASET_DIM_NAME,
     DIAGS_NC_NAME,
     TRANSECT_NC_NAME,
     METRICS_JSON_NAME,
@@ -344,6 +345,9 @@ def create_report(args):
         metrics_json_name=METRICS_JSON_NAME,
         metadata_json_name=METADATA_JSON_NAME,
     )
+
+    if DATASET_DIM_NAME in ds_diags.dims:
+        ds_diags = ds_diags.mean(DATASET_DIM_NAME)
 
     if args.commit_sha:
         metadata["commit"] = args.commit_sha

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -287,7 +287,9 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
 
     # scalar metrics for RMSE and bias
     metrics_formatted = []
-    scalar_vars_r2 = sorted([var for var in metrics if "r2" in var])
+    scalar_vars_r2 = sorted(
+        [var for var in metrics if "_r2" in var and "per_dataset" not in var]
+    )
     scalar_vars_bias = [var.replace("_r2", "_bias") for var in scalar_vars_r2]
 
     for var_r2, var_bias in zip(scalar_vars_r2, scalar_vars_bias):

--- a/workflows/diagnostics/tests/offline/test_compute.py
+++ b/workflows/diagnostics/tests/offline/test_compute.py
@@ -13,19 +13,21 @@ from synth import (  # noqa: F401
 )
 
 import fv3fit
+from fv3net.diagnostics.offline._helpers import DATASET_DIM_NAME
 from fv3net.diagnostics.offline import compute
 from fv3net.diagnostics.offline.views.create_report import create_report
 
 import pathlib
 import pytest
 import numpy as np
+import xarray as xr
 import yaml
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def data_path(tmpdir):
+@pytest.fixture(params=["single_dataset", "multiple_datasets"])
+def data_path(tmpdir, request):
     schema_path = pathlib.Path(__file__).parent / "data.zarr.json"
 
     with open(schema_path) as f:
@@ -33,6 +35,8 @@ def data_path(tmpdir):
 
     ranges = {"pressure_thickness_of_atmospheric_layer": synth.Range(0.99, 1.01)}
     ds = synth.generate(schema, ranges)
+    if request.param == "multiple_datasets":
+        ds = xr.concat([ds, ds], dim=DATASET_DIM_NAME)
 
     ds.to_zarr(str(tmpdir), consolidated=True)
     return str(tmpdir)

--- a/workflows/diagnostics/tests/offline/test_helpers.py
+++ b/workflows/diagnostics/tests/offline/test_helpers.py
@@ -1,6 +1,90 @@
+import pytest
 import xarray as xr
 import vcm
-from fv3net.diagnostics.offline._helpers import insert_column_integrated_vars
+from fv3net.diagnostics.offline._helpers import (
+    _compute_r2,
+    _rename_via_replace,
+    DATASET_DIM_NAME,
+    insert_aggregate_bias,
+    insert_column_integrated_vars,
+    insert_r2,
+)
+
+
+def test__rename_via_replace():
+    ds = xr.Dataset({"a_mse": xr.DataArray(0), "b_variance": xr.DataArray(0)})
+    result = _rename_via_replace(ds, "_mse", "_test")
+    expected = xr.Dataset({"a_test": xr.DataArray(0), "b_variance": xr.DataArray(0)})
+    xr.testing.assert_identical(result, expected)
+
+
+def test_insert_aggregate_bias():
+    ds = xr.Dataset(
+        {
+            "a_bias": xr.DataArray([1.0, 1.0], dims=[DATASET_DIM_NAME]),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = insert_aggregate_bias(ds)
+    expected = xr.Dataset(
+        {"a_bias": xr.DataArray(1.0), "a_per_dataset_bias": ds["a_bias"], "b": ds["b"]}
+    )
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("tag", ["_r2", "_per_dataset_r2"])
+def test__compute_r2(tag):
+    ds = xr.Dataset(
+        {
+            "a_mse": xr.DataArray(1.0),
+            "a_variance": xr.DataArray(2.0),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = _compute_r2(ds, tag=tag)
+    expected = xr.Dataset({f"a{tag}": 0.5})
+    xr.testing.assert_identical(result, expected)
+
+
+def test_insert_r2_without_dataset_dim():
+    ds = xr.Dataset(
+        {
+            "a_mse": xr.DataArray(1.0),
+            "a_variance": xr.DataArray(2.0),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = insert_r2(ds)
+    expected = xr.Dataset(
+        {
+            "a_r2": xr.DataArray(0.5),
+            "a_mse": xr.DataArray(1.0),
+            "a_variance": xr.DataArray(2.0),
+            "b": xr.DataArray(0),
+        }
+    )
+    xr.testing.assert_identical(result, expected)
+
+
+def test_insert_r2_with_dataset_dim():
+    ds = xr.Dataset(
+        {
+            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
+            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = insert_r2(ds)
+    expected = xr.Dataset(
+        {
+            "a_per_dataset_r2": xr.DataArray([0.5, 0.75], dims=[DATASET_DIM_NAME]),
+            "a_r2": xr.DataArray(0.7),
+            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
+            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
+            "b": xr.DataArray(0),
+        }
+    )
+    xr.testing.assert_identical(result, expected)
 
 
 def test_insert_column_integrated_vars():

--- a/workflows/diagnostics/tests/offline/test_helpers.py
+++ b/workflows/diagnostics/tests/offline/test_helpers.py
@@ -1,20 +1,54 @@
-import pytest
 import xarray as xr
 import vcm
 from fv3net.diagnostics.offline._helpers import (
-    _compute_r2,
-    _rename_via_replace,
     DATASET_DIM_NAME,
+    compute_r2,
     insert_aggregate_bias,
+    insert_aggregate_r2,
     insert_column_integrated_vars,
-    insert_r2,
+    rename_via_replace,
 )
 
 
-def test__rename_via_replace():
+def test_compute_r2():
+    ds = xr.Dataset(
+        {
+            "a_mse": xr.DataArray(1.0),
+            "a_variance": xr.DataArray(2.0),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = compute_r2(ds)
+    expected = xr.Dataset({"a_r2": 0.5})
+    xr.testing.assert_identical(result, expected)
+
+
+def test_rename_via_replace():
     ds = xr.Dataset({"a_mse": xr.DataArray(0), "b_variance": xr.DataArray(0)})
-    result = _rename_via_replace(ds, "_mse", "_test")
+    result = rename_via_replace(ds, "_mse", "_test")
     expected = xr.Dataset({"a_test": xr.DataArray(0), "b_variance": xr.DataArray(0)})
+    xr.testing.assert_identical(result, expected)
+
+
+def test_insert_aggregate_r2():
+    ds = xr.Dataset(
+        {
+            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
+            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
+            "a_r2": xr.DataArray([0.5, 0.75], dims=[DATASET_DIM_NAME]),
+            "b": xr.DataArray(0),
+        }
+    )
+    result = insert_aggregate_r2(ds)
+    expected = xr.Dataset(
+        {
+            "a_per_dataset_r2": xr.DataArray([0.5, 0.75], dims=[DATASET_DIM_NAME]),
+            "a_r2": xr.DataArray(0.7),
+            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
+            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
+            "b": xr.DataArray(0),
+        }
+    )
     xr.testing.assert_identical(result, expected)
 
 
@@ -27,60 +61,9 @@ def test_insert_aggregate_bias():
     )
     result = insert_aggregate_bias(ds)
     expected = xr.Dataset(
-        {"a_bias": xr.DataArray(1.0), "a_per_dataset_bias": ds["a_bias"], "b": ds["b"]}
-    )
-    xr.testing.assert_identical(result, expected)
-
-
-@pytest.mark.parametrize("tag", ["_r2", "_per_dataset_r2"])
-def test__compute_r2(tag):
-    ds = xr.Dataset(
         {
-            "a_mse": xr.DataArray(1.0),
-            "a_variance": xr.DataArray(2.0),
-            "b": xr.DataArray(0),
-        }
-    )
-    result = _compute_r2(ds, tag=tag)
-    expected = xr.Dataset({f"a{tag}": 0.5})
-    xr.testing.assert_identical(result, expected)
-
-
-def test_insert_r2_without_dataset_dim():
-    ds = xr.Dataset(
-        {
-            "a_mse": xr.DataArray(1.0),
-            "a_variance": xr.DataArray(2.0),
-            "b": xr.DataArray(0),
-        }
-    )
-    result = insert_r2(ds)
-    expected = xr.Dataset(
-        {
-            "a_r2": xr.DataArray(0.5),
-            "a_mse": xr.DataArray(1.0),
-            "a_variance": xr.DataArray(2.0),
-            "b": xr.DataArray(0),
-        }
-    )
-    xr.testing.assert_identical(result, expected)
-
-
-def test_insert_r2_with_dataset_dim():
-    ds = xr.Dataset(
-        {
-            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
-            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
-            "b": xr.DataArray(0),
-        }
-    )
-    result = insert_r2(ds)
-    expected = xr.Dataset(
-        {
-            "a_per_dataset_r2": xr.DataArray([0.5, 0.75], dims=[DATASET_DIM_NAME]),
-            "a_r2": xr.DataArray(0.7),
-            "a_mse": xr.DataArray([0.5, 1.0], dims=[DATASET_DIM_NAME]),
-            "a_variance": xr.DataArray([1.0, 4.0], dims=[DATASET_DIM_NAME]),
+            "a_bias": xr.DataArray(1.0),
+            "a_per_dataset_bias": xr.DataArray([1.0, 1.0], dims=[DATASET_DIM_NAME]),
             "b": xr.DataArray(0),
         }
     )


### PR DESCRIPTION
This PR makes changes to re-enable creating an offline report using a test dataset with a `"dataset"` dimension.  As before, the metrics displayed are computed in the aggregate across all datasets represented (i.e. not on a dataset by dataset basis).  

Significant internal changes:
- When a `"dataset"` dimension exists in the batches, r2 metrics are computed both in the aggregate and for each dataset.  The aggregate r2 metrics are tagged with just `"_r2"` in their names, while the per dataset metrics are tagged with `"_per_dataset_r2"`.  This allows the aggregate metrics to be easily displayed in the report.
- Something similar is done for the `"_bias"` metrics.  This is required so that scalar versions end up appropriately in the `scalar_metrics.json` file required by the report.
- Other metrics are purely saved on a dataset by dataset basis, and are averaged across datasets after the diagnostics are read in when the report is generated.

An example report can be found [here](https://storage.googleapis.com/vcm-ml-public/spencerc/2021-01-28/n2f-25km-offline-reports/tq-nn-snoalb-tapered-25-clipped-updated-pr-seed-0/index.html).  The corresponding diagnostics files can be found in this directory: `gs://vcm-ml-experiments/spencerc/2022-01-20-nudge-to-25-km-ml-models/offline_diags/tq-nn-snoalb-tapered-25-clipped-updated-pr-seed-0`.  If we read in the `offline_diagnostics.nc` from that directory and look at a per dataset r2 variable, we get something like this:

```
>>> ds.column_integrated_dq1_per_dataset_r2_2d_global
<xarray.DataArray 'column_integrated_dq1_per_dataset_r2_2d_global' (dataset: 4)>
array([0.169668, 0.181235, 0.182179, 0.184461])
Coordinates:
  * dataset  (dataset) object 'Minus 4 K' 'Unperturbed' 'Plus 4 K' 'Plus 8 K'
```

- [x] Tests added

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
