### PR TITLE
offline diags: grab snapshot from batches

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
@@ -12,10 +12,8 @@ def nearest_time_batch_index(
 ):
     min_index = 0
     min_distance = min(abs(np.array(time_batches[0]) - time))
-    print(min_distance)
     for index, time_batch in enumerate(time_batches):
         distance = min(abs(np.array(time_batch) - time))
-        print(distance)
         if distance < min_distance:
             min_index = index
     return min_index

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
@@ -1,16 +1,24 @@
 import numpy as np
 from typing import Sequence
 import xarray as xr
+import cftime
 
 from vcm.select import meridional_ring
 import vcm
 
 
-def nearest_time(select_time: str, times: Sequence[str]):
-    select_datetime = vcm.parse_datetime_from_str(select_time)
-    datetimes = np.vectorize(vcm.parse_datetime_from_str)(times)
-    closest_datetime = min(datetimes, key=lambda d: abs(d - select_datetime))
-    return vcm.encode_time(closest_datetime)
+def nearest_time_batch_index(
+    time: cftime.DatetimeJulian, time_batches: Sequence[Sequence[cftime.DatetimeJulian]]
+):
+    min_index = 0
+    min_distance = min(abs(np.array(time_batches[0]) - time))
+    print(min_distance)
+    for index, time_batch in enumerate(time_batches):
+        distance = min(abs(np.array(time_batch) - time))
+        print(distance)
+        if distance < min_distance:
+            min_index = index
+    return min_index
 
 
 def meridional_transect(ds: xr.Dataset):

--- a/workflows/diagnostics/tests/offline/test__select.py
+++ b/workflows/diagnostics/tests/offline/test__select.py
@@ -1,15 +1,30 @@
 import pytest
-from fv3net.diagnostics.offline._select import nearest_time
+import cftime
+from fv3net.diagnostics.offline._select import nearest_time_batch_index
+
+
+BATCH_ONE = [
+    cftime.DatetimeJulian(2016, 8, 1, 11),
+    cftime.DatetimeJulian(2016, 8, 1, 14),
+]
+BATCH_TWO = [
+    cftime.DatetimeJulian(2016, 8, 1, 17),
+    cftime.DatetimeJulian(2016, 8, 1, 20),
+]
+BATCH_THREE = [
+    cftime.DatetimeJulian(2016, 8, 1, 11, 30),
+    cftime.DatetimeJulian(2016, 8, 1, 20),
+]
 
 
 @pytest.mark.parametrize(
-    "select_time, closest_key",
+    "time, time_batches, expected_index",
     [
-        ("20160801.010000", "20160801.000000"),
-        ("20160801.200000", "20160801.180000"),
-        ("20190801.000000", "20170801.180000"),
+        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE], 0,),
+        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE, BATCH_TWO], 0,),
+        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE, BATCH_THREE], 1,),
     ],
 )
-def test_nearest_time(select_time, closest_key):
-    times = ["20160801.000000", "20160801.180000", "20170801.180000"]
-    assert nearest_time(select_time, times) == closest_key
+def test_nearest_time(time, time_batches, expected_index):
+    index = nearest_time_batch_index(time, time_batches)
+    assert index == expected_index


### PR DESCRIPTION
This ensures that the data that goes into the offline snapshot diagnostic has undergone the same transformations as the other "batched" data.