### PR TITLE
Emulation memory optimization

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/load.py
+++ b/external/fv3fit/fv3fit/emulation/data/load.py
@@ -5,6 +5,7 @@ import xarray as xr
 from toolz.functoolz import compose_left
 from typing import Callable, Optional, Sequence
 
+from loaders.batches import shuffle
 from .transforms import open_netcdf_dataset
 from .io import get_nc_files
 
@@ -12,7 +13,9 @@ from .io import get_nc_files
 logger = logging.getLogger(__name__)
 
 
-def _seq_to_tf_dataset(source: Sequence, transform: Callable,) -> tf.data.Dataset:
+def _seq_to_tf_dataset(
+    source: Sequence, transform: Callable, shuffle_gen: bool = True
+) -> tf.data.Dataset:
     """
     A general function to convert from a sequence into a tensorflow dataset
     to be used for ML model training.
@@ -25,7 +28,8 @@ def _seq_to_tf_dataset(source: Sequence, transform: Callable,) -> tf.data.Datase
     """
 
     def get_generator():
-        for batch in source:
+        seq = shuffle(source) if shuffle_gen else source
+        for batch in seq:
             output = transform(batch)
             yield tf.data.Dataset.from_tensor_slices(output)
 

--- a/external/fv3fit/fv3fit/emulation/data/load.py
+++ b/external/fv3fit/fv3fit/emulation/data/load.py
@@ -5,7 +5,6 @@ import xarray as xr
 from toolz.functoolz import compose_left
 from typing import Callable, Optional, Sequence
 
-from loaders.batches import shuffle
 from .transforms import open_netcdf_dataset
 from .io import get_nc_files
 
@@ -28,8 +27,7 @@ def _seq_to_tf_dataset(
     """
 
     def get_generator():
-        seq = shuffle(source) if shuffle_gen else source
-        for batch in seq:
+        for batch in source:
             output = transform(batch)
             yield tf.data.Dataset.from_tensor_slices(output)
 
@@ -38,7 +36,7 @@ def _seq_to_tf_dataset(
     tf_ds = tf.data.Dataset.from_generator(get_generator, output_signature=signature)
 
     # Flat map goes from generating tf_dataset -> generating tensors
-    tf_ds = tf_ds.prefetch(tf.data.AUTOTUNE).flat_map(lambda x: x)
+    tf_ds = tf_ds.flat_map(lambda x: x)
 
     return tf_ds
 

--- a/external/fv3fit/fv3fit/emulation/data/load.py
+++ b/external/fv3fit/fv3fit/emulation/data/load.py
@@ -12,9 +12,7 @@ from .io import get_nc_files
 logger = logging.getLogger(__name__)
 
 
-def _seq_to_tf_dataset(
-    source: Sequence, transform: Callable, shuffle_gen: bool = True
-) -> tf.data.Dataset:
+def _seq_to_tf_dataset(source: Sequence, transform: Callable) -> tf.data.Dataset:
     """
     A general function to convert from a sequence into a tensorflow dataset
     to be used for ML model training.

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -273,7 +273,7 @@ def main(config: TrainConfig, seed: int = 0):
         config.test_url, config.nfiles_valid, config.model_variables
     )
 
-    train_set = next(iter(train_ds.shuffle(1_000_000).batch(50_000)))
+    train_set = next(iter(train_ds.batch(138_400)))
     transform = config.build_transform(train_set)
 
     train_ds = train_ds.map(transform.forward)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -104,7 +104,7 @@ class TrainConfig:
     batch_size: int = 128
     valid_freq: int = 5
     verbose: int = 2
-    shuffle_buffer_size: Optional[int] = 100_000
+    shuffle_buffer_size: Optional[int] = 13840
     checkpoint_model: bool = True
     log_level: str = "INFO"
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -6,7 +6,6 @@ import json
 import logging
 import numpy as np
 import os
-import tempfile
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 import tensorflow as tf
@@ -85,8 +84,6 @@ class TrainConfig:
             during training
         checkpoint_model: if true, save a checkpoint after each epoch
         log_level: what logging level to use
-        cache: Use a cache for training/testing batches. Speeds up training for
-            I/O bound architectures.  Always disabled for rnn-v1 architectures.
     """
 
     train_url: str
@@ -110,7 +107,6 @@ class TrainConfig:
     shuffle_buffer_size: Optional[int] = 100_000
     checkpoint_model: bool = True
     log_level: str = "INFO"
-    cache: bool = True
 
     @property
     def transform_factory(self) -> ComposedTransformFactory:
@@ -249,15 +245,6 @@ class TrainConfig:
             set(self._model.input_variables) | set(self._model.output_variables)
         )
 
-    def __post_init__(self) -> None:
-        if (
-            self.model is not None
-            and "rnn-v1" in self.model.architecture.name
-            and self.cache
-        ):
-            logger.warn("Caching disabled for rnn-v1 architectures due to memory leak")
-            self.cache = False
-
 
 def save_jacobians(std_jacobians, dir_, filename="jacobians.npz"):
     with put_dir(dir_) as tmpdir:
@@ -306,27 +293,20 @@ def main(config: TrainConfig, seed: int = 0):
             )
         )
 
-    with tempfile.TemporaryDirectory() as train_temp:
-        with tempfile.TemporaryDirectory() as test_temp:
+    train_ds_batched = train_ds.batch(config.batch_size)
+    test_ds_batched = test_ds.batch(config.batch_size)
 
-            train_ds_batched = train_ds.batch(config.batch_size)
-            test_ds_batched = test_ds.batch(config.batch_size)
-
-            if config.cache:
-                train_ds_batched = train_ds_batched.cache(train_temp)
-                test_ds_batched = test_ds_batched.cache(test_temp)
-
-            history = train(
-                model,
-                train_ds_batched,
-                config.build_loss(train_set, transform),
-                optimizer=config.loss.optimizer.instance,
-                epochs=config.epochs,
-                validation_data=test_ds_batched,
-                validation_freq=config.valid_freq,
-                verbose=config.verbose,
-                callbacks=callbacks,
-            )
+    history = train(
+        model,
+        train_ds_batched,
+        config.build_loss(train_set, transform),
+        optimizer=config.loss.optimizer.instance,
+        epochs=config.epochs,
+        validation_data=test_ds_batched,
+        validation_freq=config.valid_freq,
+        verbose=config.verbose,
+        callbacks=callbacks,
+    )
 
     logger.debug("Training complete")
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -104,7 +104,7 @@ class TrainConfig:
     batch_size: int = 128
     valid_freq: int = 5
     verbose: int = 2
-    shuffle_buffer_size: Optional[int] = 13840
+    shuffle_buffer_size: Optional[int] = 13824
     checkpoint_model: bool = True
     log_level: str = "INFO"
 
@@ -273,7 +273,7 @@ def main(config: TrainConfig, seed: int = 0):
         config.test_url, config.nfiles_valid, config.model_variables
     )
 
-    train_set = next(iter(train_ds.batch(138_400)))
+    train_set = next(iter(train_ds.batch(150_000)))
     transform = config.build_transform(train_set)
 
     train_ds = train_ds.map(transform.forward)
@@ -293,8 +293,8 @@ def main(config: TrainConfig, seed: int = 0):
             )
         )
 
-    train_ds_batched = train_ds.batch(config.batch_size)
-    test_ds_batched = test_ds.batch(config.batch_size)
+    train_ds_batched = train_ds.batch(config.batch_size).prefetch(tf.data.AUTOTUNE)
+    test_ds_batched = test_ds.batch(config.batch_size).prefetch(tf.data.AUTOTUNE)
 
     history = train(
         model,

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -131,21 +131,6 @@ def test_TrainConfig_from_args_sysargv(monkeypatch):
     assert config.model.architecture.name == "rnn"
 
 
-@pytest.mark.parametrize(
-    "arch_key, expected_cache",
-    [("dense", True), ("rnn-v1", False), ("rnn-v1-shared-weights", False)],
-)
-def test_rnn_v1_cache_disable(arch_key, expected_cache):
-
-    default = get_default_config()
-    d = asdict(default)
-    d["cache"] = True
-    d["model"]["architecture"]["name"] = arch_key
-    config = TrainConfig.from_dict(d)
-
-    assert config.cache == expected_cache
-
-
 @pytest.mark.regression
 @pytest.mark.slow
 def test_training_entry_integration(tmp_path):

--- a/projects/microphysics/train/rnn.yaml
+++ b/projects/microphysics/train/rnn.yaml
@@ -8,7 +8,6 @@ valid_freq: 2
 out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
 train_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/train
 test_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/test
-cache: false
 tensor_transform:
   - to: log_cloud_input
     source: cloud_water_mixing_ratio_input


### PR DESCRIPTION
Prefetch before shuffle in the tf dataset pipeline was causing a larger amount of memory growth per epoch.  This PR adds some adjustments to reduce memory usage.

 * Remove large initial shuffle buffer for creating a sample dataset in favor of loading **more** files (pre-shuffled)
 * Change prefetch to be called after shuffling and batching
 * Lower the epoch shuffle buffer size to 6 tiles (13824 samples)

I also removed some old caching code.  `TrainConfig` no longer uses/allows the `cache` parameter.