### PR TITLE
Fix snapshot selection for unordered times in batches

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
@@ -19,6 +19,10 @@ def nearest_time_batch_index(
     return min_index
 
 
+def select_snapshot(batch: xr.Dataset, time: cftime.DatetimeJulian) -> xr.Dataset:
+    return batch.sortby("time").sel(time=time, method="nearest")
+
+
 def meridional_transect(ds: xr.Dataset):
     transect_coords = meridional_ring()
     return vcm.interpolate_unstructured(ds, transect_coords)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -29,7 +29,7 @@ from ._helpers import (
     insert_rmse,
     insert_column_integrated_vars,
 )
-from ._select import meridional_transect, nearest_time_batch_index
+from ._select import meridional_transect, nearest_time_batch_index, select_snapshot
 
 
 handler = logging.StreamHandler(sys.stdout)
@@ -324,7 +324,7 @@ def main(args):
         snapshot_index = nearest_time_batch_index(
             snapshot_time, [batch.time.values for batch in batches]
         )
-        ds_snapshot = batches[snapshot_index].sel(time=snapshot_time, method="nearest")
+        ds_snapshot = select_snapshot(batches[snapshot_index], snapshot_time)
 
         vertical_vars = [
             var for var in model.output_variables if is_3d(ds_snapshot[var])

--- a/workflows/diagnostics/tests/offline/test__select.py
+++ b/workflows/diagnostics/tests/offline/test__select.py
@@ -1,6 +1,7 @@
 import pytest
 import cftime
-from fv3net.diagnostics.offline._select import nearest_time_batch_index
+import xarray as xr
+from fv3net.diagnostics.offline._select import nearest_time_batch_index, select_snapshot
 
 
 BATCH_ONE = [
@@ -28,3 +29,25 @@ BATCH_THREE = [
 def test_nearest_time(time, time_batches, expected_index):
     index = nearest_time_batch_index(time, time_batches)
     assert index == expected_index
+
+
+ORDERED_TIMES = [
+    cftime.DatetimeJulian(2000, 1, 1),
+    cftime.DatetimeJulian(2000, 1, 7),
+    cftime.DatetimeJulian(2000, 1, 15),
+]
+UNORDERED_TIMES = [
+    cftime.DatetimeJulian(2000, 1, 7),
+    cftime.DatetimeJulian(2000, 1, 15),
+    cftime.DatetimeJulian(2000, 1, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "times", [ORDERED_TIMES, UNORDERED_TIMES], ids=["ordered-times", "unordered-times"]
+)
+def test_select_snapshot(times):
+    batch = xr.Dataset(data_vars={"foo": (["time"], [0, 1, 2])}, coords={"time": times})
+    result = select_snapshot(batch, cftime.DatetimeJulian(2000, 1, 5))
+    expected = batch.sel(time=cftime.DatetimeJulian(2000, 1, 7))
+    xr.testing.assert_identical(result, expected)


### PR DESCRIPTION
Sometimes the times in data batches passed to the offline report can be unordered.  To use the `method="nearest"` approach with `xr.Dataset.sel`, the index must be ordered; otherwise an error like this will be raised:
```
>>> import cftime
>>> import xarray as xr
>>> UNORDERED_TIMES = [
...     cftime.DatetimeJulian(2000, 1, 7),
...     cftime.DatetimeJulian(2000, 1, 15),
...     cftime.DatetimeJulian(2000, 1, 1),
... ]
>>> batch = xr.Dataset(data_vars={"foo": (["time"], [0, 1, 2])}, coords={"time": UNORDERED_TIMES})
>>> batch.sel(time=cftime.DatetimeJulian(2000, 1, 5), method="nearest")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/core/dataset.py", line 2474, in sel
    pos_indexers, new_indexes = remap_label_indexers(
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/core/coordinates.py", line 421, in remap_label_indexers
    pos_indexers, new_indexes = indexing.remap_label_indexers(
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/core/indexing.py", line 117, in remap_label_indexers
    idxr, new_idx = index.query(labels, method=method, tolerance=tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/core/indexes.py", line 224, in query
    indexer = index.get_loc(
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/coding/cftimeindex.py", line 466, in get_loc
    return pd.Index.get_loc(self, key, method=method, tolerance=tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3371, in get_loc
    indexer = self.get_indexer([key], method=method, tolerance=tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3486, in get_indexer
    return self._get_indexer(target, method, limit, tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3510, in _get_indexer
    indexer = self._get_nearest_indexer(target, limit, tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/xarray/coding/cftimeindex.py", line 437, in _get_nearest_indexer
    left_indexer = self.get_indexer(target, "pad", limit=limit)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3486, in get_indexer
    return self._get_indexer(target, method, limit, tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3508, in _get_indexer
    indexer = self._get_fill_indexer(target, method, limit, tolerance)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3584, in _get_fill_indexer
    indexer = self._get_fill_indexer_searchsorted(target, method, limit)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3608, in _get_fill_indexer_searchsorted
    indexer[nonexact] = self._searchsorted_monotonic(target[nonexact], side)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 5765, in _searchsorted_monotonic
    raise ValueError("index must be monotonic increasing or decreasing")
ValueError: index must be monotonic increasing or decreasing
```

This makes sure to sort the `batch` Dataset along the `"time"` dimension before selecting the snapshot.  

- [ ] Tests added

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
