### PR TITLE
improve memory use with libtcmalloc

### DIFF
--- a/docker/fv3fit/Dockerfile
+++ b/docker/fv3fit/Dockerfile
@@ -30,3 +30,6 @@ RUN pip3 install --no-dependencies /fv3net/external/loaders
 
 COPY external/fv3fit /fv3net/external/fv3fit
 RUN pip3 install --no-dependencies /fv3net/external/fv3fit
+
+# Greatly improves memory performance of tensorflow training
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4


### PR DESCRIPTION
Memory performance is still poor even after merging #1704. Setting this single environment variable makes a dramatic difference! 

![ld_preload_helps](https://user-images.githubusercontent.com/1386642/159412152-273c8f4b-10bb-462d-a0e3-67be8f1c16d3.png)

This plot is produced by running the following benchmark w/ and w/o the LD_PRELOAD flag:
```
from fv3fit.train_microphysics import TrainConfig, main
import os

os.environ["WANDB_RUN_GROUP"] = "debug-memory"

config = TrainConfig.from_yaml_path("rnn.yaml")
config.use_wandb = False
config.model.architecture.name = "dense"
config.model.architecture.kwargs = {}
config.checkpoint_model = False
config.epochs = 10
config.nfiles = 10
config.nfiles_valid = 1
config.out_url = "local1"
main(config)
```
