### PR TITLE
Tfdataset using map instead of from_generator

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
+++ b/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
@@ -1,25 +1,29 @@
+import logging
 from typing import Sequence
 import tensorflow as tf
+
 import vcm
 from fv3fit.emulation.data.io import get_nc_files
+from .transforms import open_netcdf_dataset
 
 __all__ = ["netcdf_url_to_dataset"]
+logger = logging.getLogger(__name__)
 
 
-def read_variables_as_dict(fs, url, variables):
+def read_variables_as_dict(url, variables):
     sig = (tf.float32,) * len(variables)
     # tf.py_function can only wrap functions which output tuples of tensors, not
     # dicts
     outputs = tf.py_function(
-        lambda url: read_variables_greedily_as_tuple(fs, url, variables), [url], sig
+        lambda url: read_variables_greedily_as_tuple(url, variables), [url], sig
     )
     return dict(zip(variables, outputs))
 
 
-def read_variables_greedily_as_tuple(fs, url, variables):
+def read_variables_greedily_as_tuple(url, variables):
     url = url.numpy().decode()
-    print(f"opening {url}")
-    ds = vcm.DerivedMapping(vcm.open_remote_nc(fs, url))
+    logger.debug(f"opening {url}")
+    ds = open_netcdf_dataset(url)
     return tuple([tf.convert_to_tensor(ds[v], dtype=tf.float32) for v in variables])
 
 
@@ -43,7 +47,7 @@ def netcdf_url_to_dataset(
     d = tf.data.Dataset.from_tensor_slices(sorted(files))
     if shuffle:
         d = d.shuffle(100_000)
-    return d.map(lambda url: read_variables_as_dict(fs, url, variables))
+    return d.map(lambda url: read_variables_as_dict(url, variables))
 
 
 def load_samples(train_dataset, n_train):

--- a/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
+++ b/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
@@ -22,7 +22,7 @@ def read_variables_as_tfdataset(url, variables, transform):
     )
 
     d = dict(zip(variables, outputs))
-    return tf.data.Dataset.from_tensor_slices(d, num_parallel_calls=tf.data.AUTOTUNE)
+    return tf.data.Dataset.from_tensor_slices(d)
 
 
 def read_variables_greedily_as_tuple(url, variables, transform):
@@ -65,7 +65,8 @@ def netcdf_url_to_dataset(
         d = d.shuffle(len(files))
 
     return d.interleave(
-        lambda url: read_variables_as_tfdataset(url, variables, transform)
+        lambda url: read_variables_as_tfdataset(url, variables, transform),
+        num_parallel_calls=tf.data.AUTOTUNE,
     )
 
 

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -240,12 +240,13 @@ class TrainConfig:
     def open_dataset(
         self, url: str, nfiles: Optional[int], required_variables: Set[str],
     ) -> tf.data.Dataset:
+        open_fn = self.transform.get_pipeline(required_variables)
+
         if self.use_generator:
             # original tf dataset routine, uses a generator underneath
-            nc_open_fn = self.transform.get_pipeline(required_variables)
             return nc_dir_to_tfdataset(
                 url,
-                nc_open_fn,
+                open_fn,
                 nfiles=nfiles,
                 shuffle=True,
                 random_state=np.random.RandomState(0),
@@ -253,7 +254,7 @@ class TrainConfig:
         else:
             # uses map across filenames to create a dataset
             return netcdf_url_to_dataset(
-                url, list(required_variables), shuffle=True, nfiles=nfiles
+                url, list(required_variables), open_fn, shuffle=True, nfiles=nfiles
             )
 
     @property

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -290,12 +290,11 @@ def main(config: TrainConfig, seed: int = 0):
         config.test_url, config.nfiles_valid, config.model_variables
     )
 
+    train_set = next(iter(train_ds.batch(150_000)))
+    transform = config.build_transform(train_set)
+
     if config.shuffle_buffer_size is not None:
         train_ds = train_ds.shuffle(config.shuffle_buffer_size)
-
-    train_set = next(iter(train_ds.batch(50_000)))
-
-    transform = config.build_transform(train_set)
 
     train_ds = train_ds.map(transform.forward)
     test_ds = test_ds.map(transform.forward)


### PR DESCRIPTION
The using `tf.Dataset.map` to map across netcdf filenames, open them, and convert to tensors allows for use of interleave, which can parallelize data input, and allows for reshuffling the file order with every epoch (not possible w/ generator currently).  

From our memory leak investigation, shuffling across samples incurs a severe input-pipeline performance cost, but is required to randomize our `from_generator` input pipeline.  Based on tensorflow profileing~60% of the time is spent waiting for inputs when sample shuffling is used vs. 30% when no sample shuffling is performed for i/o bound model training.  (Tested with 100 files over 10 epochs)

Using map, we might be able to remove the need for sample shuffling since interleave will mix samples from shuffled file ordering.  Using a draft PR to test that offline performance is not significantly reduced with production-like workflow.