### PR TITLE
Allow using auxiliary input variables in transformed prediction

### DIFF
--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -211,7 +211,7 @@ class TransformedPredictor(Predictor):
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
         base_prediction = self.base_model.predict(X)
-        return self.output_transform.apply(base_prediction)
+        return self.output_transform.apply(xr.merge([X, base_prediction]))
 
     def dump(self, path: str):
         base_model_path = os.path.join(path, self._BASE_MODEL_SUBDIR)

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -210,8 +210,13 @@ class TransformedPredictor(Predictor):
         super().__init__(sorted(list(input_variables)), sorted(list(output_variables)))
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
-        base_prediction = self.base_model.predict(X)
-        return self.output_transform.apply(xr.merge([X, base_prediction]))
+        prediction = self.base_model.predict(X)
+        transform_inputs = xr.merge([prediction, X], compat="override")
+        transformed_prediction = self.output_transform.apply(transform_inputs)
+        transformed_outputs = transformed_prediction[
+            self.output_transform.output_variables
+        ]
+        return xr.merge([prediction, transformed_outputs])
 
     def dump(self, path: str):
         base_model_path = os.path.join(path, self._BASE_MODEL_SUBDIR)

--- a/external/fv3fit/tests/test_transformed_predictor.py
+++ b/external/fv3fit/tests/test_transformed_predictor.py
@@ -21,6 +21,17 @@ def test_transformed_prediction():
     assert "Qm" in output
 
 
+def test_transformed_prediction_additional_required_input():
+    transformed_model = fv3fit.TransformedPredictor(
+        fv3fit.testing.ConstantOutputPredictor(["input"], ["Q1"]), transforms
+    )
+    input_dataset = xr.Dataset(
+        {"input": xr.DataArray([0, 1, 2]), "Q2": xr.DataArray([0, 1, 2])}
+    )
+    output = transformed_model.predict(input_dataset)
+    assert "Qm" in output
+
+
 def test_transformed_predictor_inputs_outputs():
     transformed_model = fv3fit.TransformedPredictor(base_model, transforms)
     assert transformed_model.input_variables == ["input"]

--- a/external/fv3fit/tests/test_transformed_predictor.py
+++ b/external/fv3fit/tests/test_transformed_predictor.py
@@ -1,4 +1,5 @@
 import xarray as xr
+import numpy as np
 import fv3fit
 import vcm
 
@@ -30,6 +31,28 @@ def test_transformed_prediction_additional_required_input():
     )
     output = transformed_model.predict(input_dataset)
     assert "Qm" in output
+    assert "Q2" not in output
+
+
+def test_transformed_prediction_when_inputs_contain_an_output():
+    # this case can arise in offline diags
+    base = fv3fit.testing.ConstantOutputPredictor(["input"], ["Q1"])
+    base.set_outputs(Q1=np.array([5, 6, 7]))
+    transformed_model = fv3fit.TransformedPredictor(base, transforms)
+    input_dataset = xr.Dataset(
+        {
+            "input": xr.DataArray([0, 1, 2]),
+            "Q2": xr.DataArray([0, 1, 2], dims=["z"]),
+            "Qm": xr.DataArray([3, 4, 5], dims=["z"]),
+        }
+    )
+    base_output = base.predict(input_dataset)
+    merged_output = {"Q1": base_output["Q1"], "Q2": input_dataset["Q2"]}
+    expected_Qm = transforms[0].apply(merged_output)["Qm"]
+    transformed_model_output = transformed_model.predict(input_dataset)
+    assert "Qm" in transformed_model_output
+    assert "Q2" not in transformed_model_output
+    xr.testing.assert_allclose(expected_Qm, transformed_model_output["Qm"])
 
 
 def test_transformed_predictor_inputs_outputs():


### PR DESCRIPTION
This PR allows `TransformedPredictor` to use variables from the input dataset provided to `.predict` for its transformations. This is necessary for transformations which use an auxiliary variable that is not output by the wrapped `.predict` method.

Significant internal changes:
- merge input dataset with wrapped `.predict` output dataset
- only include the output variables in the dataset returned by `TransformedPredictor.predict`

- [ ] Tests added