### PR TITLE
Perform dataset transformations on batched data for performance, shuffling

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/load.py
+++ b/external/fv3fit/fv3fit/emulation/data/load.py
@@ -27,7 +27,7 @@ def nc_files_to_tf_dataset(
     """
 
     transform = compose_left(*[open_netcdf_dataset, convert])
-    return seq_to_tfdataset(files, transform).prefetch(tf.data.AUTOTUNE)
+    return seq_to_tfdataset(files, transform).unbatch().prefetch(tf.data.AUTOTUNE)
 
 
 def nc_dir_to_tfdataset(

--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -20,7 +20,7 @@ from fv3fit.keras._models.shared.utils import (
     full_standard_normalized_input,
 )
 from fv3fit import tfdataset
-from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping
+from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping, apply_to_tuple
 
 logger = logging.getLogger(__file__)
 
@@ -45,6 +45,8 @@ class ConvolutionalHyperparameters(Hyperparameters):
         training_loop: configuration of training loop
         loss: configuration of loss functions, will be applied separately to
             each output variable
+        normalization_fit_samples: number of samples to use when fitting normalization,
+            note that one sample is one tile
     """
 
     input_variables: List[str]
@@ -62,6 +64,7 @@ class ConvolutionalHyperparameters(Hyperparameters):
         default_factory=dict
     )
     loss: LossConfig = LossConfig(scaling="standard", loss_type="mse")
+    normalization_fit_samples: int = 30
 
     @property
     def variables(self) -> Set[str]:
@@ -81,20 +84,28 @@ def get_Xy_dataset(
     requested input variables and the second containing
     the requested output variables.
     """
-    # tile, x, y, z
-    data = data.map(apply_to_mapping(ensure_nd(4)))
+    # sample, tile, x, y, z
+    data = data.map(apply_to_mapping(ensure_nd(5)))
+
     if clip_config is not None:
-        y_source = data.map(clip_sample(clip_config))
+        clip_function = clip_sample(clip_config)
     else:
-        y_source = data
-    y = y_source.map(select_keys(output_variables))
-    X = data.map(apply_to_mapping(append_halos_tensor(n_halo))).map(
-        select_keys(input_variables)
-    )
-    # now that we have halos, we need to collapse tile back into the sample dimension
-    X = X.unbatch()
-    y = y.unbatch()
-    return tf.data.Dataset.zip((X, y))
+
+        def clip_function(data):
+            return data
+
+    def map_fn(data):
+        # clipping of inputs happens within the keras model, we don't clip at the
+        # data layer so that the model still takes full-sized inputs when used
+        # in production
+        x = apply_to_tuple(append_halos_tensor(n_halo))(
+            select_keys(input_variables, data)
+        )
+        y = select_keys(output_variables, clip_function(data))
+        return x, y
+
+    # unbatch to fold sample dimension into tile dimension as new sample dimension
+    return data.map(map_fn).unbatch()
 
 
 @register_training_function("convolutional", ConvolutionalHyperparameters)
@@ -125,7 +136,13 @@ def train_convolutional_model(
     train_Xy = get_Xy(data=train_batches, clip_config=hyperparameters.clip_config)
     # need unclipped shapes for build_model
     # have to batch data so we can take statistics for scaling transforms
-    X, y = next(iter(get_Xy(data=train_batches, clip_config=None).batch(10_000_000)))
+    X, y = next(
+        iter(
+            get_Xy(data=train_batches, clip_config=None)
+            .unbatch()
+            .batch(hyperparameters.normalization_fit_samples)
+        )
+    )
 
     train_model, predict_model = build_model(hyperparameters, X=X, y=y)
     hyperparameters.training_loop.fit_loop(

--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -77,7 +77,7 @@ def get_Xy_dataset(
     clip_config: Optional[Mapping[Hashable, SliceConfig]],
     n_halo: int,
     data: tf.data.Dataset,
-):
+) -> tf.data.Dataset:
     """
     Given a tf.data.Dataset with mappings from variable name to samples,
     return a tf.data.Dataset whose entries are two tuples, the first containing the

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -193,7 +193,7 @@ def train_column_model(
         tfdataset.apply_to_mapping(tfdataset.float64_to_float32)
     )
     get_Xy = curry(get_Xy_dataset)(
-        input_variables=input_variables, output_variables=output_variables, n_dims=1,
+        input_variables=input_variables, output_variables=output_variables, n_dims=2,
     )
     if validation_batches is not None:
         validation_batches = validation_batches.map(
@@ -205,7 +205,11 @@ def train_column_model(
 
     train_Xy = get_Xy(data=train_batches, clip_config=clip_config.clip)
     # need unclipped shapes for build_model
-    X, y = next(iter(get_Xy(data=train_batches, clip_config=None).batch(build_samples)))
+    X, y = next(
+        iter(
+            get_Xy(data=train_batches, clip_config=None).unbatch().batch(build_samples)
+        )
+    )
 
     train_model, predict_model = build_model(X=X, y=y)
     del X

--- a/external/fv3fit/fv3fit/keras/_models/shared/halos.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/halos.py
@@ -193,8 +193,10 @@ def _append_halos_tensor(n_halo: int, tensor: tf.Tensor) -> tf.Tensor:
         for _ in range(6)
     ]
     for i, quantity in enumerate(quantities):
+        # split tensor into quantity list over the tile dimension
         quantity.view[:] = tensor[:, i, :].numpy()
     _halo_update(communicators=communicators, quantities=quantities, n_halo=n_halo)
+    # restore the tile dimension with None and concatenate along it
     out_tensor = tf.concat(
         [quantity.data[:, None, :] for quantity in quantities], axis=1
     )

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -254,7 +254,7 @@ class SklearnWrapper(Predictor):
     def fit(self, batches: tf.data.Dataset):
         logger = logging.getLogger("SklearnWrapper")
         logger.info(f"Fitting random forest")
-        batches = batches.map(apply_to_mapping(ensure_nd(1)))
+        batches = batches.map(apply_to_mapping(ensure_nd(2)))
 
         batches_clipped = batches.map(clip_sample(self.packer_config.clip))
         x_dataset, _ = pack_tfdataset(
@@ -265,6 +265,8 @@ class SklearnWrapper(Predictor):
         )
 
         # put all data in one batch, implement batching later
+        x_dataset = x_dataset.unbatch()
+        y_dataset = y_dataset.unbatch()
         total_samples = _get_iterator_size(iter(x_dataset))
         X: Batch = next(iter(x_dataset.batch(total_samples)))
         y: Batch = next(iter(y_dataset.batch(total_samples)))

--- a/external/fv3fit/fv3fit/tfdataset.py
+++ b/external/fv3fit/fv3fit/tfdataset.py
@@ -14,6 +14,13 @@ def apply_to_mapping(
 
 
 @curry
+def apply_to_tuple(
+    tensor_func: Callable[[tf.Tensor], tf.Tensor], data: Tuple[tf.Tensor, ...]
+) -> Tuple[tf.Tensor, ...]:
+    return tuple(tensor_func(tensor) for tensor in data)
+
+
+@curry
 def ensure_nd(n: int, tensor: tf.Tensor) -> tf.Tensor:
     """
     Given a tensor that may be n-dimensional or (n-1)-dimensional, return
@@ -116,7 +123,7 @@ def seq_to_tfdataset(
             key: tf.TensorSpec(process_shape(val.shape), dtype=val.dtype)
             for key, val in sample.items()
         },
-    ).unbatch()
+    )
 
 
 def dataset_to_tensor_dict(ds):

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import Any, Optional, Sequence
 import fv3fit
-from fv3fit._shared.config import get_hyperparameter_class
+from fv3fit._shared.config import CacheConfig, get_hyperparameter_class
 from fv3fit._shared.hyperparameters import Hyperparameters
 import fv3fit.train
 from fv3fit._shared.io import register
@@ -64,7 +64,6 @@ class MainArgs:
     training_data_config: str
     validation_data_config: str
     output_path: str
-    local_download_path: Optional[str] = None
 
 
 class MockHyperparameters:
@@ -78,6 +77,7 @@ class TestConfig:
     hyperparameters: Hyperparameters
     output_path: str
     mock_dataset: xr.Dataset
+    local_download_path: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -167,13 +167,6 @@ def call_main(
         output_transforms=output_transforms,
     )
     mock_load_batches.return_value = [config.mock_dataset for _ in range(6)]
-    if use_local_download_path is True:
-        local_download_path_arg = [
-            "--cache.local_download_path",
-            config.args.local_download_path,
-        ]
-    else:
-        local_download_path_arg = []
     with mock.patch("fv3fit.DerivedModel") as MockDerivedModel, mock.patch(
         "fv3fit.TransformedPredictor"
     ) as MockTransformedPredictor:
@@ -183,7 +176,7 @@ def call_main(
         MockTransformedPredictor.return_value = mock.MagicMock(
             name="transformed_predictor_return", spec=fv3fit.Predictor
         )
-        fv3fit.train.main(config.args, unknown_args=local_download_path_arg)
+        fv3fit.train.main(config.args)
     return CallArtifacts(
         config.output_path,
         config.variables,
@@ -388,11 +381,17 @@ def get_config(
     hyperparameters = get_hyperparameters(
         model_type, hyperparameter_dict, input_variables, output_variables
     )
+
+    if use_local_download_path:
+        local_download_path = os.path.join(base_dir, "local_data")
+    else:
+        local_download_path = None
     training_config = fv3fit.TrainingConfig(
         model_type=model_type,
         hyperparameters=hyperparameters,
         derived_output_variables=derived_output_variables,
         output_transforms=output_transforms,
+        cache=CacheConfig(local_download_path=local_download_path, in_memory=False),
     )
     mock_dataset = get_mock_dataset(n_time=9, unstacked_dims=unstacked_dims)
     train_times = [vcm.encode_time(dt) for dt in mock_dataset["time"][:6].values]
@@ -441,21 +440,20 @@ def get_config(
         yaml.dump(dataclasses.asdict(training_config), f)
     output_path = os.path.join(base_dir, "output")
 
-    if use_local_download_path:
-        local_download_path = os.path.join(base_dir, "local_data")
-    else:
-        local_download_path = None
-
     args = MainArgs(
         data_path=data_path,
         training_config=training_filename,
         training_data_config=train_data_filename,
         validation_data_config=validation_data_filename,
         output_path=output_path,
-        local_download_path=local_download_path,
     )
     return TestConfig(
-        args, training_config.variables, hyperparameters, output_path, mock_dataset
+        args,
+        training_config.variables,
+        hyperparameters,
+        output_path,
+        mock_dataset,
+        local_download_path=local_download_path,
     )
 
 
@@ -495,10 +493,6 @@ def cli_main(args: MainArgs):
         validation_args = []
     else:
         validation_args = ["--validation-data-config", args.validation_data_config]
-    if args.local_download_path is None:
-        local_download_args = []
-    else:
-        local_download_args = ["--cache.local_download_path", args.local_download_path]
     subprocess.check_call(
         [
             "python",
@@ -509,7 +503,6 @@ def cli_main(args: MainArgs):
             args.output_path,
         ]
         + validation_args
-        + local_download_args
     )
     # if you need pdb support, temporarily replace the check_call above with this:
     # fv3fit.train.main(args)
@@ -570,4 +563,4 @@ def test_cli(
     cli_main(config.args)
     fv3fit.load(config.args.output_path)
     if use_local_download_path:
-        assert len(os.listdir(config.args.local_download_path)) > 0
+        assert len(os.listdir(config.local_download_path)) > 0


### PR DESCRIPTION
The tfdataset refactor significantly reduced performance of data loading, due to transformations being performed on unbatched data. This PR fixes that performance by batching the data, and improves shuffling behavior by shuffing batches before shuffling samples.

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- dataset elements passed to training functions now have a sample dimension, and each contain one batch of data
- training functions are refactored to use elements with a sample dimension as input
- TrainingLoopConfig.fit_loop now shuffles batch elements before unbatching and shuffling them, improving shuffling on temporally-contiguous input data

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
