### PR TITLE
fv3fit: wandb integration

### DIFF
--- a/external/fv3fit/docs/index.rst
+++ b/external/fv3fit/docs/index.rst
@@ -15,6 +15,7 @@ The package provides :py:func:`fv3fit.dump` and :py:func:`fv3fit.load` functions
    ensembles
    api
    emulation/index
+   wandb_integration
 
 Indices and tables
 ==================

--- a/external/fv3fit/docs/wandb_integration.rst
+++ b/external/fv3fit/docs/wandb_integration.rst
@@ -1,0 +1,11 @@
+Integration with wandb
+======================
+
+
+Running `fv3fit.train` with the optionial flag `--wandb` will log the training run with wandb.
+See https://docs.wandb.ai/quickstart for instructions on setting up wandb.
+
+Wandb automatically initialized using the environment variables `WANDB_ENTITY, WANDB_PROJECT, WANDB_JOB_TYPE`
+if they are set. Change these environment variables if you want to change where wandb will log runs.
+
+

--- a/external/fv3fit/docs/wandb_integration.rst
+++ b/external/fv3fit/docs/wandb_integration.rst
@@ -6,6 +6,7 @@ Running `fv3fit.train` with the optionial flag `--wandb` will log the training r
 See https://docs.wandb.ai/quickstart for instructions on setting up wandb.
 
 Wandb automatically initialized using the environment variables `WANDB_ENTITY, WANDB_PROJECT, WANDB_JOB_TYPE`
-if they are set. Change these environment variables if you want to change where wandb will log runs.
+if they are set. Change these environment variables if you want to change where wandb will log runs. See
+for more detals: https://docs.wandb.ai/guides/track/advanced/environment-variables.
 
 

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -200,7 +200,7 @@ def _add_items_to_parser_arguments(
             parser.add_argument(f"--{key}", default=value)
 
 
-def _to_flat_dict(d: dict):
+def to_flat_dict(d: dict):
     """
     Converts any nested dictionaries to a flat version with
     the nested keys joined with a '.', e.g., {a: {b: 1}} ->
@@ -210,7 +210,7 @@ def _to_flat_dict(d: dict):
     new_flat = {}
     for k, v in d.items():
         if isinstance(v, dict):
-            sub_d = _to_flat_dict(v)
+            sub_d = to_flat_dict(v)
             for sk, sv in sub_d.items():
                 new_flat[".".join([k, sk])] = sv
         else:
@@ -264,7 +264,7 @@ def get_arg_updated_config_dict(args: Sequence[str], config_dict: Dict[str, Any]
         args: a list of argument strings to parse
         config_dict: the configuration to update
     """
-    config = _to_flat_dict(config_dict)
+    config = to_flat_dict(config_dict)
     parser = ArgumentParser()
     _add_items_to_parser_arguments(config, parser)
     try:

--- a/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/callbacks.py
@@ -1,8 +1,16 @@
 from .training_loop import EpochResult
 
 import logging
+import wandb
 
 logger = logging.getLogger(__name__)
+
+
+def _log_to_wandb_if_initialized(metrics):
+    try:
+        wandb.log(metrics)
+    except wandb.errors.Error:
+        pass
 
 
 class TrainingLoopLossHistory:
@@ -33,6 +41,10 @@ class TrainingLoopLossHistory:
         for batch_log in epoch_result.batch_logs:
             self.train_loss_all.append(batch_log.loss)
             self.val_loss_all.append(batch_log.val_loss)
+
+        _log_to_wandb_if_initialized(
+            metrics={"validation_loss": self.val_loss_end_of_epoch[-1]}
+        )
 
     def log_summary(self):
         logger.info(f"All batches train loss history: {self.train_loss_all}")

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -8,7 +8,7 @@ from fv3fit.emulation.losses import CustomLoss
 
 import pytest
 import tensorflow as tf
-from fv3fit._shared.config import _to_flat_dict
+from fv3fit._shared.config import to_flat_dict
 from fv3fit.emulation.data.config import TransformConfig
 from fv3fit.emulation.layers.architecture import ArchitectureConfig
 from fv3fit.emulation.models import MicrophysicsConfig
@@ -91,7 +91,7 @@ def test_TrainConfig_from_flat_dict():
     assert config.model.architecture.name == "rnn"
 
     expected = get_default_config()
-    flat_dict = _to_flat_dict(asdict(expected))
+    flat_dict = to_flat_dict(asdict(expected))
     result = TrainConfig.from_flat_dict(flat_dict)
     assert result == expected
 

--- a/external/fv3fit/tests/test__config.py
+++ b/external/fv3fit/tests/test__config.py
@@ -12,7 +12,7 @@ import tempfile
 import yaml
 from fv3fit._shared.config import (
     to_nested_dict,
-    _to_flat_dict,
+    to_flat_dict,
     get_arg_updated_config_dict,
     _add_items_to_parser_arguments,
 )
@@ -129,10 +129,10 @@ def get_cfg_and_args_dicts():
     return config_d, flat_d
 
 
-def test_to_flat_dict():
+def testto_flat_dict():
 
     config_d, expected = get_cfg_and_args_dicts()
-    result = _to_flat_dict(config_d)
+    result = to_flat_dict(config_d)
     assert result == expected
 
 
@@ -147,7 +147,7 @@ def test_flat_dict_round_trip():
 
     config_d, _ = get_cfg_and_args_dicts()
 
-    args_d = _to_flat_dict(config_d)
+    args_d = to_flat_dict(config_d)
     result = to_nested_dict(args_d)
 
     assert result == config_d

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -65,6 +65,7 @@ class MainArgs:
     validation_data_config: str
     output_path: str
     local_download_path: Optional[str] = None
+    wandb: bool = False
 
 
 class MockHyperparameters:


### PR DESCRIPTION
This adds an option to log `fv3fit.train` runs using wandb. The project, entity, and job type are automatically initialized using the  environment variables `WANDB_ENTITY, WANDB_PROJECT, WANDB_JOB_TYPE`.

Right now the only training that has logging setup is the dense model training, which will log the end of epoch validation loss. In the future, the wandb keras callback can be used; however, the training loop code needs some refactoring before it can use arbitrary keras callbacks.

Tested this out with my own local environment:  https://wandb.ai/annakwa/test-fv3fit/runs/27mfwt81

Added public API:
- `--wandb` flag for `fv3fit.train`

