### PR TITLE
use more batches in shuffling test

### DIFF
--- a/external/fv3fit/tests/test_training_loop.py
+++ b/external/fv3fit/tests/test_training_loop.py
@@ -120,7 +120,7 @@ def assert_data_is_shuffled(Xy, array_x, n_batches):
 
 @pytest.mark.slow
 def test__shuffle_batched_tfdataset():
-    batch_size = 1000
+    batch_size = 100
     n_samples = 20_000
     data, array_x = get_monotonic_data(n_samples, batch_size)
     n_batches = n_samples // batch_size
@@ -131,11 +131,10 @@ def test__shuffle_batched_tfdataset():
 
 @pytest.mark.slow
 def test_fit_loop_shuffles_batches():
-    fv3fit.set_random_seed(0)
     # for test, batch_shuffle_buffer_size should fit all batches
     # and shuffle_buffer_size should not
     # in_memory must be False because keras's model.fit handle shuffling for True
-    batch_size = 1000
+    batch_size = 100
     n_samples = 20_000
     data, array_x = get_monotonic_data(n_samples, batch_size)
     mock_model = mock.MagicMock()


### PR DESCRIPTION
This PR increases the number of batches shuffled in the shuffling test from 20 to 200 by making each of the batches smaller, which should be large enough to give consistent shuffling results. In manual testing, 5 tests did not produce a correlation over 0.002, and the threshold checked is 0.01.

Fixes #1735 