### PR TITLE
pin click when running black through pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 19.10b0
     hooks:
     - id: black
+      additional_dependencies: ['click==8.0.4']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:


### PR DESCRIPTION
An update to click broke black. This PR pins the version of click used in pre-commit to the last working version.