### PR TITLE
add tapering option to clip config

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -36,7 +36,7 @@ from fv3fit.keras._models.shared.utils import (
     full_standard_normalized_input,
 )
 from fv3fit import tfdataset
-from fv3fit.keras._models.shared.clip import clip_sequence, ClipConfig
+from fv3fit.keras._models.shared.clip import clip_sequence, ClipConfig, taper_sequence
 from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping, clip_sample
 
 
@@ -302,7 +302,10 @@ def build_model(
         config.clip_config.zero_mask_clipped_layer(denorm_layer, name)
         for denorm_layer, name in zip(denorm_output_layers, config.output_variables)
     ]
+    tapered_denorm_output_layers = taper_sequence(
+        config.clip_config, zero_filled_denorm_output_layers, config.output_variables
+    )
     predict_model = tf.keras.Model(
-        inputs=input_layers, outputs=zero_filled_denorm_output_layers
+        inputs=input_layers, outputs=tapered_denorm_output_layers
     )
     return train_model, predict_model


### PR DESCRIPTION
Add `taper` option to clip config with `cutoff` and `rate` parameters. Tapers levels $z_i$ below cutoff as 
$$ exp((i - cutoff) / rate)$$. Spencer uses cutoff=25, rate=5.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
