### PR TITLE
Add env vars for wandb to argo templates

### DIFF
--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -264,6 +264,10 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `training-flags`        | (optional) `flags` for `training` workflow                            |
 | `online-diags-flags`    | (optional) `flags` for `prognostic-run-diags` workflow                |
 | `do-prognostic-run`     | (optional) do prognostic run step; default "true"                     |
+| `wandb-project`     | (optional) if --wandb flag provided to training, will log under this project ; default 'argo-default' |
+| `wandb-tags`     | (optional) if --wandb flag provided to training, will log under these tags; default none |
+| `wandb-group`     | (optional) if --wandb flag provided to training, will log under this group; default none    |
+
 
 Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
 Slashes (`/`) are not permitted in `bucket`, `project` and `tag` to preserve the depth

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -77,6 +77,10 @@ spec:
               value: "{{inputs.parameters.training-flags}}"
             - name: wandb-project
               value: "{{inputs.parameters.wandb-project}}"
+            - name: wandb-tags
+              value: "{{inputs.parameters.wandb-tags}}"
+            - name: wandb-run-group
+              value: "{{inputs.parameters.wandb-run-group}}"
       - name: offline-diags
         dependencies: [train-model]
         templateRef:

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -38,6 +38,7 @@ spec:
       - {name: training-flags, value: " "}
       - {name: online-diags-flags, value: " "}
       - {name: do-prognostic-run, value: "true"}
+      - {name: wandb-project, value: "argo-default"}
     dag:
       tasks:
       - name: resolve-output-url
@@ -74,6 +75,8 @@ spec:
               value: "{{inputs.parameters.memory-training}}"
             - name: flags
               value: "{{inputs.parameters.training-flags}}"
+            - name: wandb-project
+              value: "{{inputs.parameters.wandb-project}}"
       - name: offline-diags
         dependencies: [train-model]
         templateRef:

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -24,6 +24,8 @@ spec:
           - {name: memory, value: 6Gi}
           - {name: flags, value: " "}
           - {name: wandb-project, value: "argo-default"}
+          - {name: wandb-tags, value: " "}
+          - {name: wandb-run-group, value: " "}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
         command: ["bash", "-c", "-x"]
@@ -36,6 +38,10 @@ spec:
             value: ai2cm
           - name: WANDB_PROJECT
             value: "{{inputs.parameters.wandb-project}}"
+          - name: WANDB_TAGS
+            value: "{{inputs.parameters.wandb-tags}}"
+          - name: WANDB_RUN_GROUP
+            value: "{{inputs.parameters.wandb-run-group}}"
         envFrom:
           - secretRef:
               name: wandb-token

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -35,7 +35,7 @@ spec:
           - name: WANDB_ENTITY
             value: ai2cm
           - name: WANDB_PROJECT
-            value: {{inputs.parameters.wandb-project}}
+            value: "{{inputs.parameters.wandb-project}}"
         envFrom:
           - secretRef:
               name: wandb-token

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -23,6 +23,7 @@ spec:
           - {name: cpu, value: 1000m}
           - {name: memory, value: 6Gi}
           - {name: flags, value: " "}
+          - {name: wandb-project, value: "argo-default"}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
         command: ["bash", "-c", "-x"]
@@ -31,6 +32,13 @@ spec:
             value: /secret/gcp-credentials/key.json
           - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
             value: /secret/gcp-credentials/key.json
+          - name: WANDB_ENTITY
+            value: ai2cm
+          - name: WANDB_PROJECT
+            value: {{inputs.parameters.wandb-project}}
+        envFrom:
+          - secretRef:
+              name: wandb-token
         volumeMounts:
           - mountPath: /secret/gcp-credentials
             name: gcp-key-secret


### PR DESCRIPTION
This adds environment variables `WANDB_PROJECT` and `WANDB_ENTITY` to the argo training workflow so that wandb enabled jobs will be logged. The default project is `argo-default` and can be set via the parameter `wandb-project`. The entity is always `ai2cm`. This is fixed since if you try to set this to your personal account it probably won't work with permissions that weren't generated using your account's API key. 