### PR TITLE
Fix bug where out-of-memory validation data has wrong shape

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
@@ -129,8 +129,10 @@ class TrainingLoopConfig:
                 .prefetch(tf.data.AUTOTUNE)
             )
             if validation_data is not None:
-                validation_fit = validation_data.batch(self.batch_size).prefetch(
-                    tf.data.AUTOTUNE
+                validation_fit = (
+                    validation_data.unbatch()
+                    .batch(self.batch_size)
+                    .prefetch(tf.data.AUTOTUNE)
                 )
             else:
                 validation_fit = None


### PR DESCRIPTION
There is currently a bug where using validation data with in_memory=False in TrainingLoopConfig causes a crash due to validation data having the wrong shape, since samples are not unbatched before being rebatched. This PR fixes that bug.

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
