### PR TITLE
Log commit SHA in wandb

### DIFF
--- a/docker/fv3fit/Dockerfile
+++ b/docker/fv3fit/Dockerfile
@@ -33,3 +33,6 @@ RUN pip3 install --no-dependencies /fv3net/external/fv3fit
 
 # Greatly improves memory performance of tensorflow training
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
+
+ARG COMMIT_SHA_ARG
+ENV COMMIT_SHA=$COMMIT_SHA_ARG

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -176,6 +176,7 @@ def get_cached_data(
 
 
 def main(args, unknown_args=None):
+
     with open(args.training_config, "r") as f:
         config_dict = yaml.safe_load(f)
         if unknown_args is not None:
@@ -199,6 +200,7 @@ def main(args, unknown_args=None):
                 f"hyperparameters from wandb config: {config_dict['hyperparameters']}"
             )
             wandb.config["training_config"] = config_dict
+            wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
 
         training_config = fv3fit.TrainingConfig.from_dict(config_dict)
 

--- a/projects/microphysics/scripts/gather_netcdfs.py
+++ b/projects/microphysics/scripts/gather_netcdfs.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import subprocess
 import wandb
 from config import PROJECT, BUCKET
@@ -34,6 +35,7 @@ if __name__ == "__main__":
         job_type="netcdf-gather", project="microphysics-emulation", entity="ai2cm"
     )
     wandb.config.update(args)
+    wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
 
     base_url = f"gs://{BUCKET}/{PROJECT}/{args.run_date}"
     train_out = f"{base_url}/{args.tag_prefix}-training_netcdfs/train"

--- a/projects/microphysics/scripts/prognostic_evaluate.py
+++ b/projects/microphysics/scripts/prognostic_evaluate.py
@@ -394,6 +394,7 @@ def main():
     )
 
     wandb.config.update(args)
+    wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
 
     def get_url_wandb(artifact: str):
         art = run.use_artifact(artifact + ":latest", type="prognostic-run")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import logging
+import os
 from functools import partial
 from typing import Any, Callable, List
 
@@ -333,6 +334,7 @@ def upload_diagnostics_for_tag(tag: str):
         tags=[tag],
         reinit=True,
     )
+    wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
     with run:
         url = get_rundir_from_prognostic_run(get_prognostic_run_from_tag(tag))
         upload_diagnostics_for_rundir(url)


### PR DESCRIPTION
It's useful to know which image runs on Weights & Biases were performed on, so now if available under the environment variable `COMMIT_SHA`, the commit SHA  is logged under `wandb.config["env"]` for all scripts currently logging to wandb.