### PR TITLE
Delete broken link from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,3 @@ Requirement changes:
 - [ ] Tests added
 
 Resolves #<github issues> [JIRA-TAG]
-
-(Delete this for the commit message)
-You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributions Guides and Standards
 
+Coding guidelines for contributors (and pull request reviewers) are described in
+the [Code Review Checklist](https://docs.google.com/document/d/1lIC1m1vYhdZITjvcUKuIE8jb05QYPwxX/edit).
+
 Please record all changes and updates in [HISTORY.rst](./HISTORY.rst) under the
 upcoming section.  It is especially important to log changes that break backwards
 compatibility so we can appropriately adjust the versioning.


### PR DESCRIPTION
Make the PR template shorter by deleting the last line, which just includes a broken link.