### PR TITLE
Fix missing wandb parameters

### DIFF
--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -37,6 +37,9 @@ spec:
       - {name: online-diags-flags, value: " "}
       - {name: do-prognostic-run, value: "true"}
       - {name: wandb-project, value: "argo-default"}
+      - {name: wandb-tags, value: " "}
+      - {name: wandb-run-group, value: " "}
+
     dag:
       tasks:
       - name: resolve-output-url


### PR DESCRIPTION
I forgot to add these as top level parameters for the train-diags-prog template in the last PR. I'm surprised the argo test did not complain, but I think their absence would probably break this template since they are referenced in a dag step.