### PR TITLE
Allow updating state in fv3fit transformer

### DIFF
--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -32,7 +32,6 @@ TransformName = Literal[
     "Q2_tendency_from_Q2_flux",
     "implied_surface_precipitation_rate",
     "implied_downward_radiative_flux_at_surface",
-    "implied_downward_radiative_flux_at_surface_no_fine_res_t_nudging",
 ]
 
 
@@ -239,37 +238,6 @@ def implied_downward_radiative_flux_at_surface(
     toa_net_flux = ds[DSW_TOA] - ds[USW_TOA] - ds[ULW_TOA]
     if include_temperature_nudging:
         toa_net_flux += ds[COL_T_NUDGE]
-    surface_upward_flux = ds[LHF] + ds[SHF] + ds[USW_SFC] + ds[ULW_SFC]
-    surface_downward_flux = _tendency_to_implied_surface_downward_flux(
-        ds["Qm"], toa_net_flux, surface_upward_flux, ds[DELP], dim="z", rectify=rectify
-    )
-    surface_downward_flux = surface_downward_flux.assign_attrs(
-        units="W/m**2",
-        long_name="Implied downward radiative flux from <Qm> budget closure",
-    )
-    ds["implied_downward_radiative_flux_at_surface"] = surface_downward_flux
-    return ds
-
-
-@register(
-    [
-        "Qm",
-        DELP,
-        DLW_SFC,
-        DSW_SFC,
-        DSW_TOA,
-        ULW_SFC,
-        ULW_TOA,
-        USW_SFC,
-        USW_TOA,
-        LHF,
-        SHF,
-    ],
-    ["implied_downward_radiative_flux_at_surface"],
-)
-def implied_downward_radiative_flux_at_surface_no_fine_res_t_nudging(ds, rectify=True):
-    """Assuming <Qm> = SHF + LHF + R_net + <T_nudge>."""
-    toa_net_flux = ds[DSW_TOA] - ds[USW_TOA] - ds[ULW_TOA]
     surface_upward_flux = ds[LHF] + ds[SHF] + ds[USW_SFC] + ds[ULW_SFC]
     surface_downward_flux = _tendency_to_implied_surface_downward_flux(
         ds["Qm"], toa_net_flux, surface_upward_flux, ds[DELP], dim="z", rectify=rectify

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -59,8 +59,8 @@ class Adapter:
         models = [fv3fit.load(url) for url in self.config.url]
         self.model = MultiModelAdapter(models)  # type: ignore
         self.tendency_names = defaultdict(list)
-        for tendency_name, state_name in self.config.tendency_predictions.items():
-            self.tendency_names[state_name].append(tendency_name)
+        for k, v in self.config.tendency_predictions.items():
+            self.tendency_names[v].append(k)
         self.state_names = {v: k for k, v in self.config.state_predictions.items()}
 
     def predict(self, inputs: State) -> State:

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -36,10 +36,10 @@ class Config:
 
 class TendencyOrStateMultiModelAdapter:
     """Adapter for multiple models that predict tendencies and state updates.
-    
+
     Args:
         models: Sequence of fv3fit.Predictor objects.
-        tendency_predictions: Mapping from names of outputs predicted by ML model to 
+        tendency_predictions: Mapping from names of outputs predicted by ML model to
             state names. These predictions will be multiplied by the physics timestep.
         state_predictions: Mapping from names of outputs predicted by ML model to
             state names. The state will be set to be equal to these predictions.
@@ -77,7 +77,7 @@ class TendencyOrStateMultiModelAdapter:
 
         Note:
             Tendencies are summed over all predictions for a given variable. For
-            example, if self.tendency_predictions = {'Q1': 'air_temperature', 
+            example, if self.tendency_predictions = {'Q1': 'air_temperature',
             'air_temperature_tendency_due_to_nudging': 'air_temperature'} then
             the returned tendency dataset will contain a tendency for
             'air_temperature' that is the sum of these two predicted tendencies.

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -9,6 +9,7 @@ from runtime.steppers.machine_learning import (
 )
 from runtime.types import State
 from runtime.names import SPHUM, TEMP
+from runtime.diagnostics.compute import precipitation_accumulation
 
 __all__ = ["Config", "Adapter"]
 
@@ -18,15 +19,19 @@ class Config:
     """
     Attributes:
         url: Sequence of paths to models that can be loaded with fv3fit.load.
-        variables: Mapping from state names to name of corresponding tendency predicted
-            by model. For example: {"air_temperature": "dQ1"}.
+        tendency_predictions: Mapping from state names to name of corresponding tendency
+            predicted by ML model. For example: {"air_temperature": "Q1"}.
+        state_predictions: Mapping from state names to name of corresponding state
+            predicted by ML model. For example:
+            {"surface_precipitation_rate": "implied_surface_precipitation_rate"}.
         limit_negative_humidity: if True, rescale tendencies to not allow specific
             humidity to become negative.
         online: if True, the ML predictions will be applied to model state.
     """
 
     url: Sequence[str]
-    variables: Mapping[str, str]
+    tendency_predictions: Mapping[str, str] = dataclasses.field(default_factory=dict)
+    state_predictions: Mapping[str, str] = dataclasses.field(default_factory=dict)
     limit_negative_humidity: bool = True
     online: bool = True
 
@@ -41,21 +46,25 @@ class Adapter:
         self.model = MultiModelAdapter(models)  # type: ignore
 
     def predict(self, inputs: State) -> State:
-        tendencies = self.model.predict(xr.Dataset(inputs))
+        prediction = self.model.predict(xr.Dataset(inputs))
         if self.config.limit_negative_humidity:
-            limited_tendencies = self.non_negative_sphum_limiter(tendencies, inputs)
-            tendencies = tendencies.update(limited_tendencies)
+            limited_prediction = self.non_negative_sphum_limiter(prediction, inputs)
+            prediction = prediction.update(limited_prediction)
 
-        state_prediction: State = {}
-        for variable_name, tendency_name in self.config.variables.items():
+        state_update: State = {}
+        for variable_name, tendency_name in self.config.tendency_predictions.items():
             with xr.set_options(keep_attrs=True):
-                state_prediction[variable_name] = (
-                    inputs[variable_name] + tendencies[tendency_name] * self.timestep
+                state_update[variable_name] = (
+                    inputs[variable_name] + prediction[tendency_name] * self.timestep
                 )
-        return state_prediction
+        for variable_name, prediction_name in self.config.state_predictions.items():
+            state_update[variable_name] = prediction[prediction_name]
+        print(state_update)
+        return state_update
 
     def apply(self, prediction: State, state: State):
         if self.config.online:
+            _replace_precip_rate_with_accumulation(prediction, self.timestep)
             state.update(prediction)
 
     def partial_fit(self, inputs: State, state: State):
@@ -63,17 +72,21 @@ class Adapter:
 
     @property
     def input_variables(self) -> Iterable[Hashable]:
-        return list(set(self.model.input_variables) | set(self.config.variables))
+        return list(
+            set(self.model.input_variables)
+            | set(self.config.tendency_predictions)
+            | set(self.config.state_predictions)
+        )
 
     def non_negative_sphum_limiter(self, tendencies, inputs):
         limited_tendencies = {}
-        if SPHUM not in self.config.variables:
+        if SPHUM not in self.config.tendency_predictions:
             raise NotImplementedError(
                 "Cannot limit specific humidity tendencies if specific humidity "
                 "updates not being predicted."
             )
-        q2_name = self.config.variables[SPHUM]
-        q1_name = self.config.variables.get(TEMP)
+        q2_name = self.config.tendency_predictions[SPHUM]
+        q1_name = self.config.tendency_predictions.get(TEMP)
         q2_new, q1_new = non_negative_sphum_mse_conserving(
             inputs[SPHUM],
             tendencies[q2_name],
@@ -84,3 +97,22 @@ class Adapter:
         if q1_name is not None:
             limited_tendencies[q1_name] = q1_new
         return limited_tendencies
+
+
+TOTAL_PRECIP_RATE = "total_precipitation_rate"
+TOTAL_PRECIP = "total_precipitation"  # has units of m
+
+
+# TODO: define setter for 'surface_precipitation_rate' in fv3gfs-wrapper
+# so that we do not need to do this conversion here. For now, this function
+# is copied from loop.py
+def _replace_precip_rate_with_accumulation(  # type: ignore
+    state_updates: State, dt: float
+) -> State:
+    # Precipitative ML models predict a rate, but the precipitation to update
+    # in the state is an accumulated total over the timestep
+    if TOTAL_PRECIP_RATE in state_updates:
+        state_updates[TOTAL_PRECIP] = precipitation_accumulation(
+            state_updates[TOTAL_PRECIP_RATE], dt
+        )
+        state_updates.pop(TOTAL_PRECIP_RATE)

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -110,7 +110,6 @@ class Adapter:
         return list(
             set(self.model.input_variables)
             | set(self.config.tendency_predictions.values())
-            | set(self.config.state_predictions.values())
         )
 
     def non_negative_sphum_limiter(self, tendencies, inputs):
@@ -129,7 +128,7 @@ class Adapter:
         return limited_tendencies
 
 
-TOTAL_PRECIP_RATE = "total_precipitation_rate"
+PRECIP_RATE = "surface_precipitation_rate"
 TOTAL_PRECIP = "total_precipitation"  # has units of m
 
 
@@ -141,8 +140,8 @@ def _replace_precip_rate_with_accumulation(  # type: ignore
 ) -> State:
     # Precipitative ML models predict a rate, but the precipitation to update
     # in the state is an accumulated total over the timestep
-    if TOTAL_PRECIP_RATE in state_updates:
+    if PRECIP_RATE in state_updates:
         state_updates[TOTAL_PRECIP] = precipitation_accumulation(
-            state_updates[TOTAL_PRECIP_RATE], dt
+            state_updates[PRECIP_RATE], dt
         )
-        state_updates.pop(TOTAL_PRECIP_RATE)
+        state_updates.pop(PRECIP_RATE)

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -1,12 +1,9 @@
 import dataclasses
-from typing import Mapping, Iterable, Hashable, Sequence
+from typing import Mapping, MutableMapping, Iterable, Hashable, Sequence, Tuple
 
 import xarray as xr
 import fv3fit
-from runtime.steppers.machine_learning import (
-    MultiModelAdapter,
-    non_negative_sphum_mse_conserving,
-)
+from runtime.steppers.machine_learning import non_negative_sphum_mse_conserving
 from runtime.types import State
 from runtime.names import SPHUM, TEMP
 from runtime.diagnostics.compute import precipitation_accumulation
@@ -19,11 +16,13 @@ class Config:
     """
     Attributes:
         url: Sequence of paths to models that can be loaded with fv3fit.load.
-        tendency_predictions: Mapping from state names to name of corresponding tendency
-            predicted by ML model. For example: {"air_temperature": "Q1"}.
-        state_predictions: Mapping from state names to name of corresponding state
-            predicted by ML model. For example:
-            {"surface_precipitation_rate": "implied_surface_precipitation_rate"}.
+        tendency_predictions: Mapping from names of outputs predicted by ML model to
+            state names. For example: {"Q1": "air_temperature"}. These predictions
+            will be multiplied by the physics timestep before being added to the state.
+        state_predictions: Mapping from names of outputs predicted by ML model to
+            state names. For example:
+            {"implied_surface_precipitation_rate": "surface_precipitation_rate"}. The
+            state will be set to be equal to these predictions.
         limit_negative_humidity: if True, rescale tendencies to not allow specific
             humidity to become negative.
         online: if True, the ML predictions will be applied to model state.
@@ -36,6 +35,43 @@ class Config:
     online: bool = True
 
 
+class TendencyOrStateMultiModelAdapter:
+    def __init__(
+        self,
+        models: Iterable[fv3fit.Predictor],
+        tendency_predictions: Mapping[str, str],
+        state_predictions: Mapping[str, str],
+    ):
+        self.models = models
+        if len(set(state_predictions.values())) < len(state_predictions.values()):
+            raise ValueError(
+                "Cannot have multiple state predictions for same state variable."
+            )
+        self.tendency_predictions = tendency_predictions
+        self.state_predictions = state_predictions
+
+    @property
+    def input_variables(self) -> Iterable[Hashable]:
+        vars = [model.input_variables for model in self.models]
+        return list({var for model_vars in vars for var in model_vars})
+
+    def predict(self, arg: xr.Dataset) -> Tuple[xr.Dataset, xr.Dataset]:
+        predictions = []
+        for model in self.models:
+            predictions.append(model.predict(arg))
+        merged_predictions = xr.merge(predictions)
+        tendencies: MutableMapping[str, xr.DataArray] = {}
+        state_updates: MutableMapping[str, xr.DataArray] = {}
+        for tendency_name, variable_name in self.tendency_predictions.items():
+            if variable_name in tendencies:
+                tendencies[variable_name] += merged_predictions[tendency_name]
+            else:
+                tendencies[variable_name] = merged_predictions[tendency_name]
+        for prediction_name, variable_name in self.state_predictions.items():
+            state_updates[variable_name] = merged_predictions[prediction_name]
+        return xr.Dataset(tendencies), xr.Dataset(state_updates)
+
+
 @dataclasses.dataclass
 class Adapter:
     config: Config
@@ -43,24 +79,23 @@ class Adapter:
 
     def __post_init__(self: "Adapter"):
         models = [fv3fit.load(url) for url in self.config.url]
-        self.model = MultiModelAdapter(models)  # type: ignore
+        self.model = TendencyOrStateMultiModelAdapter(
+            models, self.config.tendency_predictions, self.config.state_predictions
+        )
 
     def predict(self, inputs: State) -> State:
-        prediction = self.model.predict(xr.Dataset(inputs))
+        tendencies, state_updates = self.model.predict(xr.Dataset(inputs))
         if self.config.limit_negative_humidity:
-            limited_prediction = self.non_negative_sphum_limiter(prediction, inputs)
-            prediction = prediction.update(limited_prediction)
+            limited_tendencies = self.non_negative_sphum_limiter(tendencies, inputs)
+            tendencies = tendencies.update(limited_tendencies)
 
-        state_update: State = {}
-        for variable_name, tendency_name in self.config.tendency_predictions.items():
+        prediction: State = {}
+        for name in tendencies:
             with xr.set_options(keep_attrs=True):
-                state_update[variable_name] = (
-                    inputs[variable_name] + prediction[tendency_name] * self.timestep
-                )
-        for variable_name, prediction_name in self.config.state_predictions.items():
-            state_update[variable_name] = prediction[prediction_name]
-        print(state_update)
-        return state_update
+                prediction[name] = inputs[name] + tendencies[name] * self.timestep
+        for name in state_updates:
+            prediction[name] = state_updates[name]
+        return prediction
 
     def apply(self, prediction: State, state: State):
         if self.config.online:
@@ -74,28 +109,23 @@ class Adapter:
     def input_variables(self) -> Iterable[Hashable]:
         return list(
             set(self.model.input_variables)
-            | set(self.config.tendency_predictions)
-            | set(self.config.state_predictions)
+            | set(self.config.tendency_predictions.values())
+            | set(self.config.state_predictions.values())
         )
 
     def non_negative_sphum_limiter(self, tendencies, inputs):
         limited_tendencies = {}
-        if SPHUM not in self.config.tendency_predictions:
+        if SPHUM not in tendencies:
             raise NotImplementedError(
                 "Cannot limit specific humidity tendencies if specific humidity "
                 "updates not being predicted."
             )
-        q2_name = self.config.tendency_predictions[SPHUM]
-        q1_name = self.config.tendency_predictions.get(TEMP)
         q2_new, q1_new = non_negative_sphum_mse_conserving(
-            inputs[SPHUM],
-            tendencies[q2_name],
-            self.timestep,
-            q1=tendencies.get(q1_name),
+            inputs[SPHUM], tendencies[SPHUM], self.timestep, q1=tendencies.get(TEMP),
         )
-        limited_tendencies[q2_name] = q2_new
-        if q1_name is not None:
-            limited_tendencies[q1_name] = q1_new
+        limited_tendencies[SPHUM] = q2_new
+        if q1_new is not None:
+            limited_tendencies[TEMP] = q1_new
         return limited_tendencies
 
 

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -1,5 +1,6 @@
+from collections import defaultdict
 import dataclasses
-from typing import Mapping, MutableMapping, Iterable, Hashable, Sequence, Literal
+from typing import Mapping, MutableMapping, Iterable, Hashable, Sequence
 
 import xarray as xr
 import fv3fit
@@ -14,93 +15,39 @@ __all__ = ["Config", "Adapter"]
 
 
 @dataclasses.dataclass
-class MLOutputApplier:
-    """Configuration of how to apply ML predictions to state.
-
-    Attrs:
-        target_name: Name of the variable to apply ML predictions to.
-        method: How to apply ML predictions to the target variable.
-    """
-
-    target_name: str
-    method: Literal["tendency", "state"]
-
-    def apply(
-        self, inputs: State, prediction: xr.DataArray, timestep: float
-    ) -> xr.DataArray:
-        if self.method == "tendency":
-            with xr.set_options(keep_attrs=True):
-                output = inputs[self.target_name] + prediction * timestep
-        elif self.method == "state":
-            output = prediction
-        return output
-
-
-@dataclasses.dataclass
 class Config:
     """
     Attributes:
         url: Sequence of paths to models that can be loaded with fv3fit.load.
-        output_targets: Mapping from names of outputs predicted by ML model to
-            MLOutputApplier configuration. For example:
-            {"Q1": {"target_name": "air_temperature", "method": "tendency"}.
+        tendency_predictions: Mapping from names of outputs predicted by ML model to
+            state names. For example: {"Q1": "air_temperature"}. These predictions
+            will be multiplied by the physics timestep before being added to the state.
+        state_predictions: Mapping from names of outputs predicted by ML model to
+            state names. For example:
+            {"implied_surface_precipitation_rate": "surface_precipitation_rate"}. The
+            state will be set to be equal to these predictions.
         limit_negative_humidity: if True, rescale tendencies to not allow specific
             humidity to become negative.
         online: if True, the ML predictions will be applied to model state.
     """
 
     url: Sequence[str]
-    output_targets: Mapping[str, MLOutputApplier]
+    tendency_predictions: Mapping[str, str] = dataclasses.field(default_factory=dict)
+    state_predictions: Mapping[str, str] = dataclasses.field(default_factory=dict)
     limit_negative_humidity: bool = True
     online: bool = True
 
-
-class PredictionInverter:
-    """Take ML predictions and convert to mapping keyed on state variable names"""
-
-    def __init__(self, targets: Mapping[str, MLOutputApplier]):
-        states = [t.target_name for t in targets.values() if t.method == "state"]
-        tendencies = [t.target_name for t in targets.values() if t.method == "tendency"]
-        if len(set(states)) < len(states):
+    def __post_init__(self):
+        state_targets = list(self.state_predictions.values())
+        tendency_targets = list(self.tendency_predictions.values())
+        if len(set(state_targets)) < len(state_targets):
             raise ValueError(
                 "Cannot have multiple state predictions for same variable."
             )
-        if len(set(states).intersection(tendencies)) > 0:
+        if len(set(state_targets).intersection(tendency_targets)) > 0:
             raise ValueError(
                 "A variable cannot be updated by tendency and state predictions."
             )
-        self.targets = targets
-
-    def invert(self, predictions: State) -> State:
-        """Separate a dataset of predictions into tendency and state predictions.
-
-        Args:
-            predictions: tendency and/or state predictions, keyed on ML output names.
-
-        Returns:
-            Mapping of tendencies and state updates keyed on state names to be updated.
-
-        Note:
-            Tendencies are summed over all predictions for a given variable.
-        """
-        output: MutableMapping[Hashable, xr.DataArray] = {}
-        for ml_output_name, target in self.targets.items():
-            if target.method == "tendency":
-                if target.target_name in output:
-                    output[target.target_name] += predictions[ml_output_name]
-                else:
-                    output[target.target_name] = predictions[ml_output_name]
-            elif target.method == "state":
-                output[target.target_name] = predictions[ml_output_name]
-        return output
-
-    def apply(self, inputs: State, predictions: State, timestep: float) -> State:
-        """Apply tendency and state updates to the input state."""
-        apply_methods = {t.target_name: t.apply for t in self.targets.values()}
-        output: MutableMapping[Hashable, xr.DataArray] = {}
-        for name, apply in apply_methods.items():
-            output[name] = apply(inputs, predictions[name], timestep)
-        return output
 
 
 @dataclasses.dataclass
@@ -111,15 +58,29 @@ class Adapter:
     def __post_init__(self: "Adapter"):
         models = [fv3fit.load(url) for url in self.config.url]
         self.model = MultiModelAdapter(models)  # type: ignore
-        self.inverter = PredictionInverter(self.config.output_targets)
+        self.tendency_names = defaultdict(list)
+        for tendency_name, state_name in self.config.tendency_predictions.items():
+            self.tendency_names[state_name].append(tendency_name)
+        self.state_names = {v: k for k, v in self.config.state_predictions.items()}
 
     def predict(self, inputs: State) -> State:
         prediction = self.model.predict(xr.Dataset(inputs))
-        tendencies = self.inverter.invert(prediction)
+        tendencies = {
+            k: sum([prediction[item] for item in v])
+            for k, v in self.tendency_names.items()
+        }
+        state_updates: MutableMapping[Hashable, xr.DataArray] = {
+            k: prediction[v] for k, v in self.state_names.items()
+        }
+
         if self.config.limit_negative_humidity:
             limited_tendencies = self.non_negative_sphum_limiter(tendencies, inputs)
             tendencies.update(limited_tendencies)
-        return self.inverter.apply(inputs, tendencies, self.timestep)
+
+        for name in tendencies:
+            with xr.set_options(keep_attrs=True):
+                state_updates[name] = inputs[name] + tendencies[name] * self.timestep
+        return state_updates
 
     def apply(self, prediction: State, state: State):
         if self.config.online:
@@ -130,12 +91,7 @@ class Adapter:
 
     @property
     def input_variables(self) -> Iterable[Hashable]:
-        tendency_target_names = [
-            t.target_name
-            for t in self.config.output_targets.values()
-            if t.method == "tendency"
-        ]
-        return list(set(self.model.input_variables) | set(tendency_target_names))
+        return list(set(self.model.input_variables) | set(self.tendency_names))
 
     def non_negative_sphum_limiter(self, tendencies, inputs):
         limited_tendencies = {}

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -124,4 +124,3 @@ class Adapter:
         if q1_new is not None:
             limited_tendencies[TEMP] = q1_new
         return limited_tendencies
-

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -430,10 +430,11 @@ nudging: null
 online_emulator:
   limit_negative_humidity: true
   online: true
+  state_predictions: {}
+  tendency_predictions:
+    air_temperature: dQ1
   url:
   - some/path
-  variables:
-    air_temperature: dQ1
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 prephysics: null
 scikit_learn: null

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -430,10 +430,9 @@ nudging: null
 online_emulator:
   limit_negative_humidity: true
   online: true
-  output_targets:
-    Q1:
-      method: tendency
-      target_name: air_temperature
+  state_predictions: {}
+  tendency_predictions:
+    Q1: air_temperature
   url:
   - some/path
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -430,9 +430,10 @@ nudging: null
 online_emulator:
   limit_negative_humidity: true
   online: true
-  state_predictions: {}
-  tendency_predictions:
-    Q1: air_temperature
+  output_targets:
+    Q1:
+      method: tendency
+      target_name: air_temperature
   url:
   - some/path
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -432,7 +432,7 @@ online_emulator:
   online: true
   state_predictions: {}
   tendency_predictions:
-    air_temperature: dQ1
+    Q1: air_temperature
   url:
   - some/path
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -20,5 +20,7 @@ namelist:
 online_emulator:
   url:
     - "some/path"
-  tendency_predictions:
-    Q1: air_temperature
+  output_targets:
+    Q1:
+      target_name: air_temperature
+      method: tendency

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -21,4 +21,4 @@ online_emulator:
   url:
     - "some/path"
   tendency_predictions:
-    air_temperature: dQ1
+    Q1: air_temperature:

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -21,4 +21,4 @@ online_emulator:
   url:
     - "some/path"
   tendency_predictions:
-    Q1: air_temperature:
+    Q1: air_temperature

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -20,5 +20,5 @@ namelist:
 online_emulator:
   url:
     - "some/path"
-  variables:
+  tendency_predictions:
     air_temperature: dQ1

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/fine_res_ml.yml
@@ -20,7 +20,5 @@ namelist:
 online_emulator:
   url:
     - "some/path"
-  output_targets:
-    Q1:
-      target_name: air_temperature
-      method: tendency
+  tendency_predictions:
+    Q1: air_temperature

--- a/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
+++ b/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
@@ -3,10 +3,7 @@ import fv3fit
 import vcm
 import xarray as xr
 import pytest
-from runtime.transformers.fv3fit import (
-    Config,
-    Adapter,
-)
+from runtime.transformers.fv3fit import Config, Adapter
 from runtime.transformers.core import StepTransformer
 from machine_learning_mocks import get_mock_predictor
 
@@ -96,7 +93,7 @@ def test_multimodel_adapter_integration(state, tmpdir_factory):
     adapted_model = Adapter(
         Config(
             [model_path1, model_path2],
-            tendency_predictions={"dQ1": "air_temperature"},
+            tendency_predictions={"dQ1": "air_temperature", "dQ2": "air_temperature"},
             state_predictions={DOWN_SW_PREDICTION_NAME: "surface_precipitation_rate"},
             limit_negative_humidity=False,
         ),

--- a/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
+++ b/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
@@ -71,7 +71,7 @@ def test_adapter_regression(state, regtest, tmpdir_factory):
     regression_state(out, regtest)
 
 
-def test_multimodel_adapter(state):
+def test_tendency_or_state_multimodel_adapter(state):
     nz = 63
     outputs = {
         "Q1": np.full(nz, 1 / 86400),
@@ -135,7 +135,6 @@ def test_multimodel_adapter_integration(state, tmpdir_factory):
         state["air_temperature"] += 1
         return {"some_diag": state["specific_humidity"]}
 
+    assert "surface_precipitation_rate" not in state
     transform(add_one_to_temperature)()
-    assert "total_precipitation" in state
-    expected_precip = xr.full_like(state["surface_temperature"], 300.0 * 900 / 1000)
-    xr.testing.assert_allclose(state["total_precipitation"], expected_precip)
+    assert "surface_precipitation_rate" in state

--- a/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
+++ b/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
@@ -116,13 +116,13 @@ def test_multimodel_adapter_integration(state, tmpdir_factory):
     mock2 = get_mock_predictor(model_predictands="rad_fluxes")
     fv3fit.dump(mock1, model_path1)
     fv3fit.dump(mock2, model_path2)
-    DOWN_SW_PREDICITON_NAME = "total_sky_downward_shortwave_flux_at_surface"
+    DOWN_SW_PREDICTION_NAME = "total_sky_downward_shortwave_flux_at_surface"
 
     adapted_model = Adapter(
         Config(
             [model_path1, model_path2],
             tendency_predictions={"dQ1": "air_temperature"},
-            state_predictions={DOWN_SW_PREDICITON_NAME: "surface_precipitation_rate"},
+            state_predictions={DOWN_SW_PREDICTION_NAME: "surface_precipitation_rate"},
             limit_negative_humidity=False,
         ),
         900,
@@ -136,3 +136,6 @@ def test_multimodel_adapter_integration(state, tmpdir_factory):
         return {"some_diag": state["specific_humidity"]}
 
     transform(add_one_to_temperature)()
+    assert "total_precipitation" in state
+    expected_precip = xr.full_like(state["surface_temperature"], 300.0 * 900 / 1000)
+    xr.testing.assert_allclose(state["total_precipitation"], expected_precip)

--- a/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
+++ b/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
@@ -35,7 +35,7 @@ def test_adapter_regression(state, regtest, tmpdir_factory):
     adapted_model = Adapter(
         Config(
             [model_path],
-            {"air_temperature": "dQ1", "specific_humidity": "dQ2"},
+            tendency_predictions={"air_temperature": "dQ1", "specific_humidity": "dQ2"},
             limit_negative_humidity=True,
         ),
         900,
@@ -77,8 +77,8 @@ def test_multimodel_adapter(state, tmpdir_factory):
     adapted_model = Adapter(
         Config(
             [model_path1, model_path2],
-            {
-                "air_temperature": "dQ1",
+            tendency_predictions={"air_temperature": "dQ1"},
+            state_predictions={
                 "surface_temperature": "total_sky_downward_shortwave_flux_at_surface",
             },
             limit_negative_humidity=False,

--- a/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
+++ b/workflows/prognostic_c48_run/tests/test_fv3fit_transformer.py
@@ -116,14 +116,13 @@ def test_multimodel_adapter_integration(state, tmpdir_factory):
     mock2 = get_mock_predictor(model_predictands="rad_fluxes")
     fv3fit.dump(mock1, model_path1)
     fv3fit.dump(mock2, model_path2)
+    DOWN_SW_PREDICITON_NAME = "total_sky_downward_shortwave_flux_at_surface"
 
     adapted_model = Adapter(
         Config(
             [model_path1, model_path2],
             tendency_predictions={"dQ1": "air_temperature"},
-            state_predictions={
-                "total_sky_downward_shortwave_flux_at_surface": "surface_temperature",
-            },
+            state_predictions={DOWN_SW_PREDICITON_NAME: "surface_precipitation_rate"},
             limit_negative_humidity=False,
         ),
         900,


### PR DESCRIPTION
This PR allows using fine-res ML predictions as direct state updates in addition to as tendencies. It also allows the prediction of multiple tendencies that are all intended to be applied to the same state variable.

Refactored public API:
- Delete `runtime.transformers.fv3fit.Config.variables`
- Add `runtime.transformers.fv3fit.Config.tendency_predictions` and `runtime.transformers.fv3fit.Config.state_predictions` and note these are a mapping from ML output name to FV3GFS state variable name

Requirement changes:
- Update `fv3gfs-wrapper` submodule to latest master commit to allow setting of `surface_precipitation_rate`

- [x] Tests added