### PR TITLE
offline diags: check for either type of derived model

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -25,8 +25,16 @@ def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
     return ds.stack(sample=stack_dims).transpose("sample", ...)
 
 
+def _is_derived(predictor: fv3fit.Predictor) -> bool:
+    return isinstance(predictor, fv3fit.DerivedModel) or isinstance(
+        predictor, fv3fit.TransformedPredictor
+    )
+
+
 def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):
-    base_model = model.base_model if isinstance(model, fv3fit.DerivedModel) else model
+    base_model = model
+    while _is_derived(base_model):
+        base_model = base_model.base_model
     stacked_sample = _stack_sample_data(sample)
 
     try:

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_input_sensitivity.py
@@ -26,15 +26,20 @@ def _stack_sample_data(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _is_derived(predictor: fv3fit.Predictor) -> bool:
-    return isinstance(predictor, fv3fit.DerivedModel) or isinstance(
-        predictor, fv3fit.TransformedPredictor
-    )
+    is_derived_model = isinstance(predictor, fv3fit.DerivedModel)
+    is_transformed_predictor = isinstance(predictor, fv3fit.TransformedPredictor)
+    return is_derived_model or is_transformed_predictor
+
+
+def _get_base_model(model: fv3fit.Predictor) -> fv3fit.Predictor:
+    base_model = model
+    while _is_derived(base_model):
+        base_model = base_model.base_model  # type: ignore
+    return base_model
 
 
 def plot_input_sensitivity(model: fv3fit.Predictor, sample: xr.Dataset):
-    base_model = model
-    while _is_derived(base_model):
-        base_model = base_model.base_model
+    base_model = _get_base_model(model)
     stacked_sample = _stack_sample_data(sample)
 
     try:


### PR DESCRIPTION
For the input sensitivity figure in the offline diags report, it is necessary to access the "base model" if the provided predictor is a `DerivedModel` or `TransformedPredictor`. Currently the offline diags only checks for a `DerivedModel`.

Significant internal changes:
- if predictor is an instance of `fv3fit.TransformedPredictor` or `fv3fit.DerivedModel`, keep grabbing the `base_model` until we get a model that is not derived.