### PR TITLE
Parse fv3 log lines into json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ build_image_%:
 build_images: $(addprefix build_image_, $(IMAGES))
 push_images: $(addprefix push_image_, $(IMAGES))
 
+build_image_log_handler: docker/log_handler/requirements.txt
+
 build_image_fv3fit: docker/fv3fit/requirements.txt
 
 build_image_prognostic_run: docker/prognostic_run/requirements.txt
@@ -203,6 +205,13 @@ constraints.txt:
 	sed -i.bak  's/\[.*\]//g' constraints.txt
 	rm -f constraints.txt.bak .dataflow-versions.txt
 	@echo "remember to update numpy version in external/vcm/pyproject.toml"
+
+
+docker/%/requirements.txt: docker/%/requirements.in
+	cp -f constraints.txt $@
+	pip-compile  \
+	--no-annotate \
+	--output-file $@ $<
 
 docker/prognostic_run/requirements.txt: constraints.txt
 	cp constraints.txt docker/prognostic_run/requirements.txt

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -13,14 +13,17 @@ local state, and therefore easier to translate to a distributed context.
 For a segmented run "Runs" and "Segments" are the main entities. Runs have
 many segments and some global data stores.
 """
+import fileinput
 import logging
 import sys
+from typing import List
 
 import click
 import fv3config
 import fsspec
 
 from .run import run_segment
+from .logs import handle_fv3_log
 from . import api
 
 logger = logging.getLogger(__name__)
@@ -62,3 +65,27 @@ def run_native(fv3config_path: str, rundir: str):
     with open(fv3config_path) as f:
         config = fv3config.load(f)
     sys.exit(run_segment(config, rundir))
+
+
+@cli.command("parse-logs")
+@click.argument("paths", nargs=-1)
+def parse_logs(paths: List[str]):
+    """Parse a log file at a local path or from stdin
+
+    If not used within a pipe, it requires a full file path to one or more text
+    files, not to segmented run.
+
+    Example:
+
+        gsutil cat gs://bucket/path/to/log.txt | runfv3 parse-logs
+
+    """
+    if paths:
+        files = paths
+    else:
+        # "-" means stdin
+        files = ["-"]
+
+    with fileinput.input(files) as f:
+        for line in handle_fv3_log(f, labels={"fname": fileinput.filename()}):
+            print(line)

--- a/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
@@ -6,7 +6,6 @@ Description of special payload strings
 https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
 """
 from dataclasses import dataclass
-import logging
 import re
 from enum import Enum
 from typing import Mapping, Optional
@@ -132,13 +131,3 @@ def handle_fv3_log(f: Iterable[str], labels: Mapping[str, Any] = {},) -> Iterabl
     handler = Handler(labels)
     for line in f:
         yield handler.handle(parse_line(line))
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    fname = "/Users/noahb/workspace/ai2cm/fv3net/logs.txt"
-    import fileinput
-
-    with fileinput.input() as f:
-        for line in handle_fv3_log(f, labels={"fname": fileinput.filename()}):
-            print(line)

--- a/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""
+https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs
+
+Description of special payload strings
+https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+"""
+from dataclasses import dataclass
+import logging
+import re
+from enum import Enum
+from typing import Mapping, Optional
+import json
+from typing import Any, Iterable
+
+__all__ = ["handle_fv3_log"]
+
+
+class LineType(Enum):
+    # need to be letters for named groups to work
+    PYTHON_LOG = "python"
+    MAX_MIN = "max_min"
+    FV3_LOG = "fortran"
+
+
+# regexp for floating point number
+floating_point = r"[-+]?[0-9]*(\.[0-9]+(E-?\d+)?)?"
+
+REGEX = {
+    LineType.PYTHON_LOG: re.compile(
+        r"(?P<severity>(INFO|WARNING|ERROR|DEBUG|CRITICAL))"
+        ":"
+        r"(?P<module>.*?)"
+        ":"
+        r"(?P<message>.*)$"
+    ),
+    LineType.MAX_MIN: re.compile(
+        r"(?P<max_min_name>.*?)"
+        r"\s*max\s*=\s*"
+        + (r"(?P<max>" + floating_point + ")")
+        + r"\s*min\s*=\s*"
+        + (r"(?P<min>" + floating_point + ")")
+    ),
+    LineType.FV3_LOG: re.compile("(?P<message>.*$)"),
+}
+
+
+@dataclass
+class LogLine:
+    type: LineType
+    data: dict
+    line: str
+
+
+def parse_line(line):
+    for line_type in LineType:
+        match = REGEX[line_type].match(line)
+        if match:
+            return LogLine(line_type, match.groupdict(), line)
+    raise ValueError(f"Unable to parse line: {line}")
+
+
+class Handler:
+    """Handler handels the parsed lines produces by the log stream
+
+    Attributes:
+        model_time: the last handled time
+    """
+
+    LABEL_NAME = "logging.googleapis.com/labels"
+
+    def __init__(self, labels=Mapping[str, Any]):
+        """
+        Args:
+            labels: labels to make available for query in the Google Cloud Logging
+                console
+        """
+        self.model_time: Optional[str] = None
+        self.labels = labels
+
+    def _insert_model_time(self, payload):
+        payload[self.LABEL_NAME]["model_time"] = self.model_time
+        payload["model_time"] = self.model_time
+
+    def handle(self, line: LogLine):
+        payload = {**line.data}
+        payload[self.LABEL_NAME] = {"kind": line.type.value, **self.labels}
+        if line.type == LineType.PYTHON_LOG:
+            message = payload.pop("message")
+            try:
+                payload["json"] = json.loads(message)
+            except json.JSONDecodeError:
+                payload["message"] = message
+
+        if line.type == LineType.FV3_LOG:
+            payload["severity"] = "DEBUG"
+
+        self.model_time = payload.get("json", {}).get("time") or self.model_time
+
+        self._insert_model_time(payload)
+        return json.dumps(payload)
+
+
+def handle_fv3_log(f: Iterable[str], labels: Mapping[str, Any] = {},) -> Iterable[str]:
+    """Consume a fv3 log stream and produce a json stream
+
+    Args:
+
+        f: a iterable of lines ... e.g. a file object or sys.stdin
+        labels: the labels to make available for query in the Google Cloud Logging
+        output_stream: where to write the transformed data to e.g. sys.stdout
+
+    Examples:
+
+        Here are some jq filters that can processe these outputs.
+
+        To print the fortran log lines only::
+
+            jq -r 'select(.["logging.googleapis.com/labels"].kind == "fortran" ) \
+                | .message'
+
+        To print just the water vapor path and time::
+
+            jq -r 'select(.json.water_vapor_path )  \
+            | {time: .model_time, wvp: .json.water_vapor_path}'
+
+        To show all min/max variables::
+
+            jq -sr '[.[].max_min_name | select(. != null) | . ]  |  unique'
+
+    """  # noqa
+    handler = Handler(labels)
+    for line in f:
+        yield handler.handle(parse_line(line))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    fname = "/Users/noahb/workspace/ai2cm/fv3net/logs.txt"
+    import fileinput
+
+    with fileinput.input() as f:
+        for line in handle_fv3_log(f, labels={"fname": fileinput.filename()}):
+            print(line)

--- a/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/logs.py
@@ -60,7 +60,7 @@ def parse_line(line):
 
 
 class Handler:
-    """Handler handels the parsed lines produces by the log stream
+    """Handler handles the parsed lines produces by the log stream
 
     Attributes:
         model_time: the last handled time

--- a/workflows/prognostic_c48_run/tests/segmented_run/_regtest_outputs/test_handle_fv3_log.test_Handler.out
+++ b/workflows/prognostic_c48_run/tests/segmented_run/_regtest_outputs/test_handle_fv3_log.test_Handler.out
@@ -1,0 +1,10 @@
+{"severity": "DEBUG", "module": "runtime.loop", "logging.googleapis.com/labels": {"kind": "python", "model_time": null}, "message": "Physics Step (apply)", "model_time": null}
+{"message": "WARNING from PE     0: diag_util_mod::opening_file: module/field_name (dynamics/w50) NOT registered", "logging.googleapis.com/labels": {"kind": "fortran", "model_time": null}, "severity": "DEBUG", "model_time": null}
+{"max_min_name": " PS", "max": "1034.9816787407742", "min": "539.31719196478946", "logging.googleapis.com/labels": {"kind": "max_min", "model_time": null}, "model_time": null}
+{"message": "WARNING from PE     0: diag_util_mod::opening_file: module/field_name (dynamics/w50) NOT registered", "logging.googleapis.com/labels": {"kind": "fortran", "model_time": null}, "severity": "DEBUG", "model_time": null}
+{"message": " ---isec,seconds         900        1800", "logging.googleapis.com/labels": {"kind": "fortran", "model_time": null}, "severity": "DEBUG", "model_time": null}
+{"message": "  gfs diags time since last bucket empty:   0.25000000000000000      hrs", "logging.googleapis.com/labels": {"kind": "fortran", "model_time": null}, "severity": "DEBUG", "model_time": null}
+{"severity": "INFO", "module": "runtime.loop", "logging.googleapis.com/labels": {"kind": "python", "model_time": null}, "message": "Computing Postphysics Updates", "model_time": null}
+{"severity": "INFO", "module": "runtime.loop", "logging.googleapis.com/labels": {"kind": "python", "model_time": null}, "message": "Computing Postphysics Updates", "model_time": null}
+{"severity": "INFO", "module": "runtime.loop", "logging.googleapis.com/labels": {"kind": "python", "model_time": null}, "json": {"a": 1}, "model_time": null}
+{"message": "    ", "logging.googleapis.com/labels": {"kind": "fortran", "model_time": null}, "severity": "DEBUG", "model_time": null}

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_handle_fv3_log.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_handle_fv3_log.py
@@ -1,0 +1,48 @@
+import subprocess
+import re
+import typing
+from runtime.segmented_run.logs import (
+    LogLine,
+    LineType,
+    parse_line,
+    handle_fv3_log,
+    floating_point,
+)
+
+
+def test_parse_line():
+    assert LogLine(
+        LineType.FV3_LOG, {"message": "some data"}, "some data"
+    ) == parse_line("some data")
+    line = "INFO:fv3:[1]"
+    return LogLine(
+        LineType.PYTHON_LOG, {"severity": "INFO", "module": "fv3", "json": [1]}, line
+    ) == parse_line(line)
+
+
+def test_parse_floating_point():
+    assert re.search(floating_point, "1.0E-002").group(0) == "1.0E-002"
+    assert re.search(floating_point, "2.0").group(0) == "2.0"
+    assert re.search(floating_point, "-123.0").group(0) == "-123.0"
+
+
+def test_Handler(regtest: typing.TextIO):
+    data = """DEBUG:runtime.loop:Physics Step (apply)
+WARNING from PE     0: diag_util_mod::opening_file: module/field_name (dynamics/w50) NOT registered
+ PS max =    1034.9816787407742       min =    539.31719196478946
+WARNING from PE     0: diag_util_mod::opening_file: module/field_name (dynamics/w50) NOT registered
+ ---isec,seconds         900        1800
+  gfs diags time since last bucket empty:   0.25000000000000000      hrs
+INFO:runtime.loop:Computing Postphysics Updates
+INFO:runtime.loop:Computing Postphysics Updates
+INFO:runtime.loop:{"a": 1}
+    """  # noqa
+    input_stream = data.splitlines()
+    for line in handle_fv3_log(input_stream):
+        print(line, file=regtest)
+
+
+def test_read_from_subprocess():
+    """Check that we can iterate over lines from a subprocess as expected"""
+    proc = subprocess.Popen(["printf", "a\nb\nc\nd"], stdout=subprocess.PIPE, text=True)
+    assert list(proc.stdout) == ["a\n", "b\n", "c\n", "d"]

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -727,7 +727,7 @@ def test_fv3run_emulation_zarr_out(completed_rundir, configuration, regtest):
     emu_state_zarr.info(regtest)
 
 
-def test_each_line_of_life_is_json(completed_segment):
+def test_each_line_of_file_is_json(completed_segment):
     with completed_segment.join("logs.txt").open() as f:
         k = 0
         for line in f:

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -727,6 +727,16 @@ def test_fv3run_emulation_zarr_out(completed_rundir, configuration, regtest):
     emu_state_zarr.info(regtest)
 
 
+def test_each_line_of_life_is_json(completed_segment):
+    with completed_segment.join("logs.txt").open() as f:
+        k = 0
+        for line in f:
+            json.loads(line)
+            k += 1
+    some_lines_read = k > 0
+    assert some_lines_read
+
+
 def test_fv3run_emulation_nc_out(completed_segment, configuration, regtest):
 
     if configuration != ConfigEnum.microphys_emulation:


### PR DESCRIPTION
It would be nice to monitor and analzye the fv3 logs more easily to e.g. allow faster turnaround on top level metrics.  Currently, the FV3 logs are not very machine readable and do not integrate well with k8s/gcp logging. This PR processes the logs to output structure json objects that will integrate smoothly with many types of tooling (jq, Google Cloud Logging, etc). One could envision some agent monitoring the stream and uploading top level metrics to wandb.

Some examples:

This is what a fortran output line is transformed to:

    {
      "message": "NOTE from PE     0: MPP_DOMAINS_SET_STACK_SIZE: stack size set to    32768.",
      "logging.googleapis.com/labels": {
        "kind": "fortran",
        "fname": null,
        "model_time": null
      },
      "severity": "DEBUG",
      "model_time": null
    }

A python log line where the message is a json formatted string looks
like this:
```
    {
      "severity": "INFO",
      "module": "statistics",
      "logging.googleapis.com/labels": {
        "kind": "python",
        "fname": null,
        "model_time": "2016-08-10T00:15:00"
      },
      "json": {
        "time": "2016-08-10T00:15:00",
        "column_integrated_dQu": 0,
        "column_integrated_dQv": 0,
        "storage_of_specific_humidity_path_due_to_microphysics": 1.4559948181603119e-05,
        "evaporation": 3.477911480923804e-05,
        "cnvprcp_after_physics": 2.3219503874294952e-05,
        "total_precip_after_physics": 2.78660017111974e-05,
        "storage_of_mass_due_to_fv3_physics": 4.2218462977353356e-05,
        "column_integrated_dQ1_change_non_neg_sphum_constraint": -9.21344804488168,
        "column_integrated_dQ2_change_non_neg_sphum_constraint": 4.112280082814816e-06,
        "net_moistening": -1.0003816217438856e-05,
        "net_heating": 32.11221217099007,
        "water_vapor_path": 25.614354993013656,
        "physics_precip": 3.096222412355266e-05,
        "area": 38505756482.50796,
        "cnvprcp_after_python": 2.3219503874294952e-05,
        "total_precipitation_rate": 4.519084260558481e-05,
        "storage_of_mass_due_to_python": -9.813743709285837e-05
      },
      "model_time": "2016-08-10T00:15:00"
    }
```

I added returns to the examples above for readability....they are
actually emited one json per line, which makes processing with `jq` etc
trivial.