### PR TITLE
Add fv3net/diagnostics/prognostic_run to mypy precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,8 @@ repos:
         workflows/prognostic_c48_run/tests/.+ |
         external/fv3fit/fv3fit/.+ |
         external/loaders/loaders/.+ |
-        workflows/diagnostics/fv3net/diagnostics/offline/.+
+        workflows/diagnostics/fv3net/diagnostics/offline/.+ |
+        workflows/diagnostics/fv3net/diagnostics/prognostic_run/.+
         )$
       exclude: |
         (?x)^(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -24,7 +24,7 @@ import fsspec
 from joblib import Parallel, delayed
 
 
-from typing import Mapping, Union, Tuple, Sequence
+from typing import Optional, Mapping, MutableMapping, Union, Tuple, Sequence
 
 import vcm
 
@@ -107,7 +107,7 @@ def _merge_diag_computes(
 
 
 def merge_diags(diags: Sequence[Tuple[str, xr.Dataset]]) -> Mapping[str, xr.DataArray]:
-    out = {}
+    out: MutableMapping[str, xr.DataArray] = {}
     for name, ds in diags:
         out.update(_prepare_diag_dict(name, ds))
     return out
@@ -155,11 +155,13 @@ def time_mean(ds: xr.Dataset, dim: str = "time") -> xr.Dataset:
     return _assign_diagnostic_time_attrs(result, ds)
 
 
-def _get_time_attrs(ds: Union[xr.Dataset, xr.DataArray]) -> Mapping[str, str]:
+def _get_time_attrs(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[Mapping[str, str]]:
     if "time" in ds.coords:
         start_time = str(ds.time.values[0])
         end_time = str(ds.time.values[-1])
         return {"diagnostic_start_time": start_time, "diagnostic_end_time": end_time}
+    else:
+        return None
 
 
 def _assign_diagnostic_time_attrs(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -22,7 +22,7 @@ __all__ = ["ComputedDiagnosticsList", "RunDiagnostics"]
 
 GRID_VARS = ["area", "lonb", "latb", "lon", "lat", "land_sea_mask"]
 
-Diagnostics = Iterable[xr.Dataset]
+Diagnostics = Sequence[xr.Dataset]
 Metadata = Any
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/config.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/config.py
@@ -1,10 +1,10 @@
-from typing import Mapping, Sequence
+from typing import Mapping, List
 import intake
 
 
 def get_verification_entries(
     name: str, catalog: intake.catalog.Catalog
-) -> Mapping[str, Sequence[str]]:
+) -> Mapping[str, List[str]]:
     """Given simulation name, return catalog keys for c48 dycore and physics data.
 
     Args:
@@ -15,7 +15,7 @@ def get_verification_entries(
         Mapping from category name ('physics', 'dycore', or '3d') to sequence
         of catalog keys representing given diagnostics for specified simulation.
     """
-    entries = {"2d": [], "3d": []}
+    entries: Mapping[str, List[str]] = {"2d": [], "3d": []}
     for item in catalog:
         metadata = catalog[item].metadata
         item_simulation = metadata.get("simulation", None)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
@@ -5,6 +5,7 @@ import xarray as xr
 import vcm
 
 SECONDS_PER_DAY = 86400
+TOLERANCE = 1.0e-12
 
 logger = logging.getLogger(__name__)
 
@@ -276,14 +277,14 @@ def _total_precip_to_surface(ds: xr.Dataset) -> xr.DataArray:
     return total_precip_to_surface.rename("total_precip_to_surface")
 
 
-def _column_dq1_or_nq1(ds: xr.Dataset, tol=1.0e-12) -> xr.DataArray:
+def _column_dq1_or_nq1(ds: xr.Dataset) -> xr.DataArray:
     """<dQ1>+<nQ1> with appropriate long name if either is zero. Useful for movies."""
     column_dq1 = _column_dq1(ds)
     column_nq1 = _column_nq1(ds)
     column_dq1_or_nq1 = column_dq1 + column_nq1
-    if abs(column_nq1).max() < tol:
+    if abs(column_nq1).max() < TOLERANCE:
         long_name = "<dQ1> column integrated moistening from ML"
-    elif abs(column_dq1).max() < tol:
+    elif abs(column_dq1).max() < TOLERANCE:
         long_name = "<nQ1> column integrated moistening from nudging"
     else:
         long_name = "<dQ1> + <nQ1> column integrated moistening from ML + nudging"
@@ -291,14 +292,14 @@ def _column_dq1_or_nq1(ds: xr.Dataset, tol=1.0e-12) -> xr.DataArray:
     return column_dq1_or_nq1.rename("column_integrated_dQ1_or_nQ1")
 
 
-def _column_dq2_or_nq2(ds: xr.Dataset, tol=1.0e-12) -> xr.DataArray:
+def _column_dq2_or_nq2(ds: xr.Dataset) -> xr.DataArray:
     """<dQ2>+<nQ2> with appropriate long name if either is zero. Useful for movies."""
     column_dq2 = _column_dq2(ds)
     column_nq2 = _column_nq2(ds)
     column_dq2_or_nq2 = column_dq2 + column_nq2
-    if abs(column_nq2).max() < tol:
+    if abs(column_nq2).max() < TOLERANCE:
         long_name = "<dQ2> column integrated moistening from ML"
-    elif abs(column_dq2).max() < tol:
+    elif abs(column_dq2).max() < TOLERANCE:
         long_name = "<nQ2> column integrated moistening from nudging"
     else:
         long_name = "<dQ2> + <nQ2> column integrated moistening from ML + nudging"

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -33,7 +33,6 @@ WANDB_PROJECT = "microphysics-emulation"
 WANDB_ENTITY = "ai2cm"
 
 log_functions = []
-summary_functions = []
 
 
 def register_log(func):
@@ -154,7 +153,7 @@ def global_average_cloud_5d_300mb_ppm(ds: xr.Dataset) -> Iterable[Tuple[str, flo
 
     selected_height = selected.interp(z=z)
     average_cloud = float(
-        vcm.weighted_average(selected_height, ds.area, dims=set(selected_height.dims))
+        vcm.weighted_average(selected_height, ds.area, dims=selected_height.dims)
     )
     yield (
         global_average_cloud_5d_300mb_ppm.__name__,
@@ -193,8 +192,8 @@ def skills_3d(
 ):
     out = {}
     for field in fields:
-        prediction = transform(ds, field, source="emulator")
-        truth = transform(ds, field, source="physics")
+        prediction = transform(ds, field, "emulator")
+        truth = transform(ds, field, "physics")
         out[field] = skill_improvement(truth, prediction, ds.area)
     return xr.Dataset(out)
 
@@ -202,8 +201,8 @@ def skills_3d(
 def column_integrated_skill(
     ds: xr.Dataset, transform: Callable[[xr.Dataset, str], xr.DataArray],
 ):
-    prediction = transform(ds, source="emulator")
-    truth = transform(ds, source="physics")
+    prediction = transform(ds, "emulator")
+    truth = transform(ds, "physics")
     return skill_improvement_column(truth, prediction, ds.area)
 
 
@@ -346,7 +345,9 @@ def get_summary_functions() -> Iterable[
         ("column_skill/gscond", tendencies.gscond_tendency),
         ("column_skill/precpd", tendencies.precpd_tendency),
     ]:
-        func = partial(summarize_column_skill, prefix=name, tendency_func=tendency_func)
+        func: Callable = partial(
+            summarize_column_skill, prefix=name, tendency_func=tendency_func
+        )
         func.__name__ = name
         yield func
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -132,7 +132,7 @@ def skill_time_table(ds):
 def summarize_column_skill(ds, prefix, tendency_func):
     return {
         f"{prefix}/{field}": float(
-            column_integrated_skill(ds, partial(tendency_func, field=field))
+            column_integrated_skill(ds, lambda x, y: tendency_func(x, field, y))
         )
         for field in SKILL_FIELDS
     }.items()

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from typing_extensions import Protocol
-from typing import List
+from typing import List, Mapping
 import warnings
 
 import fsspec
@@ -135,7 +135,9 @@ def loads_stats(b: bytes):
 def open_segmented_stats(url: str) -> pd.DataFrame:
     fs = get_fs(url)
     logfiles = sorted(fs.glob(f"{url}/**/statistics.txt"))
-    records = sum([loads_stats(fs.cat(logfile)) for logfile in logfiles], [])
+    records: List[Mapping] = sum(
+        [loads_stats(fs.cat(logfile)) for logfile in logfiles], []
+    )
     return pd.DataFrame.from_records(records)
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -1,12 +1,12 @@
 import logging
 from collections import defaultdict
-from typing import Tuple, Mapping
+from typing import Tuple, Mapping, MutableMapping
 import xarray as xr
 
 import cartopy.crs as ccrs
 import jinja2
 import matplotlib.pyplot as plt
-import matplotlib
+from matplotlib.colors import LogNorm
 import numpy as np
 
 from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
@@ -17,6 +17,7 @@ import fv3viz
 from report import MatplotlibFigure, RawHTML
 
 COORD_VARS = ["lon", "lat", "lonb", "latb"]
+OverlaidPlotData = MutableMapping[str, MutableMapping[str, MatplotlibFigure]]
 
 
 template = jinja2.Template(
@@ -63,7 +64,7 @@ def plot_2d_matplotlib(
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
     All matching diagnostics must be 2D and have the same dimensions."""
 
-    data = defaultdict(dict)
+    data: OverlaidPlotData = defaultdict(dict)
 
     # kwargs handling
     ylabel = opts.pop("ylabel", "")
@@ -123,7 +124,7 @@ def plot_cubed_sphere_map(
         run_diags must include lat/lon/latb/lonb coordinates.
     """
 
-    data = defaultdict(dict)
+    data: OverlaidPlotData = defaultdict(dict)
     if metrics_for_title is None:
         metrics_for_title = {}
 
@@ -181,7 +182,7 @@ def plot_histogram(
 def plot_histogram2d(run_diags: RunDiagnostics, xname: str, yname: str) -> RawHTML:
     """Plot 2D histogram of xname versus yname overlaid across runs."""
 
-    data = defaultdict(dict)
+    data: OverlaidPlotData = defaultdict(dict)
     count_name = f"{xname.lower()}_versus_{yname.lower()}_hist_2d"
     conditional_average_name = f"conditional_average_of_{yname}_on_{xname}"
     x_bin_name = f"{xname}_bins"
@@ -203,7 +204,7 @@ def plot_histogram2d(run_diags: RunDiagnostics, xname: str, yname: str) -> RawHT
         xcenters = x.values + 0.5 * x_bin_widths.values
         fig, ax = plt.subplots()
         xx, yy = np.meshgrid(xedges, yedges)
-        ax.pcolormesh(xx, yy, count.T, norm=matplotlib.colors.LogNorm(), cmap="Blues")
+        ax.pcolormesh(xx, yy, count.T, norm=LogNorm(), cmap="Blues")
         ax.plot(xcenters, conditional_average, color="r", linewidth=2)
         ax.set_xlabel(f"{xname} [{x_bin_widths.units}]")
         ax.set_ylabel(f"{yname} [{y_bin_widths.units}]")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from typing import Iterable, Mapping, Sequence, Tuple
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 import os
 import xarray as xr
 import fsspec
@@ -44,7 +44,7 @@ logging.basicConfig(level=logging.INFO)
 hv.extension("bokeh")
 PUBLIC_GCS_DOMAIN = "https://storage.googleapis.com"
 MovieManifest = Sequence[Tuple[str, str]]
-PublicLinks = Mapping[str, Sequence[Tuple[str, str]]]
+PublicLinks = Dict[str, List[Tuple[str, str]]]
 
 
 def upload(html: str, url: str, content_type: str = "text/html"):
@@ -536,7 +536,7 @@ def _get_movie_manifest(movie_urls: MovieUrls, output: str) -> MovieManifest:
 
 def _get_public_links(movie_urls: MovieUrls, output: str) -> PublicLinks:
     """Get the public links at which each movie can be opened in a browser."""
-    public_links = {}
+    public_links: PublicLinks = {}
     for run_name, urls in movie_urls.items():
         for url in urls:
             movie_name = _movie_name(url)
@@ -638,7 +638,3 @@ def main_json(args):
         args.input, args.urls_are_rundirs
     )
     make_report(computed_diagnostics, args.output)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
We use a lot of type hints in the prognostic run diagnostics, but they are not verified as part of linting. This PR adds this code to the mypy files and fixes the existing issues.

EDIT: the existing mypy issues can be seen here: https://app.circleci.com/pipelines/github/ai2cm/fv3net/11717/workflows/8ac94a1b-f715-4361-86ad-4a92030f4061/jobs/104292