### PR TITLE
Fix integration test empty WANDB_TAGS var

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -389,3 +389,5 @@ spec:
             value: "24"
           - name: memory-prog
             value: 25Gi
+          - name: wandb-group
+            value: integration-tests

--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -41,8 +41,6 @@ spec:
             value: ai2cm
           - name: WANDB_PROJECT
             value: "{{inputs.parameters.wandb-project}}"
-          - name: WANDB_TAGS
-            value: "{{inputs.parameters.wandb-tags}}"
           - name: WANDB_RUN_GROUP
             value: "{{inputs.parameters.wandb-group}}"
         envFrom:
@@ -55,6 +53,10 @@ spec:
           - |
 
             gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+
+            if [ ! -z {{inputs.parameters.wandb-tags}} ]; then
+              export WANDB_TAGS={{inputs.parameters.wandb-tags}}
+            fi
 
             cat << EOF > test_data.yaml
             {{inputs.parameters.test_data_config}}

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -39,8 +39,6 @@ spec:
             value: ai2cm
           - name: WANDB_PROJECT
             value: "{{inputs.parameters.wandb-project}}"
-          - name: WANDB_TAGS
-            value: "{{inputs.parameters.wandb-tags}}"
           - name: WANDB_RUN_GROUP
             value: "{{inputs.parameters.wandb-group}}"
         envFrom:
@@ -51,6 +49,10 @@ spec:
             name: gcp-key-secret
         args:
           - |
+
+            if [ ! -z {{inputs.parameters.wandb-tags}} ]; then
+              export WANDB_TAGS={{inputs.parameters.wandb-tags}}
+            fi
 
             cat <<EOF >training_config.yaml
             {{inputs.parameters.training_config}}


### PR DESCRIPTION
By default the argo workflow set the env var WANDB_TAGS to an empty string. Wandb raises an error if this is an empty string rather than not defined. I changed the templates only set this env var if non empty.
