### PR TITLE
Prog run: diagnostics dimension order consistency

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -169,13 +169,18 @@ class DiagnosticFile:
             for key in average:
                 average[key].attrs["units"] = self._units[key]
             data_to_sink = {
-                key: average[key] for key in average if key in self.variables
+                key: sort_dims(average[key]) for key in average if key in self.variables
             }
             self._sink.sink(self._current_label, data_to_sink)
             self._last_time_flushed = self._current_label
 
     def __del__(self):
         self.flush()
+
+
+def sort_dims(da: xr.DataArray, preferred_order=["z", "y", "x"]):
+    dims_in_array = [dim for dim in preferred_order if dim in da.dims]
+    return da.transpose(*dims_in_array)
 
 
 def get_diagnostic_files(

--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -23,6 +23,9 @@ from .tensorboard import TensorBoardSink
 logger = logging.getLogger(__name__)
 
 
+PREFERRED_ORDER = ["z", "y", "x", "y_interface", "x_interface"]
+
+
 @dataclasses.dataclass
 class DiagnosticFileConfig:
     """Configurations for Diagnostic Files
@@ -178,7 +181,7 @@ class DiagnosticFile:
         self.flush()
 
 
-def sort_dims(da: xr.DataArray, preferred_order=["z", "y", "x"]):
+def sort_dims(da: xr.DataArray, preferred_order=PREFERRED_ORDER):
     dims_in_array = [dim for dim in preferred_order if dim in da.dims]
     return da.transpose(*dims_in_array)
 

--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -23,7 +23,7 @@ from .tensorboard import TensorBoardSink
 logger = logging.getLogger(__name__)
 
 
-PREFERRED_ORDER = ["z", "y", "x", "y_interface", "x_interface"]
+PREFERRED_ORDER = ["z", "z_soil", "y", "y_interface", "x", "x_interface"]
 
 
 @dataclasses.dataclass
@@ -181,7 +181,9 @@ class DiagnosticFile:
         self.flush()
 
 
-def sort_dims(da: xr.DataArray, preferred_order=PREFERRED_ORDER):
+def sort_dims(
+    da: xr.DataArray, preferred_order: Sequence[str] = PREFERRED_ORDER
+) -> xr.DataArray:
     dims_in_array = [dim for dim in preferred_order if dim in da.dims]
     return da.transpose(*dims_in_array)
 


### PR DESCRIPTION
We've had a heterogeneous set of prognostic runs fail with the same array dimension error when writing diagnostics to zarr. In at least one case it's because the python wrapper is not returning consistent diagnostic dimension order across ranks and timesteps, causing the zarr monitor to fail to append. This PR enforces consistent dimension order for anything written to zarr. 

Significant internal changes:
- Diagnostics are now required to have dimensions in z,y,x (3d) or y,x (2d) order when written. 

- [X] Tests added

Resolves #1767 (at least some of the cases, hopefully all)
