### PR TITLE
Backport diags array fix

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -169,13 +169,18 @@ class DiagnosticFile:
             for key in average:
                 average[key].attrs["units"] = self._units[key]
             data_to_sink = {
-                key: average[key] for key in average if key in self.variables
+                key: sort_dims(average[key]) for key in average if key in self.variables
             }
             self._sink.sink(self._current_label, data_to_sink)
             self._last_time_flushed = self._current_label
 
     def __del__(self):
         self.flush()
+
+
+def sort_dims(da: xr.DataArray, preferred_order=["z", "y", "x"]):
+    dims_in_array = [dim for dim in preferred_order if dim in da.dims]
+    return da.transpose(*dims_in_array)
 
 
 def get_diagnostic_files(

--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -23,6 +23,9 @@ from .tensorboard import TensorBoardSink
 logger = logging.getLogger(__name__)
 
 
+PREFERRED_ORDER = ["z", "y", "x", "y_interface", "x_interface"]
+
+
 @dataclasses.dataclass
 class DiagnosticFileConfig:
     """Configurations for Diagnostic Files
@@ -178,7 +181,7 @@ class DiagnosticFile:
         self.flush()
 
 
-def sort_dims(da: xr.DataArray, preferred_order=["z", "y", "x"]):
+def sort_dims(da: xr.DataArray, preferred_order=PREFERRED_ORDER):
     dims_in_array = [dim for dim in preferred_order if dim in da.dims]
     return da.transpose(*dims_in_array)
 

--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -23,7 +23,7 @@ from .tensorboard import TensorBoardSink
 logger = logging.getLogger(__name__)
 
 
-PREFERRED_ORDER = ["z", "y", "x", "y_interface", "x_interface"]
+PREFERRED_ORDER = ["z", "z_soil", "y", "y_interface", "x", "x_interface"]
 
 
 @dataclasses.dataclass
@@ -181,7 +181,9 @@ class DiagnosticFile:
         self.flush()
 
 
-def sort_dims(da: xr.DataArray, preferred_order=PREFERRED_ORDER):
+def sort_dims(
+    da: xr.DataArray, preferred_order: Sequence[str] = PREFERRED_ORDER
+) -> xr.DataArray:
     dims_in_array = [dim for dim in preferred_order if dim in da.dims]
     return da.transpose(*dims_in_array)
 


### PR DESCRIPTION
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]
