### PR TITLE
Generate emulation training data v4

### DIFF
--- a/external/emulation/emulation/_monitor/monitor.py
+++ b/external/emulation/emulation/_monitor/monitor.py
@@ -233,18 +233,18 @@ class StorageHook:
             rank = MPI.COMM_WORLD.Get_rank()
             self._store_tfrecord = _TFRecordStore("tfrecords", rank)
 
-    def _store_interval_check(self, time):
+    def _store_data_at_time(self, time: cftime.DatetimeJulian):
 
-        # add increment since we are in the middle of timestep
-        increment = timedelta(seconds=self.dt_sec)
-        elapsed = (time + increment) - self.initial_time
+        elapsed: timedelta = time - self.initial_time
+        elapsed_seconds = elapsed.total_seconds()
 
         logger.debug(f"Time elapsed after increment: {elapsed}")
         logger.debug(
             f"Output frequency modulus: {elapsed.seconds % self.output_freq_sec}"
         )
-
-        return elapsed.seconds % self.output_freq_sec == 0
+        return (elapsed_seconds % self.output_freq_sec == 0) and (
+            elapsed_seconds >= self.output_start_sec
+        )
 
     def store(self, state: FortranState) -> None:
         """
@@ -266,7 +266,8 @@ class StorageHook:
             self.initial_time = time
 
         # add increment since we are in the middle of timestep
-        if self._store_interval_check(time):
+        increment = timedelta(seconds=self.dt_sec)
+        if self._store_data_at_time(time + increment):
 
             logger.debug(
                 f"Store flags: save_zarr={self.save_zarr}, save_nc={self.save_nc}"

--- a/external/emulation/tests/test_config.py
+++ b/external/emulation/tests/test_config.py
@@ -1,5 +1,13 @@
 from emulation._emulate.microphysics import TimeMask
-from emulation.config import EmulationConfig, ModelConfig
+from emulation.config import (
+    EmulationConfig,
+    ModelConfig,
+    StorageConfig,
+    _load_nml,
+    _get_timestep,
+    _get_storage_hook,
+    get_hooks,
+)
 import datetime
 
 
@@ -35,3 +43,29 @@ def test_ModelConfig_with_interval():
         mask for mask in config._build_masks() if isinstance(mask, TimeMask)
     ][0]
     assert time_schedule.schedule == schedule
+
+
+def test__get_timestep(dummy_rundir):
+    namelist = _load_nml()
+    timestep = _get_timestep(namelist)
+
+    assert timestep == 900
+
+
+def test__load_nml(dummy_rundir):
+
+    namelist = _load_nml()
+    assert namelist["coupler_nml"]["hours"] == 1
+
+
+def test__get_storage_hook(dummy_rundir):
+    config = StorageConfig()
+    hook = _get_storage_hook(config)
+    assert hook
+
+
+def test_get_hooks(dummy_rundir):
+    gscond, model, storage = get_hooks()
+    assert storage
+    assert model
+    assert gscond

--- a/external/emulation/tests/test_top_level.py
+++ b/external/emulation/tests/test_top_level.py
@@ -1,2 +1,2 @@
 def test_hooks_defined():
-    from emulation import store, microphysics  # noqa: F401
+    from emulation import gscond, store, microphysics  # noqa: F401

--- a/external/emulation/tests/test_zc_emu_monitor.py
+++ b/external/emulation/tests/test_zc_emu_monitor.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import os
 from typing import Mapping
 
@@ -172,3 +173,25 @@ def test_StorageHook_does_not_modify_state():
     state_before = state.copy()
     hook.store(state)
     assert state == state_before
+
+
+def test_StorageHook__store_data_at_time():
+
+    hook = StorageHook(output_freq_sec=10, save_nc=False, save_zarr=False)
+    t0 = datetime(2020, 1, 1, 0, 0, 0)
+    hook.initial_time = t0
+    assert hook._store_data_at_time(t0 + timedelta(seconds=10))
+
+    hook = StorageHook(
+        output_freq_sec=10, output_start_sec=11, save_nc=False, save_zarr=False
+    )
+    t0 = datetime(2020, 1, 1, 0, 0, 0)
+    hook.initial_time = t0
+    assert not hook._store_data_at_time(t0 + timedelta(seconds=10))
+    assert hook._store_data_at_time(t0 + timedelta(seconds=20))
+
+    hook = StorageHook(
+        output_freq_sec=18000, output_start_sec=864_000, save_nc=False, save_zarr=False
+    )
+    hook.initial_time = datetime(2016, 3, 1, 0, 0, 0)
+    assert hook._store_data_at_time(datetime(2016, 3, 11, 0, 0))

--- a/projects/microphysics/configs/default.yaml
+++ b/projects/microphysics/configs/default.yaml
@@ -198,299 +198,58 @@ diagnostics:
   - tendency_of_pressure_thickness_of_atmospheric_layer_due_to_fv3_physics
 experiment_name: default_experiment
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 namelist:
-  amip_interp_nml:
-    data_set: reynolds_oi
-    date_out_of_range: climo
-    interp_oi_sst: true
-    no_anom_sst: false
-    use_ncep_ice: false
-    use_ncep_sst: true
+  namsfc:
+    # these flags make the coarse run use the GRIB data for snoalb and vegetation
+    # if not included, it will use the restart data (which may differ from GRIB file)
+    # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
+    fabss: 0
+    fabsl: 0
+    fvmnl: 0
+    fvmns: 0
+    fvmxl: 0
+    fvmxs: 0
+    # for time-varying SSTs from GRIB
+    ftsfs: 0
+    # for time-varying sea ice from GRIB
+    fsicl: 0
+    fsics: 0
+    faisl: 0
+    faiss: 0
   atmos_model_nml:
     blocksize: -1
-    chksum_debug: false
-    dycore_only: false
-    fdiag: 0.0
-    fhmax: 1024.0
-    fhmaxhf: -1.0
-    fhout: 0.25
-    fhouthf: 0.0
-  cires_ugwp_nml:
-    knob_ugwp_azdir:
-    - 2
-    - 4
-    - 4
-    - 4
-    knob_ugwp_doaxyz: 1
-    knob_ugwp_doheat: 1
-    knob_ugwp_dokdis: 0
-    knob_ugwp_effac:
-    - 1
-    - 1
-    - 1
-    - 1
-    knob_ugwp_ndx4lh: 4
-    knob_ugwp_solver: 2
-    knob_ugwp_source:
-    - 1
-    - 1
-    - 1
-    - 0
-    knob_ugwp_stoch:
-    - 0
-    - 0
-    - 0
-    - 0
-    knob_ugwp_version: 0
-    knob_ugwp_wvspec:
-    - 1
-    - 32
-    - 32
-    - 32
-    launch_level: 55
   coupler_nml:
-    atmos_nthreads: 1
-    calendar: julian
     current_date:
     - 2016
-    - 8
-    - 2
+    - $MONTH_INT
+    - 1
     - 0
     - 0
     - 0
-    days: 10
-    dt_atmos: 900
-    dt_ocean: 900
-    hours: 6
-    memuse_verbose: true
+    days: 12
+    hours: 0
     minutes: 0
-    months: 0
-    ncores_per_node: 32
     seconds: 0
-    use_hyper_thread: true
   diag_manager_nml:
     flush_nc_files: true
-    prepend_date: false
-  external_ic_nml:
-    checker_tr: false
-    filtered_terrain: true
-    gfs_dwinds: true
-    levp: 64
-    nt_checker: 0
-  fms_io_nml:
-    checksum_required: false
-    max_files_r: 100
-    max_files_w: 100
-  fms_nml:
-    clock_grain: ROUTINE
-    domains_stack_size: 3000000
-    print_memory_usage: false
   fv_core_nml:
-    a_imp: 1.0
-    adjust_dry_mass: false
-    beta: 0.0
-    consv_am: false
-    consv_te: 1.0
-    d2_bg: 0.0
-    d2_bg_k1: 0.16
-    d2_bg_k2: 0.02
-    d4_bg: 0.15
-    d_con: 1.0
-    d_ext: 0.0
-    dddmp: 0.2
-    delt_max: 0.002
-    dnats: 1
     do_sat_adj: false
-    do_vort_damp: true
-    dwind_2d: false
-    external_eta: true
-    external_ic: false
-    fill: true
-    fv_debug: false
-    fv_sg_adj: 900
-    gfs_phil: false
-    hord_dp: 6
-    hord_mt: 6
-    hord_tm: 6
-    hord_tr: 8
-    hord_vt: 6
-    hydrostatic: false
-    io_layout:
-    - 1
-    - 1
-    k_split: 1
-    ke_bg: 0.0
-    kord_mt: 10
-    kord_tm: -10
-    kord_tr: 10
-    kord_wz: 10
-    layout:
-    - 1
-    - 1
-    make_nh: false
-    mountain: true
-    n_split: 6
-    n_sponge: 4
-    na_init: 0
-    ncep_ic: false
-    nggps_ic: false
-    no_dycore: false
-    nord: 2
-    npx: 49
-    npy: 49
-    npz: 79
-    ntiles: 6
     nudge: false
-    nudge_qv: true
+    nudge_qv: false
+    warm_start: false
+    external_ic: true
+    external_eta: false
+    make_nh: true
+    nggps_ic: true
+    mountain: false
+    na_init: 1
     nwat: 2
-    p_fac: 0.1
-    phys_hydrostatic: false
-    print_freq: 3
-    range_warn: false
-    reset_eta: false
-    rf_cutoff: 800.0
-    rf_fast: false
-    tau: 5.0
-    use_hydro_pressure: false
-    vtdm4: 0.06
-    warm_start: true
-    z_tracer: true
-  fv_grid_nml: {}
   gfdl_cloud_microphysics_nml:
-    c_cracw: 0.8
-    c_paut: 0.5
-    c_pgacs: 0.01
-    c_psaci: 0.05
-    ccn_l: 300.0
-    ccn_o: 100.0
-    const_vg: false
-    const_vi: false
-    const_vr: false
-    const_vs: false
-    de_ice: false
-    do_qa: true
-    do_sedi_heat: false
-    dw_land: 0.16
-    dw_ocean: 0.1
     fast_sat_adj: false
-    fix_negative: true
-    icloud_f: 1
-    mono_prof: true
-    mp_time: 450.0
-    prog_ccn: false
-    qi0_crt: 8.0e-05
-    qi_lim: 1.0
-    ql_gen: 0.001
-    ql_mlt: 0.001
-    qs0_crt: 0.001
-    rad_graupel: true
-    rad_rain: true
-    rad_snow: true
-    rh_inc: 0.3
-    rh_inr: 0.3
-    rh_ins: 0.3
-    rthresh: 1.0e-05
-    sedi_transport: false
-    tau_g2v: 900.0
-    tau_i2s: 1000.0
-    tau_l2v:
-    - 225.0
-    tau_v2l: 150.0
-    use_ccn: true
-    use_ppm: false
-    vg_max: 12.0
-    vi_max: 1.0
-    vr_max: 12.0
-    vs_max: 2.0
-    z_slope_ice: true
-    z_slope_liq: true
   gfs_physics_nml:
-    cal_pre: false
-    cdmbgwd:
-    - 3.5
-    - 0.25
-    cnvcld: false
-    cnvgwd: true
-    debug: false
-    dspheat: true
-    fhcyc: 24.0
-    fhlwr: 3600.0
-    fhswr: 3600.0
-    fhzero: 0.25
-    hybedmf: true
-    iaer: 111
-    ialb: 1
-    ico2: 2
-    iems: 1
-    imfdeepcnv: 2
-    imfshalcnv: 2
-    imp_physics: 99
-    isol: 2
-    isot: 1
-    isubc_lw: 2
-    isubc_sw: 2
-    ivegsrc: 1
-    ldiag3d: true
-    lwhtr: true
-    ncld: 1
-    nst_anl: true
-    pdfcld: false
-    pre_rad: false
-    prslrd0: 0.0
-    random_clds: false
-    redrag: true
     satmedmf: false
-    shal_cnv: true
-    swhtr: true
-    trans_trac: true
-    use_ufo: true
-    save_zc_microphysics: true
-    emulate_zc_microphysics: true
-  interpolator_nml:
-    interp_method: conserve_great_circle
-  nam_stochy:
-    lat_s: 96
-    lon_s: 192
-    ntrunc: 94
-  namsfc:
-    fabsl: 99999
-    faisl: 99999
-    faiss: 99999
-    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
-    fnacna: ''
-    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
-    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
-    fnalbc2: grb/global_albedo4.1x1.grb
-    fnglac: grb/global_glacier.2x2.grb
-    fnmskh: grb/seaice_newland.grb
-    fnmxic: grb/global_maxice.2x2.grb
-    fnslpc: grb/global_slope.1x1.grb
-    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
-    fnsnoa: ''
-    fnsnoc: grb/global_snoclim.1.875.grb
-    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
-    fntg3c: grb/global_tg3clim.2.6x1.5.grb
-    fntsfa: ''
-    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
-    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
-    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
-    fnvmnc: grb/global_shdmin.0.144x0.144.grb
-    fnvmxc: grb/global_shdmax.0.144x0.144.grb
-    fnzorc: igbp
-    fsicl: 99999
-    fsics: 99999
-    fslpl: 99999
-    fsmcl:
-    - 99999
-    - 99999
-    - 99999
-    fsnol: 99999
-    fsnos: 99999
-    fsotl: 99999
-    ftsfl: 99999
-    ftsfs: 90
-    fvetl: 99999
-    fvmnl: 99999
-    fvmxl: 99999
-    ldebug: false
-orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+    hybedmf: true
+    imp_physics: 99
+    ncld: 1
+    ldiag3d: true

--- a/projects/microphysics/configs/default.yaml
+++ b/projects/microphysics/configs/default.yaml
@@ -202,7 +202,7 @@ orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 namelist:
   namsfc:
     # these flags make the coarse run use the GRIB data for snoalb and vegetation
-    # if not included, it will use the restart data (which may differ from GRIB file)
+    # if not included, it will use the initial condition data (which may differ from GRIB file)
     # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
     fabss: 0
     fabsl: 0

--- a/projects/microphysics/configs/default_short.yaml
+++ b/projects/microphysics/configs/default_short.yaml
@@ -200,7 +200,7 @@ forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 namelist:
   namsfc:
     # these flags make the coarse run use the GRIB data for snoalb and vegetation
-    # if not included, it will use the restart data (which may differ from GRIB file)
+    # if not included, it will use the initial condition data (which may differ from GRIB file)
     # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
     fabss: 0
     fabsl: 0

--- a/projects/microphysics/configs/default_short.yaml
+++ b/projects/microphysics/configs/default_short.yaml
@@ -198,298 +198,57 @@ diagnostics:
 experiment_name: default_experiment
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 namelist:
-  amip_interp_nml:
-    data_set: reynolds_oi
-    date_out_of_range: climo
-    interp_oi_sst: true
-    no_anom_sst: false
-    use_ncep_ice: false
-    use_ncep_sst: true
+  namsfc:
+    # these flags make the coarse run use the GRIB data for snoalb and vegetation
+    # if not included, it will use the restart data (which may differ from GRIB file)
+    # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
+    fabss: 0
+    fabsl: 0
+    fvmnl: 0
+    fvmns: 0
+    fvmxl: 0
+    fvmxs: 0
+    # for time-varying SSTs from GRIB
+    ftsfs: 0
+    # for time-varying sea ice from GRIB
+    fsicl: 0
+    fsics: 0
+    faisl: 0
+    faiss: 0
   atmos_model_nml:
     blocksize: -1
-    chksum_debug: false
-    dycore_only: false
-    fdiag: 0.0
-    fhmax: 1024.0
-    fhmaxhf: -1.0
-    fhout: 0.25
-    fhouthf: 0.0
-  cires_ugwp_nml:
-    knob_ugwp_azdir:
-    - 2
-    - 4
-    - 4
-    - 4
-    knob_ugwp_doaxyz: 1
-    knob_ugwp_doheat: 1
-    knob_ugwp_dokdis: 0
-    knob_ugwp_effac:
-    - 1
-    - 1
-    - 1
-    - 1
-    knob_ugwp_ndx4lh: 4
-    knob_ugwp_solver: 2
-    knob_ugwp_source:
-    - 1
-    - 1
-    - 1
-    - 0
-    knob_ugwp_stoch:
-    - 0
-    - 0
-    - 0
-    - 0
-    knob_ugwp_version: 0
-    knob_ugwp_wvspec:
-    - 1
-    - 32
-    - 32
-    - 32
-    launch_level: 55
   coupler_nml:
-    atmos_nthreads: 1
-    calendar: julian
     current_date:
     - 2016
-    - 8
-    - 2
+    - $MONTH_INT
+    - 1
     - 0
     - 0
     - 0
-    days: 10
-    dt_atmos: 900
-    dt_ocean: 900
-    hours: 6
-    memuse_verbose: true
+    days: 12
+    hours: 0
     minutes: 0
-    months: 0
-    ncores_per_node: 32
     seconds: 0
-    use_hyper_thread: true
   diag_manager_nml:
     flush_nc_files: true
-    prepend_date: false
-  external_ic_nml:
-    checker_tr: false
-    filtered_terrain: true
-    gfs_dwinds: true
-    levp: 64
-    nt_checker: 0
-  fms_io_nml:
-    checksum_required: false
-    max_files_r: 100
-    max_files_w: 100
-  fms_nml:
-    clock_grain: ROUTINE
-    domains_stack_size: 3000000
-    print_memory_usage: false
   fv_core_nml:
-    a_imp: 1.0
-    adjust_dry_mass: false
-    beta: 0.0
-    consv_am: false
-    consv_te: 1.0
-    d2_bg: 0.0
-    d2_bg_k1: 0.16
-    d2_bg_k2: 0.02
-    d4_bg: 0.15
-    d_con: 1.0
-    d_ext: 0.0
-    dddmp: 0.2
-    delt_max: 0.002
-    dnats: 1
     do_sat_adj: false
-    do_vort_damp: true
-    dwind_2d: false
-    external_eta: true
-    external_ic: false
-    fill: true
-    fv_debug: false
-    fv_sg_adj: 900
-    gfs_phil: false
-    hord_dp: 6
-    hord_mt: 6
-    hord_tm: 6
-    hord_tr: 8
-    hord_vt: 6
-    hydrostatic: false
-    io_layout:
-    - 1
-    - 1
-    k_split: 1
-    ke_bg: 0.0
-    kord_mt: 10
-    kord_tm: -10
-    kord_tr: 10
-    kord_wz: 10
-    layout:
-    - 1
-    - 1
-    make_nh: false
-    mountain: true
-    n_split: 6
-    n_sponge: 4
-    na_init: 0
-    ncep_ic: false
-    nggps_ic: false
-    no_dycore: false
-    nord: 2
-    npx: 49
-    npy: 49
-    npz: 79
-    ntiles: 6
     nudge: false
-    nudge_qv: true
+    nudge_qv: false
+    warm_start: false
+    external_ic: true
+    external_eta: false
+    make_nh: true
+    nggps_ic: true
+    mountain: false
+    na_init: 1
     nwat: 2
-    p_fac: 0.1
-    phys_hydrostatic: false
-    print_freq: 3
-    range_warn: false
-    reset_eta: false
-    rf_cutoff: 800.0
-    rf_fast: false
-    tau: 5.0
-    use_hydro_pressure: false
-    vtdm4: 0.06
-    warm_start: true
-    z_tracer: true
-  fv_grid_nml: {}
   gfdl_cloud_microphysics_nml:
-    c_cracw: 0.8
-    c_paut: 0.5
-    c_pgacs: 0.01
-    c_psaci: 0.05
-    ccn_l: 300.0
-    ccn_o: 100.0
-    const_vg: false
-    const_vi: false
-    const_vr: false
-    const_vs: false
-    de_ice: false
-    do_qa: true
-    do_sedi_heat: false
-    dw_land: 0.16
-    dw_ocean: 0.1
     fast_sat_adj: false
-    fix_negative: true
-    icloud_f: 1
-    mono_prof: true
-    mp_time: 450.0
-    prog_ccn: false
-    qi0_crt: 8.0e-05
-    qi_lim: 1.0
-    ql_gen: 0.001
-    ql_mlt: 0.001
-    qs0_crt: 0.001
-    rad_graupel: true
-    rad_rain: true
-    rad_snow: true
-    rh_inc: 0.3
-    rh_inr: 0.3
-    rh_ins: 0.3
-    rthresh: 1.0e-05
-    sedi_transport: false
-    tau_g2v: 900.0
-    tau_i2s: 1000.0
-    tau_l2v:
-    - 225.0
-    tau_v2l: 150.0
-    use_ccn: true
-    use_ppm: false
-    vg_max: 12.0
-    vi_max: 1.0
-    vr_max: 12.0
-    vs_max: 2.0
-    z_slope_ice: true
-    z_slope_liq: true
   gfs_physics_nml:
-    cal_pre: false
-    cdmbgwd:
-    - 3.5
-    - 0.25
-    cnvcld: false
-    cnvgwd: true
-    debug: false
-    dspheat: true
-    fhcyc: 24.0
-    fhlwr: 3600.0
-    fhswr: 3600.0
-    fhzero: 0.25
-    hybedmf: true
-    iaer: 111
-    ialb: 1
-    ico2: 2
-    iems: 1
-    imfdeepcnv: 2
-    imfshalcnv: 2
-    imp_physics: 99
-    isol: 2
-    isot: 1
-    isubc_lw: 2
-    isubc_sw: 2
-    ivegsrc: 1
-    ldiag3d: true
-    lwhtr: true
-    ncld: 1
-    nst_anl: true
-    pdfcld: false
-    pre_rad: false
-    prslrd0: 0.0
-    random_clds: false
-    redrag: true
     satmedmf: false
-    shal_cnv: true
-    swhtr: true
-    trans_trac: true
-    use_ufo: true
-    save_zc_microphysics: true
-    emulate_zc_microphysics: true
-  interpolator_nml:
-    interp_method: conserve_great_circle
-  nam_stochy:
-    lat_s: 96
-    lon_s: 192
-    ntrunc: 94
-  namsfc:
-    fabsl: 99999
-    faisl: 99999
-    faiss: 99999
-    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
-    fnacna: ''
-    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
-    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
-    fnalbc2: grb/global_albedo4.1x1.grb
-    fnglac: grb/global_glacier.2x2.grb
-    fnmskh: grb/seaice_newland.grb
-    fnmxic: grb/global_maxice.2x2.grb
-    fnslpc: grb/global_slope.1x1.grb
-    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
-    fnsnoa: ''
-    fnsnoc: grb/global_snoclim.1.875.grb
-    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
-    fntg3c: grb/global_tg3clim.2.6x1.5.grb
-    fntsfa: ''
-    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
-    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
-    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
-    fnvmnc: grb/global_shdmin.0.144x0.144.grb
-    fnvmxc: grb/global_shdmax.0.144x0.144.grb
-    fnzorc: igbp
-    fsicl: 99999
-    fsics: 99999
-    fslpl: 99999
-    fsmcl:
-    - 99999
-    - 99999
-    - 99999
-    fsnol: 99999
-    fsnos: 99999
-    fsotl: 99999
-    ftsfl: 99999
-    ftsfs: 90
-    fvetl: 99999
-    fvmnl: 99999
-    fvmxl: 99999
-    ldebug: false
+    hybedmf: true
+    imp_physics: 99
+    ncld: 1
+    ldiag3d: true
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/projects/microphysics/create_training/Makefile
+++ b/projects/microphysics/create_training/Makefile
@@ -7,5 +7,5 @@ create:
 
 gather:
 	python ../scripts/gather_netcdfs.py \
-		gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/create-training-microphysics-v4-1- \
+		gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/create-training-microphysics-v4-2- \
 		gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/microphysics-training-data-v4

--- a/projects/microphysics/create_training/Makefile
+++ b/projects/microphysics/create_training/Makefile
@@ -1,14 +1,11 @@
 
 CONFIG ?= ./training_fv3config_template.yaml
-OUTPUT_FREQUENCY ?= 18000
-TAG_PREFIX ?= microphysics-training-data-v3
-RUN_DATE ?= 2021-11-18
 
 create:
 	argo submit argo.yaml \
 		-p config="$(shell base64 --wrap=0 $(CONFIG))" \
-		-p tag="$(TAG_PREFIX)" \
-		-p output_frequency="$(OUTPUT_FREQUENCY)"
 
 gather:
-	python ../scripts/gather_netcdfs.py $(RUN_DATE) $(TAG_PREFIX)
+	python ../scripts/gather_netcdfs.py \
+		gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/create-training-microphysics-v4-1- \
+		gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/microphysics-training-data-v4

--- a/projects/microphysics/create_training/README.md
+++ b/projects/microphysics/create_training/README.md
@@ -39,6 +39,16 @@ while using the make operation to adjust the source of the gathered netCDFs.
 
 ### v4
 
+Location and directory structure:
+
+```
+$ gsutil ls gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/microphysics-training-data-v4
+gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/microphysics-training-data-v4/test/
+gs://vcm-ml-experiments/microphysics-emulation/2022-04-18/microphysics-training-data-v4/train/
+```
+
+Changes:
+
 - Add `add_cloud_water_after_gscond` as ML output
 - Run each month for 30 days with 20 day burn-in before saving data
 - Use forcing data from GRIB files rather than initial data

--- a/projects/microphysics/create_training/README.md
+++ b/projects/microphysics/create_training/README.md
@@ -33,4 +33,12 @@ The netCDFs will be gathered into the base project folder for a given run date
 while using the make operation to adjust the source of the gathered netCDFs.
 
 
+# History
 
+## microphysics-training-data
+
+### v4
+
+- Add `add_cloud_water_after_gscond` as ML output
+- Run each month for 30 days with 20 day burn-in before saving data
+- Use forcing data from GRIB files rather than initial data

--- a/projects/microphysics/create_training/argo.yaml
+++ b/projects/microphysics/create_training/argo.yaml
@@ -1,14 +1,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: create-training-microphysics-
+  name: create-training-microphysics-v4-2
   labels:
-    app: microphysics-training-data
+    project: microphysics-emulation
 spec:
   entrypoint: main
-  arguments:
-    parameters:
-      - name: tag
   volumes:
   - name: gcp-key-secret
     secret:
@@ -44,8 +41,13 @@ spec:
       operator: "Equal"
       value: "med-sim-pool"
       effect: "NoSchedule"
+    metadata:
+      labels:
+        project: microphysics-emulation
+        job_type: training_data
+        author: noahb
     container:
-      image: "us.gcr.io/vcm-ml/prognostic_run:latest"
+      image: "us.gcr.io/vcm-ml/prognostic_run:8839cf6e2f2ae5d649cdce515a22784ce8f8ec55"
       imagePullPolicy: Always
       workingDir: "/fv3net/projects/microphysics"
       resources:
@@ -62,7 +64,7 @@ spec:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /secret/gcp-credentials/key.json
       - name: WANDB_RUN_GROUP
-        value: "{{workflow.parameters.tag}}"
+        value: "{{workflow.name}}"
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret
@@ -70,4 +72,4 @@ spec:
         - run_single_training.sh
         - "{{workflow.parameters.config}}"
         - "{{inputs.parameters.month}}"
-        - "{{workflow.parameters.tag}}"
+        - "{{workflow.name}}"

--- a/projects/microphysics/create_training/training_fv3config_template.yaml
+++ b/projects/microphysics/create_training/training_fv3config_template.yaml
@@ -53,7 +53,7 @@ diagnostics:
 namelist:
   namsfc:
     # these flags make the coarse run use the GRIB data for snoalb and vegetation
-    # if not included, it will use the restart data (which may differ from GRIB file)
+    # if not included, it will use the initial condition data (which may differ from GRIB file)
     # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
     fabss: 0
     fabsl: 0

--- a/projects/microphysics/create_training/training_fv3config_template.yaml
+++ b/projects/microphysics/create_training/training_fv3config_template.yaml
@@ -1,5 +1,5 @@
 base_version: v0.5
-duration: "12d"
+duration: "30d"
 fortran_diagnostics: []
 initial_conditions: $IC_URL
 diagnostics:
@@ -51,6 +51,23 @@ diagnostics:
   - tendency_of_ozone_mixing_ratio_due_to_fv3_physics
   - tendency_of_pressure_thickness_of_atmospheric_layer_due_to_fv3_physics
 namelist:
+  namsfc:
+    # these flags make the coarse run use the GRIB data for snoalb and vegetation
+    # if not included, it will use the restart data (which may differ from GRIB file)
+    # for more info see https://docs.google.com/document/d/1ndOG4u3gZ6kWJV6TqLh-E04n15tl9Ni55B2bavta1Cc/edit#heading=h.uqcex6mf4e10
+    fabss: 0
+    fabsl: 0
+    fvmnl: 0
+    fvmns: 0
+    fvmxl: 0
+    fvmxs: 0
+    # for time-varying SSTs from GRIB
+    ftsfs: 0
+    # for time-varying sea ice from GRIB
+    fsicl: 0
+    fsics: 0
+    faisl: 0
+    faiss: 0
   atmos_model_nml:
     blocksize: -1
   coupler_nml:
@@ -91,5 +108,9 @@ namelist:
     emulate_zc_microphysics: false
 zhao_carr_emulation:
   storage:
-    output_freq_sec: 18000
+    # 5 hour sampling
+    output_freq_sec:  18000
+    # 20 day burn-in
+    output_start_sec: 172_800
     save_nc: true
+    save_zarr: false

--- a/projects/microphysics/scripts/gather_netcdfs.py
+++ b/projects/microphysics/scripts/gather_netcdfs.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import subprocess
 import wandb
-from config import PROJECT, BUCKET
 
 
 # Initial condition timesteps to gather for training data
@@ -19,16 +18,11 @@ if __name__ == "__main__":
             "This script gathers netcdfs from a set of training runs"
             " and uploads them to train/test groups on GCS. Runs are"
             " assumed to be in "
-            "gs://<BUCKET>/<PROJECT>/<RUN_DATE>/<TAG>/artifacts/<TIMESTAMP>/netcdf_output"  # noqa E501
-            " format to be gathered.  The <RUN_DATE> is the date the job"
-            " was performed and <TAG> the unique project name."
+            "<prefix><month>/artifacts/*/netcdf_output"
         )
     )
-    parser.add_argument(
-        "run_date", help="date string when training was run, e.g., 2021-11-18"
-    )
-    parser.add_argument("tag_prefix", help="Common tag prefix for training data runs")
-
+    parser.add_argument("tag_prefix", help="Common URL prefix for training data runs")
+    parser.add_argument("output_prefix", help="Output prefix for training data")
     args = parser.parse_args()
 
     run = wandb.init(
@@ -37,24 +31,28 @@ if __name__ == "__main__":
     wandb.config.update(args)
     wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
 
-    base_url = f"gs://{BUCKET}/{PROJECT}/{args.run_date}"
-    train_out = f"{base_url}/{args.tag_prefix}-training_netcdfs/train"
-    valid_out = f"{base_url}/{args.tag_prefix}-training_netcdfs/test"
+    assert args.tag_prefix.startswith("gs://")
+    assert args.output_prefix.startswith("gs://")
+
+    output_prefix = args.output_prefix.rstrip("/")
+
+    train_out = output_prefix + "/" + "train"
+    valid_out = output_prefix + "/" + "test"
 
     command = ["gsutil", "-m", "cp"]
 
     for timestamp in train_timestamps:
-        tag = f"{args.tag_prefix}-{timestamp}"
-        nc_src = f"{base_url}/{tag}/artifacts/*/netcdf_output/*.nc"
+        tag = f"{args.tag_prefix}{timestamp}"
+        nc_src = f"{tag}/artifacts/*/netcdf_output/*.nc"
         dir_args = [nc_src, train_out]
         subprocess.check_call(command + dir_args)
 
     for timestamp in valid_timestamps:
-        tag = f"{args.tag_prefix}-{timestamp}"
-        nc_src = f"{base_url}/{tag}/artifacts/*/netcdf_output/*.nc"
+        tag = f"{args.tag_prefix}{timestamp}"
+        nc_src = f"{tag}/artifacts/*/netcdf_output/*.nc"
         dir_args = [nc_src, valid_out]
         subprocess.check_call(command + dir_args)
 
     artifact = wandb.Artifact("microphysics-training-data", type="training_netcdfs")
-    artifact.add_reference(f"{base_url}/training_netcdfs")
+    artifact.add_reference(output_prefix, checksum=False)
     wandb.log_artifact(artifact)

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -449,6 +449,7 @@ zhao_carr_emulation:
     ranges: {}
   storage:
     output_freq_sec: 3600
+    output_start_sec: 0
     save_nc: true
     save_tfrecord: false
     save_zarr: true


### PR DESCRIPTION
v3 of the emulation data was generated in November and lacked some important information like cloud after the condensation scheme. The training data also showed some initial condition dependence due to using surface forcings from the initial condtions rather than GRIB files.

* Generate v4 of this training set addressing these issues
* Add  `emulation.ModelConfig.output_start_sec`


cc @frodre 
Probably easiest to review commit-by-commit.