### PR TITLE
JSON Logging for Emulation Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build_images: $(addprefix build_image_, $(IMAGES))
 push_images: $(addprefix push_image_, $(IMAGES))
 
 build_image_fv3fit: docker/fv3fit/requirements.txt
+build_image_artifacts: docker/artifacts/requirements.txt
 
 build_image_prognostic_run: docker/prognostic_run/requirements.txt
 	tools/docker_build_cached.sh us.gcr.io/vcm-ml/prognostic_run:$(CACHE_TAG) \
@@ -230,6 +231,15 @@ docker/fv3fit/requirements.txt:
 		external/fv3fit/setup.py \
 		external/loaders/setup.py \
 		external/vcm/setup.py
+
+docker/artifacts/requirements.txt:
+	cp -f constraints.txt $@
+	# this will subset the needed dependencies from constraints.txt
+	# while preserving the versions
+	pip-compile --no-annotate \
+		--output-file $@ \
+		external/artifacts/setup.py \
+		docker/artifacts/requirements.in
 
 .PHONY: lock_pip constraints.txt
 ## Lock the pip dependencies of this repo

--- a/docker/artifacts/Dockerfile
+++ b/docker/artifacts/Dockerfile
@@ -1,8 +1,24 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y python3 python3-pip
-COPY constraints.txt constraints.txt
-ENV PIP_CONSTRAINT=/constraints.txt
+RUN apt-get update && apt-get install -y python3 python3-pip curl gzip
+
+# Install argo for cronjob submission
+# https://github.com/argoproj/argo-workflows/releases/tag/v2.11.6
+RUN curl -sL https://github.com/argoproj/argo-workflows/releases/download/v2.11.6/argo-linux-amd64.gz \
+    | gunzip  > /usr/local/bin/argo \
+    && chmod +x /usr/local/bin/argo \
+    && echo
+
+COPY docker/artifacts/requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
 COPY external/artifacts /tmp/artifacts
-RUN pip3 install /tmp/artifacts
+RUN pip3 install --no-cache-dir --no-dependencies /tmp/artifacts
+
+COPY projects/microphysics/argo /projects/microphysics/argo
+COPY projects/microphysics/experiments /projects/microphysics/experiments
+COPY projects/microphysics/train /projects/microphysics/train
+COPY projects/microphysics/configs /projects/microphysics/configs
+
+ARG COMMIT_SHA_ARG
+ENV COMMIT_SHA=$COMMIT_SHA_ARG

--- a/docker/artifacts/requirements.in
+++ b/docker/artifacts/requirements.in
@@ -1,0 +1,2 @@
+# A requirement for argo submission in the emulation project
+pyyaml

--- a/docker/fv3fit/Dockerfile
+++ b/docker/fv3fit/Dockerfile
@@ -35,6 +35,11 @@ RUN pip3 install --no-dependencies /fv3net/external/loaders
 COPY external/fv3fit /fv3net/external/fv3fit
 RUN pip3 install --no-dependencies /fv3net/external/fv3fit
 
+# Add emulation project scripts
+COPY projects/microphysics/scripts /fv3net/projects/microphysics/scripts
+RUN chmod +x /fv3net/projects/microphysics/scripts/*
+ENV PATH=/fv3net/projects/microphysics/scripts:${PATH}
+
 # Greatly improves memory performance of tensorflow training
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
 

--- a/external/artifacts/fv3net/artifacts/metadata.py
+++ b/external/artifacts/fv3net/artifacts/metadata.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 import os
-from typing import Mapping, List, Optional
+from typing import Any, Mapping, List, Optional
 
 
 @dataclasses.dataclass
@@ -15,3 +15,17 @@ class StepMetadata:
 
     def print_json(self):
         print(json.dumps({"step_metadata": dataclasses.asdict(self)}))
+
+
+def log_fact_json(
+    data: Mapping[str, Any],
+    kind: str = "metrics",
+    labels: Optional[Mapping[str, str]] = None,
+) -> None:
+
+    payload = dict(json=data)
+
+    labels = {} if labels is None else labels
+    payload["logging.googleapis.com/labels"] = dict(kind=kind, **labels)
+
+    print(json.dumps(payload))

--- a/external/fv3fit/fv3fit/emulation/keras.py
+++ b/external/fv3fit/fv3fit/emulation/keras.py
@@ -45,6 +45,6 @@ def score_model(model: tf.keras.Model, data: Mapping[str, tf.Tensor],) -> Scorin
         ``model``.
     """
     model = fv3fit.keras.adapters.ensure_dict_output(model)
-    prediction = model(data)
+    prediction = model.predict(data, batch_size=8192)
     names = sorted(set(prediction) & set(data))
     return score_multi_output(get(names, data), get(names, prediction), names)

--- a/external/fv3fit/fv3fit/wandb.py
+++ b/external/fv3fit/fv3fit/wandb.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import dataclasses
 import logging
+import os
 import wandb
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,6 +45,7 @@ class WandBConfig:
             job_type=self.job_type,
             config=config,
         )
+        wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
 
 
 def log_to_table(log_key: str, data: Dict[str, Any], index: Optional[List[Any]] = None):

--- a/external/fv3fit/tests/emulation/test_scoring.py
+++ b/external/fv3fit/tests/emulation/test_scoring.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-from fv3fit.emulation import scoring
 from fv3fit.emulation.scoring import score, score_single_output, score_multi_output
 
 
@@ -43,24 +42,7 @@ def test_score(target, prediction):
 
 def test_score_single_output_flat_scores(target, prediction):
 
-    scores, profiles = score_single_output(target, prediction, "field", rescale=False)
-
-    for v in scores.values():
-        assert v == 1.0
-
-    for v in profiles.values():
-        np.testing.assert_array_equal(v, np.ones(2))
-
-
-def test_score_rescale(target, prediction, monkeypatch):
-
-    fieldname = "field"
-    monkeypatch.setitem(scoring.SCALE_VALUES, fieldname, 1 / 10)
-
-    target *= 10
-    prediction *= 10
-
-    scores, profiles = score_single_output(target, prediction, fieldname, rescale=True)
+    scores, profiles = score_single_output(target, prediction, "field")
 
     for v in scores.values():
         assert v == 1.0
@@ -75,26 +57,7 @@ def test_score_multi_output_flat_scores(target, prediction):
     targets = [target] * nout
     predictions = [prediction] * nout
     names = ["field{i}" for i in range(nout)]
-    scores, profiles = score_multi_output(targets, predictions, names, rescale=False)
-
-    for v in scores.values():
-        assert v == 1.0
-
-    for v in profiles.values():
-        np.testing.assert_array_equal(v, np.ones(2))
-
-
-def test_multi_out_score_rescale(target, prediction, monkeypatch):
-
-    fieldname = "field"
-    monkeypatch.setitem(scoring.SCALE_VALUES, fieldname, 1 / 10)
-
-    target *= 10
-    prediction *= 10
-
-    scores, profiles = score_multi_output(
-        [target], [prediction], [fieldname], rescale=True
-    )
+    scores, profiles = score_multi_output(targets, predictions, names)
 
     for v in scores.values():
         assert v == 1.0

--- a/projects/microphysics/argo/end_to_end.py
+++ b/projects/microphysics/argo/end_to_end.py
@@ -20,6 +20,9 @@ def load_yaml(path):
 
 
 class ArgoJob(Protocol):
+    project: str
+    name: str  # trial name
+
     @property
     def parameters(self):
         """return dict of argo parameters"""
@@ -94,7 +97,11 @@ def submit_jobs(jobs: Sequence[ArgoJob], experiment_name: str):
         for job in jobs:
             submit(
                 job,
-                labels={"experiment": experiment_name},
+                labels={
+                    "project": job.project,
+                    "experiment": experiment_name,
+                    "trial": job.name,
+                },
                 other_parameters={
                     "wandb-tags": f"experiment/{experiment_name}",
                     "wandb-group": experiment_name,
@@ -138,6 +145,8 @@ class PrognosticJob:
     # See the source for more information.
     config: dict = dataclasses.field(repr=False)
     image_tag: str
+    bucket: str = "vcm-ml-experiments"
+    project: str = "microphysics-emulation"
 
     @property
     def entrypoint(self):

--- a/projects/microphysics/experiments/default.py
+++ b/projects/microphysics/experiments/default.py
@@ -1,21 +1,30 @@
+import argparse
 import sys
+import glob
+import os
 
 sys.path.insert(0, "../argo")
 
 from end_to_end import EndToEndJob, load_yaml, submit_jobs  # noqa: E402
 
 
-def _get_job(config_name: str, revision):
-    config = load_yaml(f"../train/{config_name}.yaml")
+def _get_job(config: str, revision, suffix):
+    config_name = os.path.splitext(os.path.basename(config))[0]
+    config = load_yaml(config)
     return EndToEndJob(
-        name=f"{config_name}-{revision[:6]}-v1",
+        name=f"{config_name}-{revision[:6]}-{suffix}",
         fv3fit_image_tag=revision,
         image_tag=revision,
         ml_config=config,
-        prog_config=load_yaml("../configs/default_short.yaml"),
+        prog_config=load_yaml("../configs/default.yaml"),
     )
 
 
-revision = sys.argv[1] if len(sys.argv) > 1 else "latest"
-jobs = [_get_job(config, revision) for config in ["limited", "rnn"]]
-submit_jobs(jobs, f"{revision}-end-to-end")
+configs = glob.glob("../train/*.yaml")
+parser = argparse.ArgumentParser()
+parser.add_argument("--revision", default="latest")
+parser.add_argument("--suffix", default="v1")
+
+args = parser.parse_args()
+jobs = [_get_job(config, args.revision, args.suffix) for config in configs]
+submit_jobs(jobs, f"{args.revision}-end-to-end")

--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -2,6 +2,9 @@ import argparse
 from dataclasses import asdict
 import json
 import logging
+import sys
+from typing import Any, Dict, Tuple
+from fv3net.artifacts.metadata import StepMetadata, log_fact_json
 import numpy as np
 import os
 import tensorflow as tf
@@ -19,7 +22,7 @@ from vcm import get_fs
 logger = logging.getLogger(__name__)
 
 
-def load_final_model_or_checkpoint(train_out_url) -> tf.keras.Model:
+def load_final_model_or_checkpoint(train_out_url) -> Tuple[tf.keras.Model, str]:
 
     model_url = os.path.join(train_out_url, "model.tf")
     checkpoints = os.path.join(train_out_url, "checkpoints", "*.tf")
@@ -34,7 +37,7 @@ def load_final_model_or_checkpoint(train_out_url) -> tf.keras.Model:
     else:
         raise FileNotFoundError(f"No keras models found at {train_out_url}")
 
-    return tf.keras.models.load_model(url_to_load)
+    return tf.keras.models.load_model(url_to_load), url_to_load
 
 
 def main(config: TrainConfig, seed: int = 0, model_url: str = None):
@@ -48,10 +51,19 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
         config.wandb.init(config=d)
 
     if model_url is None:
-        model = load_final_model_or_checkpoint(config.out_url)
+        model, model_url = load_final_model_or_checkpoint(config.out_url)
     else:
         logger.info(f"Loading user specified model from {model_url}")
         model = tf.keras.models.load_model(model_url)
+
+    StepMetadata(
+        job_type="train_score",
+        url=config.out_url,
+        dependencies=dict(
+            train_data=config.train_url, test_data=config.test_url, model=model_url
+        ),
+        args=sys.argv[1:],
+    ).print_json()
 
     train_ds = config.open_dataset(
         config.train_url, config.nfiles, config.model_variables
@@ -67,6 +79,16 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
     test_scores, test_profiles = score_model(model, test_set)
     logger.debug("Scoring Complete")
 
+    summary_metrics: Dict[str, Any] = {
+        f"score/train/{key}": value for key, value in train_scores.items()
+    }
+    summary_metrics.update(
+        {f"score/test/{key}": value for key, value in test_scores.items()}
+    )
+
+    # Logging for google cloud
+    log_fact_json(data=summary_metrics)
+
     if config.use_wandb:
         pred_sample = model.predict(test_set)
         log_profile_plots(test_set, pred_sample)
@@ -76,8 +98,8 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
         train_profiles["level"] = np.arange(len(sample_profile))
         test_profiles["level"] = np.arange(len(sample_profile))
 
-        log_to_table("score/train", train_scores, index=[config.wandb.job.name])
-        log_to_table("score/test", test_scores, index=[config.wandb.job.name])
+        config.wandb.job.log(summary_metrics)
+
         log_to_table("profiles/train", train_profiles)
         log_to_table("profiles/test", test_profiles)
 

--- a/projects/microphysics/train/dense.yaml
+++ b/projects/microphysics/train/dense.yaml
@@ -9,7 +9,6 @@ valid_freq: 2
 out_url: gs://vcm-ml-scratch/andrep/2021-10-02-wandb-training/dense
 train_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/train
 test_url: gs://vcm-ml-experiments/microphysics-emulation/2021-11-24/microphysics-training-data-v3-training_netcdfs/test
-cache: false
 tensor_transform:
   - to: log_cloud_input
     source: cloud_water_mixing_ratio_input
@@ -86,7 +85,6 @@ model:
   normalize_default:
     center: per_feature
     scale: all
-  enforce_positive: false
   selection_map: {}
   timestep_increment_sec: 900
 transform:


### PR DESCRIPTION
This PR adds json metric logging for emulation diagnostic scripts that can be ingested by gcloud's logging infrastructure.  In addition to this a new regression CronJob (https://github.com/ai2cm/vcm-workflow-control/pull/127) will be run nightly to log important metrics from our training and prognostic runs nightly.

Metrics Added:
- training time
- prognostic run length
- MSE/bias scores on a test dataset for trained models
