### PR TITLE
Use available cpu for movie generation

### DIFF
--- a/workflows/argo/prognostic_run_diags.yaml
+++ b/workflows/argo/prognostic_run_diags.yaml
@@ -184,7 +184,7 @@ spec:
       command: ["/bin/bash", "-x", "-e", "-c"]
       args:
       - |
-        prognostic_run_diags movie --n_timesteps 960 {{inputs.parameters.run}} {{inputs.parameters.output}}
+        prognostic_run_diags movie --n_timesteps 960 --n_jobs 26 {{inputs.parameters.run}} {{inputs.parameters.output}}
       workingDir: /home/jovyan/fv3net/workflows/diagnostics
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
The argo template for online movie generation was updated to request 26 cpu, but the command-line was still using the default of `n_jobs=8`.
