### PR TITLE
Bump version of nc-time-axis to v1.4.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -36,7 +36,7 @@ cachy==0.3.0
 certifi==2021.10.8
 cffi==1.14.4
 cfgv==3.2.0
-cftime==1.2.1
+cftime==1.6.0
 chardet==3.0.4
 charset-normalizer==2.0.11
 cleo==0.7.6
@@ -170,7 +170,7 @@ nbclassic==0.2.6
 nbclient==0.5.3
 nbconvert==6.0.7
 nbformat==5.1.2
-nc-time-axis==1.2.0
+nc-time-axis==1.4.1
 nest-asyncio==1.5.1
 netcdf4==1.5.5
 nltk==3.6.7

--- a/external/vcm/tests/_regtest_outputs/test_fv3_metadata.test_standardize_fv3_diagnostics_reg.out
+++ b/external/vcm/tests/_regtest_outputs/test_fv3_metadata.test_standardize_fv3_diagnostics_reg.out
@@ -17,15 +17,16 @@ variables:
 // global attributes:
 }
 <xarray.DataArray 'time' (time: 10)>
-array([cftime.DatetimeJulian(2016, 1, 1, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 2, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 3, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 4, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 5, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 6, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 7, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 8, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 9, 0, 0, 0, 0),
-       cftime.DatetimeJulian(2016, 1, 10, 0, 0, 0, 0)], dtype=object)
+array([cftime.DatetimeJulian(2016, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 2, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 3, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 4, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 5, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 6, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 7, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 8, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 9, 0, 0, 0, 0, has_year_zero=False),
+       cftime.DatetimeJulian(2016, 1, 10, 0, 0, 0, 0, has_year_zero=False)],
+      dtype=object)
 Coordinates:
   * time     (time) object 2016-01-01 00:00:00 ... 2016-01-10 00:00:00

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,5 @@
 apache-beam[gcp]
-nc-time-axis
+nc-time-axis>=1.4.1
 bump2version
 yq
 pytest-regtest

--- a/workflows/diagnostics/tests/prognostic/_regtest_outputs/test_load_diag_data.test_evaluation_pair_to_input_data.out
+++ b/workflows/diagnostics/tests/prognostic/_regtest_outputs/test_load_diag_data.test_evaluation_pair_to_input_data.out
@@ -44,7 +44,7 @@ variables:
 
 // global attributes:
 }
-time 7151b727a6f28023527facbac8dac491
+time 08762d03ff9aecd3690c342c7189c570
 x dc9136a3153fe1adada82a1b225b8d1d
 y dc9136a3153fe1adada82a1b225b8d1d
 pressure 5ffba331ffbf7a5f41da67d710427656
@@ -93,7 +93,7 @@ variables:
 
 // global attributes:
 }
-time 7151b727a6f28023527facbac8dac491
+time 08762d03ff9aecd3690c342c7189c570
 x dc9136a3153fe1adada82a1b225b8d1d
 y dc9136a3153fe1adada82a1b225b8d1d
 pressure 5ffba331ffbf7a5f41da67d710427656
@@ -512,7 +512,7 @@ variables:
 }
 x dc9136a3153fe1adada82a1b225b8d1d
 y dc9136a3153fe1adada82a1b225b8d1d
-time 073e68517ab1de13f9f7196e1f8a67f8
+time 48706651e4f065eb9b4915d4c31ab35a
 Verification
 xarray.Dataset {
 dimensions:
@@ -874,7 +874,7 @@ variables:
 }
 x dc9136a3153fe1adada82a1b225b8d1d
 y dc9136a3153fe1adada82a1b225b8d1d
-time 073e68517ab1de13f9f7196e1f8a67f8
+time 48706651e4f065eb9b4915d4c31ab35a
 grid
 xarray.Dataset {
 dimensions:


### PR DESCRIPTION
This bumps our version of nc-time-axis to v1.4.1 (its latest version).  In particular v1.4.0 addressed a number of longstanding issues related to setting tick positions and label formats, as well as issues integrating with matplotlib methods such as `axvline`.

Requirement changes:
- nc-time-axis bumped from v1.2.0 to v1.4.1
- cftime bumped from v1.2.1 to v1.6.0 (nc-time-axis requires an update to cftime)

- [x] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)

