### PR TITLE
Fix CI docker image pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,9 @@ jobs:
             echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GOOGLE_CREDENTIALS | base64 --decode)" >> $BASH_ENV
       - gcp-gcr/gcr-auth
-      - run: sudo -E .circleci/build_and_push_image.sh
+      - run: |
+          sudo chmod -R 777 /home/circleci/.docker && \
+          .circleci/build_and_push_image.sh
   lint:
     docker:
       - image: circleci/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.14.1
+  gcp-gcr: circleci/gcp-gcr@0.15.0
   slack: circleci/slack@3.4.2
 jobs:
   pytest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
             echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GOOGLE_CREDENTIALS | base64 --decode)" >> $BASH_ENV
       - gcp-gcr/gcr-auth
       - run: |
-          sudo chmod -R 777 /home/circleci/.docker && \
+          sudo chown -R circleci:circleci /home/circleci/.docker && \
           .circleci/build_and_push_image.sh
   lint:
     docker:


### PR DESCRIPTION
Resolves #1799 

After drilling down, the original issue seemed to be that using docker in a script with `sudo -E build_script.sh` no longer passes the gcloud credentials properly when invoking docker to push images.  E.g., even a standalone a script with `docker push <image>` wouldn't work, while `sudo -E bash` and then pushing using would.

@nbren12 Suggested just doing everything on a single user.  After removing the `sudo -E` part prior to calling `.circleci/build_and_push_image.sh` the following error was left:
```
#3 ERROR: rpc error: code = Unknown desc = open /home/circleci/.docker/.token_seed: permission denied
------
 > [internal] load metadata for docker.io/library/ubuntu:20.04:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: rpc error: code = Unknown desc = open /home/circleci/.docker/.token_seed: permission denied
make: *** [Makefile:23: build_image_artifacts] Error 1
```

By changing the permissions of some circleCI files needed to run docker, I could then push images on the default user, `circleci`. Not sure how well this will work out in the long term, but it passes for now.