### PR TITLE
Fix bug in step metadata of prog run

### DIFF
--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -105,8 +105,11 @@ def write_chunks(config: UserConfig):
 
 def get_model_urls(config_dict: dict) -> List[str]:
     urls: List[str] = []
-    urls = config_dict.get("scikit_learn", {}).get("model", [])
-    prephysics_config = config_dict.get("prephysics", [])
-    for entry in prephysics_config:
-        urls += entry.get("model", [])
+    ml_config = config_dict.get("scikit_learn")
+    if ml_config is not None:
+        urls += ml_config["model"]
+    prephysics_config = config_dict.get("prephysics")
+    if prephysics_config is not None:
+        for entry in prephysics_config:
+            urls += entry.get("model", [])
     return urls

--- a/workflows/prognostic_c48_run/tests/test_config.py
+++ b/workflows/prognostic_c48_run/tests/test_config.py
@@ -1,5 +1,8 @@
+import dacite
 import pytest
-from runtime.config import get_model_urls
+from runtime.config import get_model_urls, UserConfig
+
+dummy_prescriber = {"dataset_key": "data_url", "variables": ["a"]}
 
 
 @pytest.mark.parametrize(
@@ -7,11 +10,11 @@ from runtime.config import get_model_urls
     [
         ({}, []),
         ({"scikit_learn": None, "prephysics": None}, []),
-        ({"scikit_learn": None, "prephysics": [{"some_prescribed_data": 0}]}, []),
+        ({"scikit_learn": None, "prephysics": [dummy_prescriber]}, []),
         (
             {
                 "scikit_learn": {"model": ["ml_model_url"]},
-                "prephysics": [{"some_prescribed_data": 0}],
+                "prephysics": [dummy_prescriber],
             },
             ["ml_model_url"],
         ),
@@ -19,7 +22,7 @@ from runtime.config import get_model_urls
             {
                 "scikit_learn": {"model": ["ml_model_url"]},
                 "prephysics": [
-                    {"some_prescribed_data": 0},
+                    dummy_prescriber,
                     {"model": ["prephysics_model_0", "prephysics_model_1"]},
                 ],
             },
@@ -28,4 +31,7 @@ from runtime.config import get_model_urls
     ],
 )
 def test_get_model_urls(config, model_urls):
+    # Since this function is coupled to the UserConfig, check that test is in sync
+    # with this class
+    dacite.from_dict(UserConfig, config, dacite.Config(strict=True))
     assert set(get_model_urls(config)) == set(model_urls)

--- a/workflows/prognostic_c48_run/tests/test_config.py
+++ b/workflows/prognostic_c48_run/tests/test_config.py
@@ -1,0 +1,31 @@
+import pytest
+from runtime.config import get_model_urls
+
+
+@pytest.mark.parametrize(
+    "config, model_urls",
+    [
+        ({}, []),
+        ({"scikit_learn": None, "prephysics": None}, []),
+        ({"scikit_learn": None, "prephysics": [{"some_prescribed_data": 0}]}, []),
+        (
+            {
+                "scikit_learn": {"model": ["ml_model_url"]},
+                "prephysics": [{"some_prescribed_data": 0}],
+            },
+            ["ml_model_url"],
+        ),
+        (
+            {
+                "scikit_learn": {"model": ["ml_model_url"]},
+                "prephysics": [
+                    {"some_prescribed_data": 0},
+                    {"model": ["prephysics_model_0", "prephysics_model_1"]},
+                ],
+            },
+            ["ml_model_url", "prephysics_model_0", "prephysics_model_1"],
+        ),
+    ],
+)
+def test_get_model_urls(config, model_urls):
+    assert set(get_model_urls(config)) == set(model_urls)

--- a/workflows/prognostic_c48_run/tests/test_config.py
+++ b/workflows/prognostic_c48_run/tests/test_config.py
@@ -1,6 +1,7 @@
 import dacite
 import pytest
 from runtime.config import get_model_urls, UserConfig
+import dataclasses
 
 dummy_prescriber = {"dataset_key": "data_url", "variables": ["a"]}
 
@@ -33,5 +34,7 @@ dummy_prescriber = {"dataset_key": "data_url", "variables": ["a"]}
 def test_get_model_urls(config, model_urls):
     # Since this function is coupled to the UserConfig, check that test is in sync
     # with this class
-    dacite.from_dict(UserConfig, config, dacite.Config(strict=True))
-    assert set(get_model_urls(config)) == set(model_urls)
+    validated_config = dataclasses.asdict(
+        dacite.from_dict(UserConfig, config, dacite.Config(strict=True))
+    )
+    assert set(get_model_urls(validated_config)) == set(model_urls)


### PR DESCRIPTION
I forgot that if the user config omits a key (like scikit_learn) it is present in the final config, but with a None value. This caused a bug when the step metadata function assumed that the key wouldn't be in the final dict.


- [x] Tests added
