### PR TITLE
Fix the e2e emulation run

### DIFF
--- a/projects/microphysics/argo/argo.yaml
+++ b/projects/microphysics/argo/argo.yaml
@@ -121,6 +121,8 @@ spec:
         value: /secret/gcp-credentials/key.json
       - name: WANDB_RUN_GROUP
         value: "{{inputs.parameters.tag}}"
+      - name: FSSPEC_GS_REQUESTER_PAYS
+        value: "vcm-ml"
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret

--- a/projects/microphysics/argo/argo.yaml
+++ b/projects/microphysics/argo/argo.yaml
@@ -196,7 +196,7 @@ spec:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /secret/gcp-credentials/key.json
       - name: WANDB_RUN_GROUP
-        value: "{{workflow.parameters.wandb-group}}"
+        value: "{{inputs.parameters.tag}}"
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret

--- a/projects/microphysics/configs/default.yaml
+++ b/projects/microphysics/configs/default.yaml
@@ -222,8 +222,8 @@ namelist:
   coupler_nml:
     current_date:
     - 2016
-    - $MONTH_INT
-    - 1
+    - 8
+    - 2
     - 0
     - 0
     - 0
@@ -237,13 +237,13 @@ namelist:
     do_sat_adj: false
     nudge: false
     nudge_qv: false
-    warm_start: false
-    external_ic: true
-    external_eta: false
-    make_nh: true
-    nggps_ic: true
-    mountain: false
-    na_init: 1
+    warm_start: true
+    external_ic: false
+    external_eta: true
+    make_nh: false
+    nggps_ic: false
+    mountain: true
+    na_init: 0
     nwat: 2
   gfdl_cloud_microphysics_nml:
     fast_sat_adj: false

--- a/projects/microphysics/configs/default_short.yaml
+++ b/projects/microphysics/configs/default_short.yaml
@@ -220,8 +220,8 @@ namelist:
   coupler_nml:
     current_date:
     - 2016
-    - $MONTH_INT
-    - 1
+    - 8
+    - 2
     - 0
     - 0
     - 0
@@ -235,13 +235,13 @@ namelist:
     do_sat_adj: false
     nudge: false
     nudge_qv: false
-    warm_start: false
-    external_ic: true
-    external_eta: false
-    make_nh: true
-    nggps_ic: true
-    mountain: false
-    na_init: 1
+    warm_start: true
+    external_ic: false
+    external_eta: true
+    make_nh: false
+    nggps_ic: false
+    mountain: true
+    na_init: 0
     nwat: 2
   gfdl_cloud_microphysics_nml:
     fast_sat_adj: false

--- a/projects/microphysics/experiments/default.py
+++ b/projects/microphysics/experiments/default.py
@@ -37,4 +37,5 @@ parser.add_argument("--test", action="store_true")
 
 args = parser.parse_args()
 jobs = [_get_job(config, args.revision, args.suffix, args.test) for config in configs]
-submit_jobs(jobs, f"{args.revision}-end-to-end")
+test_str = "-test-" if args.test else ""
+submit_jobs(jobs, f"emu-end-to-end-{test_str}{args.revision}")

--- a/projects/microphysics/experiments/default.py
+++ b/projects/microphysics/experiments/default.py
@@ -8,20 +8,24 @@ sys.path.insert(0, "../argo")
 from end_to_end import EndToEndJob, load_yaml, submit_jobs  # noqa: E402
 
 
-def _get_job(config: str, revision, suffix):
+def _get_job(config: str, revision: str, suffix: str, test: bool):
     config_name = os.path.splitext(os.path.basename(config))[0]
     config = load_yaml(config)
 
-    config["nfiles"] = 50
-    config["epochs"] = 3
-    config["nfiles_valid"] = 10
+    if test:
+        config["nfiles"] = 50
+        config["epochs"] = 3
+        config["nfiles_valid"] = 10
+        run_config = "default_short"
+    else:
+        run_config = "default"
 
     return EndToEndJob(
         name=f"{config_name}-{revision[:6]}-{suffix}",
         fv3fit_image_tag=revision,
         image_tag=revision,
         ml_config=config,
-        prog_config=load_yaml("../configs/default_short.yaml"),
+        prog_config=load_yaml(f"../configs/{run_config}.yaml"),
     )
 
 
@@ -29,7 +33,8 @@ configs = glob.glob("../train/*.yaml")
 parser = argparse.ArgumentParser()
 parser.add_argument("--revision", default="latest")
 parser.add_argument("--suffix", default="v1")
+parser.add_argument("--test", action="store_true")
 
 args = parser.parse_args()
-jobs = [_get_job(config, args.revision, args.suffix) for config in configs]
+jobs = [_get_job(config, args.revision, args.suffix, args.test) for config in configs]
 submit_jobs(jobs, f"{args.revision}-end-to-end")

--- a/projects/microphysics/experiments/default.py
+++ b/projects/microphysics/experiments/default.py
@@ -37,5 +37,5 @@ parser.add_argument("--test", action="store_true")
 
 args = parser.parse_args()
 jobs = [_get_job(config, args.revision, args.suffix, args.test) for config in configs]
-test_str = "-test-" if args.test else ""
-submit_jobs(jobs, f"emu-end-to-end-{test_str}{args.revision}")
+test_str = "test-" if args.test else ""
+submit_jobs(jobs, f"emu-end-to-end-{test_str}{args.revision[:6]}")

--- a/projects/microphysics/experiments/default.py
+++ b/projects/microphysics/experiments/default.py
@@ -11,12 +11,17 @@ from end_to_end import EndToEndJob, load_yaml, submit_jobs  # noqa: E402
 def _get_job(config: str, revision, suffix):
     config_name = os.path.splitext(os.path.basename(config))[0]
     config = load_yaml(config)
+
+    config["nfiles"] = 50
+    config["epochs"] = 3
+    config["nfiles_valid"] = 10
+
     return EndToEndJob(
         name=f"{config_name}-{revision[:6]}-{suffix}",
         fv3fit_image_tag=revision,
         image_tag=revision,
         ml_config=config,
-        prog_config=load_yaml("../configs/default.yaml"),
+        prog_config=load_yaml("../configs/default_short.yaml"),
     )
 
 


### PR DESCRIPTION
This PR fixes a few minor things with the E2E emulation workflow
* reverts changes to the prognostic config introduced in #1788
* Address requester pays issue with prognostic run step
* Ensure the prognostic run, piggy-back diags, and prognostic eval appear in in the same wandb run group
* Adds a test mode for faster checks on the E2E job in `default.py`