### PR TITLE
Use datatables for more navigable image grids

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -116,6 +116,13 @@ class RunDiagnostics:
         """The available variables"""
         return set.union(*[set(d) for d in self.diagnostics])
 
+    @property
+    def long_names(self) -> Mapping[str, str]:
+        """Mapping from variable name to long names"""
+        vars = self.variables
+        run = self.runs[0]
+        return {v: self.get_variable(run, v).attrs.get("long_name", v) for v in vars}
+
     def _get_run(self, run: str) -> xr.Dataset:
         return self.diagnostics[self._run_index[run]]
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -24,16 +24,21 @@ OverlaidPlotData = MutableMapping[str, MutableMapping[str, MatplotlibFigure]]
 template = jinja2.Template(
     """
 <h2> {{varfilter}} </h2>
-<table cellpadding="0" cellspacing="0">
+<table class="display" style="width:100%">
 
+<thead>
 <tr>
+<th>Variable</th>
 {% for run in runs %}
 <th><center> {{ run }} </center></th>
 {% endfor %}
 </tr>
+</thead>
 
+<tbody>
 {% for varname in variables_to_plot %}
 <tr>
+<td> {{ varname }} </td>
 {% for run in runs %}
 <td>
 {{ images[varname][run] }}
@@ -41,6 +46,7 @@ template = jinja2.Template(
 {% endfor %}
 </tr>
 {% endfor %}
+</tbody>
 </table>
 """
 )

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -38,7 +38,7 @@ template = jinja2.Template(
 <tbody>
 {% for varname in variables_to_plot %}
 <tr>
-<td> {{ varname }} </td>
+<td> {{ variable_long_names[varname] }} </td>
 {% for run in runs %}
 <td>
 {{ images[varname][run] }}
@@ -73,6 +73,7 @@ def plot_2d_matplotlib(
     All matching diagnostics must be 2D and have the same dimensions."""
 
     data: OverlaidPlotData = defaultdict(dict)
+    variable_long_names = {}
 
     # kwargs handling
     ylabel = opts.pop("ylabel", "")
@@ -88,6 +89,7 @@ def plot_2d_matplotlib(
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)
             long_name_and_units = f"{v.long_name} [{v.units}]"
+            variable_long_names[varname] = v.long_name
             fig, ax = plt.subplots()
             if contour:
                 levels = CONTOUR_LEVELS.get(varname)
@@ -108,6 +110,7 @@ def plot_2d_matplotlib(
             runs=sorted(run_diags.runs),
             variables_to_plot=sorted(variables_to_plot),
             varfilter=varfilter,
+            variable_long_names=variable_long_names,
         )
     )
 
@@ -133,6 +136,7 @@ def plot_cubed_sphere_map(
     """
 
     data: OverlaidPlotData = defaultdict(dict)
+    variable_long_names = {}
     if metrics_for_title is None:
         metrics_for_title = {}
 
@@ -143,6 +147,7 @@ def plot_cubed_sphere_map(
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
             ds = run_diags.get_variables(run, COORD_VARS + [varname])
+            variable_long_names[varname] = ds[varname].long_name
             plot_title = _render_map_title(
                 run_metrics, shortname, run, metrics_for_title
             )
@@ -160,6 +165,7 @@ def plot_cubed_sphere_map(
             runs=sorted(run_diags.runs),
             variables_to_plot=sorted(variables_to_plot),
             varfilter=varfilter,
+            variable_long_names=variable_long_names,
         )
     )
 
@@ -230,6 +236,7 @@ def plot_histogram2d(run_diags: RunDiagnostics, xname: str, yname: str) -> RawHT
             runs=sorted(run_diags.runs),
             variables_to_plot=[count_name],
             varfilter="2D Histogram",
+            variable_long_names={count_name: "<Q2> versus water vapor path"},
         )
     )
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -73,7 +73,6 @@ def plot_2d_matplotlib(
     All matching diagnostics must be 2D and have the same dimensions."""
 
     data: OverlaidPlotData = defaultdict(dict)
-    variable_long_names = {}
 
     # kwargs handling
     ylabel = opts.pop("ylabel", "")
@@ -89,7 +88,6 @@ def plot_2d_matplotlib(
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)
             long_name_and_units = f"{v.long_name} [{v.units}]"
-            variable_long_names[varname] = v.long_name
             fig, ax = plt.subplots()
             if contour:
                 levels = CONTOUR_LEVELS.get(varname)
@@ -110,7 +108,7 @@ def plot_2d_matplotlib(
             runs=sorted(run_diags.runs),
             variables_to_plot=sorted(variables_to_plot),
             varfilter=varfilter,
-            variable_long_names=variable_long_names,
+            variable_long_names=run_diags.long_names,
         )
     )
 
@@ -136,7 +134,6 @@ def plot_cubed_sphere_map(
     """
 
     data: OverlaidPlotData = defaultdict(dict)
-    variable_long_names = {}
     if metrics_for_title is None:
         metrics_for_title = {}
 
@@ -147,7 +144,6 @@ def plot_cubed_sphere_map(
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
             ds = run_diags.get_variables(run, COORD_VARS + [varname])
-            variable_long_names[varname] = ds[varname].long_name
             plot_title = _render_map_title(
                 run_metrics, shortname, run, metrics_for_title
             )
@@ -165,7 +161,7 @@ def plot_cubed_sphere_map(
             runs=sorted(run_diags.runs),
             variables_to_plot=sorted(variables_to_plot),
             varfilter=varfilter,
-            variable_long_names=variable_long_names,
+            variable_long_names=run_diags.long_names,
         )
     )
 
@@ -236,9 +232,7 @@ def plot_histogram2d(run_diags: RunDiagnostics, xname: str, yname: str) -> RawHT
             runs=sorted(run_diags.runs),
             variables_to_plot=[count_name],
             varfilter="2D Histogram",
-            variable_long_names={
-                count_name: "water vapor path versus minus column integrated Q2"
-            },
+            variable_long_names={count_name: f"{xname} versus {yname}"},
         )
     )
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -236,7 +236,9 @@ def plot_histogram2d(run_diags: RunDiagnostics, xname: str, yname: str) -> RawHT
             runs=sorted(run_diags.runs),
             variables_to_plot=[count_name],
             varfilter="2D Histogram",
-            variable_long_names={count_name: "<Q2> versus water vapor path"},
+            variable_long_names={
+                count_name: "water vapor path versus minus column integrated Q2"
+            },
         )
     )
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -46,25 +46,28 @@ hv.extension("bokeh")
 COLOR_CYCLE = hv.Cycle(fv3viz.wong_palette)
 fv3viz.use_colorblind_friendly_style()
 PUBLIC_GCS_DOMAIN = "https://storage.googleapis.com"
+JQUERY_CDN = "https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+DATATABLES_CSS_CDN = "https://cdn.datatables.net/1.11.5/css/jquery.dataTables.css"
+DATATABLES_JS_CDN = "https://cdn.datatables.net/1.11.5/js/jquery.dataTables.js"
 MovieManifest = Sequence[Tuple[str, str]]
 PublicLinks = Dict[str, List[Tuple[str, str]]]
 
 
 def get_datatables_header() -> str:
-    header = ""
-    header += '\n<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>'  # noqa: E501
-    header += '\n<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.css">'  # noqa: E501
-    header += '\n<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.js"></script>'  # noqa: E501
+    header = f'\n<script src="{JQUERY_CDN}"></script>'
+    header += f'\n<link rel="stylesheet" type="text/css" href="{DATATABLES_CSS_CDN}">'
+    header += f'\n<script src="{DATATABLES_JS_CDN}"></script>'
     header += """
-<script>
-    $(document).ready(function() {
-        $('table.display').DataTable( {
-            "scrollY":        "400px",
-            "scrollCollapse": true,
-            "paging":         false
-        } );
-    } );
-</script>"""
+        <script>
+            $(document).ready(function() {
+                $('table.display').DataTable( {
+                    "scrollX":        "100%",
+                    "scrollY":        "700px",
+                    "scrollCollapse": true,
+                    "paging":         false
+                } );
+            } );
+        </script>"""
     return header
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -68,6 +68,7 @@ def get_datatables_header() -> str:
                     "paging":         false,
                     "columnDefs": [{"targets": [0], "className": "firstcolumn"}]
                 } );
+                $('table.dataframe').DataTable();
             } );
         </script>"""
     return header

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -54,7 +54,8 @@ PublicLinks = Dict[str, List[Tuple[str, str]]]
 
 
 def get_datatables_header() -> str:
-    header = f'\n<script src="{JQUERY_CDN}"></script>'
+    header = "<style>th{font-size: 1.15em}\n.firstcolumn{font-size: 1.15em}</style>"
+    header += f'\n<script src="{JQUERY_CDN}"></script>'
     header += f'\n<link rel="stylesheet" type="text/css" href="{DATATABLES_CSS_CDN}">'
     header += f'\n<script src="{DATATABLES_JS_CDN}"></script>'
     header += """
@@ -64,7 +65,8 @@ def get_datatables_header() -> str:
                     "scrollX":        "100%",
                     "scrollY":        "700px",
                     "scrollCollapse": true,
-                    "paging":         false
+                    "paging":         false,
+                    "columnDefs": [{"targets": [0], "className": "firstcolumn"}]
                 } );
             } );
         </script>"""

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -50,6 +50,28 @@ MovieManifest = Sequence[Tuple[str, str]]
 PublicLinks = Dict[str, List[Tuple[str, str]]]
 
 
+def get_datatables_header() -> str:
+    header = ""
+    header += '\n<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>'  # noqa: E501
+    header += '\n<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.css">'  # noqa: E501
+    header += '\n<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.js"></script>'  # noqa: E501
+    header += """
+<script>
+    $(document).ready(function() {
+        $('table.display').DataTable( {
+            "scrollY":        "400px",
+            "scrollCollapse": true,
+            "paging":         false
+        } );
+    } );
+</script>"""
+    return header
+
+
+def get_header() -> str:
+    return get_html_header() + "\n" + get_datatables_header()
+
+
 def upload(html: str, url: str, content_type: str = "text/html"):
     """Upload to a local or remote path, setting the content type if remote
 
@@ -439,7 +461,7 @@ def render_index(metadata, diagnostics, metrics, movie_links):
         title="Prognostic run report",
         metadata={**metadata, **render_links(movie_links)},
         sections=sections_index,
-        html_header=get_html_header(),
+        html_header=get_header(),
     )
 
 
@@ -454,7 +476,7 @@ def render_hovmollers(metadata, diagnostics):
         title="Latitude versus time hovmoller plots",
         metadata=metadata,
         sections=sections_hovmoller,
-        html_header=get_html_header(),
+        html_header=get_header(),
     )
 
 
@@ -471,7 +493,7 @@ def render_maps(metadata, diagnostics, metrics):
         title="Time-mean maps",
         metadata=metadata,
         sections=sections,
-        html_header=get_html_header(),
+        html_header=get_header(),
     )
 
 
@@ -486,7 +508,7 @@ def render_zonal_pressures(metadata, diagnostics):
         title="Pressure versus latitude plots",
         metadata=metadata,
         sections=sections_zonal_pressure,
-        html_header=get_html_header(),
+        html_header=get_header(),
     )
 
 
@@ -504,7 +526,7 @@ def render_process_diagnostics(metadata, diagnostics, metrics):
         title="Process diagnostics",
         metadata=metadata,
         sections=sections,
-        html_header=get_html_header(),
+        html_header=get_header(),
     )
 
 

--- a/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
+++ b/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
@@ -144,6 +144,20 @@ def test_RunDiagnostics_list_variables():
     assert diagnostics.variables == {"a", "b", "c"}
 
 
+def test_RunDiagnostics_long_names():
+    ds = xarray.Dataset({})
+    a = xarray.DataArray(1, attrs={"long_name": "foo"})
+    c = xarray.DataArray(1, attrs={"long_name": "bar"})
+    diagnostics = RunDiagnostics(
+        [
+            ds.assign(a=a, b=1).assign_attrs(run="1"),
+            ds.assign(b=1).assign_attrs(run="2"),
+            ds.assign(c=c).assign_attrs(run="3"),
+        ]
+    )
+    assert diagnostics.long_names == {"a": "foo", "b": "b", "c": "bar"}
+
+
 metrics_df = pd.DataFrame(
     {
         "run": ["run1", "run1", "run2", "run2"],


### PR DESCRIPTION
Parts of prognostic reports with many 2D plots are hard to read/navigate. This PR uses [DataTables](https://datatables.net/) to make these pages easier to view and search.

Example report: https://storage.googleapis.com/vcm-ml-public/oliwm/example-datatables-report-v2/maps.html