### PR TITLE
Add github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+Short description of the issue itself, describing expected and actual behavior if possible.
+
+Steps to reproduce the problem:
+- Step 1
+- More Steps
+
+If relevant, suggestions on how to solve the problem.


### PR DESCRIPTION
fv3net does not currently have an issue template, and as a result the information content of issues can vary a lot. This PR adds a basic issue template suggesting important details to include.

Resolves #1826
