### PR TITLE
Add renaming mapping for PIRE sfc tmp variables

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -3,8 +3,10 @@ from typing import Mapping, Sequence
 
 MovieUrls = Mapping[str, Sequence[str]]
 
+# Renamed keys already have "_coarse" suffix removed prior to the renaming being applied
 VERIFICATION_RENAME_MAP = {
-    "40day_may2020": {"2d": {"TB": "TMPlowest", "tsfc": "TMPsfc"}}
+    "40day_may2020": {"2d": {"TB": "TMPlowest", "tsfc": "TMPsfc"}},
+    "1yr_pire_postspinup": {"2d": {"TB": "TMPlowest", "tsfc": "TMPsfc"}},
 }
 
 RMSE_VARS = [


### PR DESCRIPTION
Renaming will let surface temperature variables from reference be included in prognostic run report.

Resolves #<[1158](https://github.com/ai2cm/fv3net/issues/1158)> 
