### PR TITLE
Make vcm.histogram2d handle different dim orders for inputs

### DIFF
--- a/external/vcm/tests/test_histogram.py
+++ b/external/vcm/tests/test_histogram.py
@@ -16,24 +16,21 @@ def test_histogram():
 
 
 def test_histogram2d():
-    var1 = xr.DataArray(
-        np.reshape(np.arange(0, 40, 2), (5, 4)), dims=["x", "y"], name="temp"
-    )
-    var2 = xr.DataArray(
-        np.reshape(np.arange(0, 20, 1), (5, 4)), dims=["x", "y"], name="humidity"
-    )
+    data_x = np.arange(0, 40, 2)
+    data_y = np.arange(0, 20, 1)
+    bins = [np.array([0, 20, 40]), np.array([0, 10, 20])]
+    var1 = xr.DataArray(np.reshape(data_x, (5, 4)), dims=["x", "y"], name="temp")
+    var2 = xr.DataArray(np.reshape(data_y, (5, 4)), dims=["x", "y"], name="humidity")
     temp_coords = {"temp_bins": [0, 20]}
     sphum_coords = {"humidity_bins": [0, 10]}
     expected_count = xr.DataArray(
-        [[10, 0], [0, 10]],
+        np.histogram2d(data_x, data_y, bins)[0],
         coords={**temp_coords, **sphum_coords},
         dims=["temp_bins", "humidity_bins"],
     )
     expected_xwidth = xr.DataArray([20, 20], coords=temp_coords, dims="temp_bins")
     expected_ywidth = xr.DataArray([10, 10], coords=sphum_coords, dims="humidity_bins")
-    count, xwidth, ywidth = histogram2d(
-        var1, var2, bins=[np.array([0, 20, 40]), np.array([0, 10, 20])]
-    )
+    count, xwidth, ywidth = histogram2d(var1, var2, bins=bins)
     xr.testing.assert_equal(count, expected_count)
     xr.testing.assert_equal(xwidth, expected_xwidth)
     xr.testing.assert_equal(ywidth, expected_ywidth)

--- a/external/vcm/tests/test_histogram.py
+++ b/external/vcm/tests/test_histogram.py
@@ -21,6 +21,7 @@ def test_histogram2d():
     bins = [np.array([0, 20, 40]), np.array([0, 10, 20])]
     var1 = xr.DataArray(np.reshape(data_x, (5, 4)), dims=["x", "y"], name="temp")
     var2 = xr.DataArray(np.reshape(data_y, (5, 4)), dims=["x", "y"], name="humidity")
+    var2 = var2.transpose("y", "x")  # vcm.histogram2d should handle this
     temp_coords = {"temp_bins": [0, 20]}
     sphum_coords = {"humidity_bins": [0, 10]}
     expected_count = xr.DataArray(

--- a/external/vcm/vcm/calc/histogram.py
+++ b/external/vcm/vcm/calc/histogram.py
@@ -46,7 +46,9 @@ def histogram2d(
     """
     xcoord_name = f"{x.name}_bins" if x.name is not None else "xbins"
     ycoord_name = f"{y.name}_bins" if y.name is not None else "ybins"
-    count, xedges, yedges = np.histogram2d(x.values.ravel(), y.values.ravel(), **kwargs)
+    count, xedges, yedges = np.histogram2d(
+        x.values.ravel(), y.transpose(*x.dims).values.ravel(), **kwargs
+    )
     xcoord: Mapping[Hashable, Any] = {xcoord_name: xedges[:-1]}
     ycoord: Mapping[Hashable, Any] = {ycoord_name: yedges[:-1]}
     xwidth = xedges[1:] - xedges[:-1]


### PR DESCRIPTION
Currently `vcm.histogram2d` implicitly assumes that the two supplied data arrays have the same shape/dimension order. This is causing issues in the prognostic report, where `water_vapor_path` and `minus_column_integrated_q2` can have different dim orders (I think because one comes from python diags whereas the other can involve Fortran diags). This PR tests this behavior and makes a fix.

- [x] Tests added