### PR TITLE
Bring spectral normalization code into fv3fit package

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/shared/convolutional_network.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/convolutional_network.py
@@ -2,7 +2,7 @@ from fv3fit._shared.config import RegularizerConfig
 import tensorflow as tf
 from typing import Optional, Sequence
 import dataclasses
-import tensorflow_addons as tfa
+from .spectral_normalization import SpectralNormalization
 
 
 @dataclasses.dataclass
@@ -177,7 +177,7 @@ class ConvolutionalNetworkConfig:
                 use_bias=use_bias,
             )
             if self.spectral_normalization:
-                hidden_layer = tfa.layers.SpectralNormalization(
+                hidden_layer = SpectralNormalization(
                     hidden_layer, name=f"spectral_norm_{label}_{i}"
                 )
             x = hidden_layer(x)

--- a/external/fv3fit/fv3fit/keras/_models/shared/dense_network.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/dense_network.py
@@ -2,7 +2,7 @@ from fv3fit._shared.config import RegularizerConfig
 import tensorflow as tf
 from typing import Sequence
 import dataclasses
-import tensorflow_addons as tfa
+from .spectral_normalization import SpectralNormalization
 
 
 @dataclasses.dataclass
@@ -70,7 +70,7 @@ class DenseNetworkConfig:
                 name=f"hidden_{label}_{i}",
             )
             if self.spectral_normalization:
-                hidden_layer = tfa.layers.SpectralNormalization(
+                hidden_layer = SpectralNormalization(
                     hidden_layer, name=f"spectral_norm_{label}_{i}"
                 )
             x = hidden_layer(x)

--- a/external/fv3fit/fv3fit/keras/_models/shared/spectral_normalization.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/spectral_normalization.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 # Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 # =============================================================================
 
 # this file comes from tensorflow_addons
+# https://github.com/tensorflow/addons/blob/cb0f29a4e66/tensorflow_addons/layers/spectral_normalization.py
 
 import tensorflow as tf
 
@@ -29,6 +31,7 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
 
     Wrap `tf.keras.layers.Conv2D`:
 
+    >>> import numpy as np
     >>> x = np.random.rand(1, 10, 10, 1)
     >>> conv2d = SpectralNormalization(tf.keras.layers.Conv2D(2, 2))
     >>> y = conv2d(x)

--- a/external/fv3fit/fv3fit/keras/_models/shared/spectral_normalization.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/spectral_normalization.py
@@ -1,0 +1,131 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+# this file comes from tensorflow_addons
+
+import tensorflow as tf
+
+
+@tf.keras.utils.register_keras_serializable(package="Fv3fit")
+class SpectralNormalization(tf.keras.layers.Wrapper):
+    """Performs spectral normalization on weights.
+
+    This wrapper controls the Lipschitz constant of the layer by
+    constraining its spectral norm, which can stabilize the training of GANs.
+
+    See [Spectral Normalization for Generative Adversarial Networks](https://arxiv.org/abs/1802.05957).
+
+    Wrap `tf.keras.layers.Conv2D`:
+
+    >>> x = np.random.rand(1, 10, 10, 1)
+    >>> conv2d = SpectralNormalization(tf.keras.layers.Conv2D(2, 2))
+    >>> y = conv2d(x)
+    >>> y.shape
+    TensorShape([1, 9, 9, 2])
+
+    Wrap `tf.keras.layers.Dense`:
+
+    >>> x = np.random.rand(1, 10, 10, 1)
+    >>> dense = SpectralNormalization(tf.keras.layers.Dense(10))
+    >>> y = dense(x)
+    >>> y.shape
+    TensorShape([1, 10, 10, 10])
+
+    Args:
+      layer: A `tf.keras.layers.Layer` instance that
+        has either `kernel` or `embeddings` attribute.
+      power_iterations: `int`, the number of iterations during normalization.
+    Raises:
+      AssertionError: If not initialized with a `Layer` instance.
+      ValueError: If initialized with negative `power_iterations`.
+      AttributeError: If `layer` does not has `kernel` or `embeddings` attribute.
+    """
+
+    def __init__(self, layer: tf.keras.layers, power_iterations: int = 1, **kwargs):
+        super().__init__(layer, **kwargs)
+        if power_iterations <= 0:
+            raise ValueError(
+                "`power_iterations` should be greater than zero, got "
+                "`power_iterations={}`".format(power_iterations)
+            )
+        self.power_iterations = power_iterations
+        self._initialized = False
+
+    def build(self, input_shape):
+        """Build `Layer`"""
+        super().build(input_shape)
+        input_shape = tf.TensorShape(input_shape)
+        self.input_spec = tf.keras.layers.InputSpec(shape=[None] + input_shape[1:])
+
+        if hasattr(self.layer, "kernel"):
+            self.w = self.layer.kernel
+        elif hasattr(self.layer, "embeddings"):
+            self.w = self.layer.embeddings
+        else:
+            raise AttributeError(
+                "{} object has no attribute 'kernel' nor "
+                "'embeddings'".format(type(self.layer).__name__)
+            )
+
+        self.w_shape = self.w.shape.as_list()
+
+        self.u = self.add_weight(
+            shape=(1, self.w_shape[-1]),
+            initializer=tf.initializers.TruncatedNormal(stddev=0.02),
+            trainable=False,
+            name="sn_u",
+            dtype=self.w.dtype,
+        )
+
+    def call(self, inputs, training=None):
+        """Call `Layer`"""
+        if training is None:
+            training = tf.keras.backend.learning_phase()
+
+        if training:
+            self.normalize_weights()
+
+        output = self.layer(inputs)
+        return output
+
+    def compute_output_shape(self, input_shape):
+        return tf.TensorShape(self.layer.compute_output_shape(input_shape).as_list())
+
+    def normalize_weights(self):
+        """Generate spectral normalized weights.
+
+        This method will update the value of `self.w` with the
+        spectral normalized value, so that the layer is ready for `call()`.
+        """
+
+        w = tf.reshape(self.w, [-1, self.w_shape[-1]])
+        u = self.u
+
+        with tf.name_scope("spectral_normalize"):
+            for _ in range(self.power_iterations):
+                v = tf.math.l2_normalize(tf.matmul(u, w, transpose_b=True))
+                u = tf.math.l2_normalize(tf.matmul(v, w))
+            u = tf.stop_gradient(u)
+            v = tf.stop_gradient(v)
+            sigma = tf.matmul(tf.matmul(v, w), u, transpose_b=True)
+            self.u.assign(tf.cast(u, self.u.dtype))
+            self.w.assign(
+                tf.cast(tf.reshape(self.w / sigma, self.w_shape), self.w.dtype)
+            )
+
+    def get_config(self):
+        config = {"power_iterations": self.power_iterations}
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/external/fv3fit/setup.py
+++ b/external/fv3fit/setup.py
@@ -12,7 +12,6 @@ requirements = [
     "fsspec>=0.6.2",
     "pyyaml>=5.1.2",
     "tensorflow>=2.5.2",
-    "tensorflow-addons>=0.11.2",
     "typing_extensions>=3.7.4.3",
     "dacite>=1.6.0",
     "wandb[media]>=0.12.1",

--- a/external/fv3fit/tests/keras/test_doctest.py
+++ b/external/fv3fit/tests/keras/test_doctest.py
@@ -1,5 +1,6 @@
 import doctest
 from fv3fit.keras._models.shared import spectral_normalization
 
+
 def test_spectral_normalization():
     doctest.testmod(spectral_normalization, raise_on_error=True)

--- a/external/fv3fit/tests/keras/test_doctest.py
+++ b/external/fv3fit/tests/keras/test_doctest.py
@@ -1,0 +1,5 @@
+import doctest
+from fv3fit.keras._models.shared import spectral_normalization
+
+def test_spectral_normalization():
+    doctest.testmod(spectral_normalization, raise_on_error=True)


### PR DESCRIPTION
We only use tensorflow_addons for spectral normalization, and that package has compatibility issues with nix. This PR brings in that code to avoid the dependency.

Significant internal changes:
- SpectralNormalization code now exists in fv3fit, copied from tensorflow_addons

Requirement changes:
- fv3fit no longer depends on tensorflow_addons

- [ ] Tests added

Resolves #1286
