### PR TITLE
Use consistent bins for 1D and 2D q2 histograms

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -13,8 +13,7 @@ COL_MOISTENING = "column_integrated_q2"
 HISTOGRAM_BINS = {
     PRECIP_RATE: np.logspace(-1, np.log10(500), 101),
     WVP: np.linspace(-10, 90, 101),
-    COL_DRYING: np.linspace(-10, 90, 101),
-    COL_MOISTENING: np.linspace(-10, 90, 101),
+    COL_DRYING: np.linspace(-50, 150, 101),
 }
 
 # argument typehint for diags in save_prognostic_run_diags but used

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -14,6 +14,7 @@ HISTOGRAM_BINS = {
     PRECIP_RATE: np.logspace(-1, np.log10(500), 101),
     WVP: np.linspace(-10, 90, 101),
     COL_DRYING: np.linspace(-50, 150, 101),
+    COL_MOISTENING: np.linspace(-150, 50, 101),
 }
 
 # argument typehint for diags in save_prognostic_run_diags but used

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -100,7 +100,7 @@ def _compute_wvp_vs_q2_histogram(ds: xr.Dataset) -> xr.Dataset:
     counts = xr.Dataset()
     col_drying = -ds[COL_MOISTENING].rename(COL_DRYING)
     col_drying.attrs["units"] = ds[COL_MOISTENING].attrs.get("units")
-    bins = [HISTOGRAM_BINS[WVP], np.linspace(-50, 150, 101)]
+    bins = [HISTOGRAM_BINS[WVP], HISTOGRAM_BINS[COL_DRYING]]
 
     counts, wvp_bins, q2_bins = vcm.histogram2d(ds[WVP], col_drying, bins=bins)
     return xr.Dataset(

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -348,7 +348,9 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
             output_dir=output_dir,
         )
         plt.close(hist_wvp)
-        hist_col_drying = plot_histogram(ds_diags, f"{COL_DRYING}_histogram")
+        hist_col_drying = plot_histogram(
+            ds_diags, f"{COL_DRYING}_histogram", yscale="log"
+        )
         report.insert_report_figure(
             report_sections,
             hist_col_drying,

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -475,7 +475,7 @@ def compute_hist_2d_bias(diag_arg: DiagArg):
 
 def _compute_wvp_vs_q2_histogram(ds: xr.Dataset) -> xr.Dataset:
     counts = xr.Dataset()
-    bins = [HISTOGRAM_BINS[WVP], np.linspace(-50, 150, 101)]
+    bins = [HISTOGRAM_BINS[WVP], HISTOGRAM_BINS[COL_DRYING]]
     counts, wvp_bins, q2_bins = vcm.histogram2d(ds[WVP], ds[COL_DRYING], bins=bins)
     return xr.Dataset(
         {


### PR DESCRIPTION
This will remove some plotting artifacts in the water vapor path versus column Q2 plots in the offline report. Currently, because different bins for <Q2> are used for the 1D and 2D histograms there end up being many missing values in the 2D histogram which results in plotting artifacts. See example attached.

![hist2d_wvp_vs_q2-1](https://user-images.githubusercontent.com/23640870/169097280-614f1b48-b602-4a36-981b-9b59ac02c0ab.png)
