### PR TITLE
Add pQ1 and pQ2 to hybrid mapper outputs

### DIFF
--- a/external/loaders/loaders/mappers/_hybrid.py
+++ b/external/loaders/loaders/mappers/_hybrid.py
@@ -11,6 +11,8 @@ from loaders.mappers._fine_res_budget import FineResBudget
 def compute_hybrid_budget(ds: xr.Dataset) -> xr.Dataset:
     ds["dQ1"] = ds.Q1 - ds.tendency_of_air_temperature_due_to_fv3_physics
     ds["dQ2"] = ds.Q2 - ds.tendency_of_specific_humidity_due_to_fv3_physics
+    ds["pQ1"] = ds.tendency_of_air_temperature_due_to_fv3_physics
+    ds["pQ2"] = ds.tendency_of_specific_humidity_due_to_fv3_physics
     ds["dQxwind"] = ds.x_wind_tendency_due_to_nudging
     ds["dQywind"] = ds.y_wind_tendency_due_to_nudging
     return ds

--- a/external/loaders/tests/_regtest_outputs/test__nudged.test_open_fine_resolution_nudging_hybrid.out
+++ b/external/loaders/tests/_regtest_outputs/test__nudged.test_open_fine_resolution_nudging_hybrid.out
@@ -204,6 +204,10 @@ variables:
 	object time() ;
 	float32 dQ1(tile, z, y, x) ;
 	float32 dQ2(tile, z, y, x) ;
+	float32 pQ1(tile, z, y, x) ;
+		pQ1:units = unknown ;
+	float32 pQ2(tile, z, y, x) ;
+		pQ2:units = unknown ;
 	float32 dQxwind(tile, z, y_interface, x) ;
 		dQxwind:units = m/s s^-1 ;
 	float32 dQywind(tile, z, y, x_interface) ;


### PR DESCRIPTION
Necessary for properly computing Q2 in the offline diags.