### PR TITLE
Update emails in setup.py files to allenai.org

### DIFF
--- a/external/emulation/setup.py
+++ b/external/emulation/setup.py
@@ -25,7 +25,7 @@ test_requirements = []
 
 setup(
     author="Vulcan Technologies LLC",
-    author_email="andrep@vulcan.com",
+    author_email="andrep@allenai.org",
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/external/fv3fit/setup.py
+++ b/external/fv3fit/setup.py
@@ -28,7 +28,7 @@ test_requirements = ["pytest"]
 
 setup(
     author="Vulcan Technologies LLC",
-    author_email="jeremym@vulcan.com",
+    author_email="jeremym@allenai.org",
     python_requires=">=3.6.9",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/external/fv3kube/setup.py
+++ b/external/fv3kube/setup.py
@@ -6,7 +6,7 @@ setup(
     version="0.1.0",
     python_requires=">=3.6.9",
     author="Oliver Watt-Meyer",
-    author_email="oliwm@vulcan.com",
+    author_email="oliverwm@allenai.org",
     packages=find_packages(),
     package_dir={"": "."},
     package_data={"fv3kube": ["base_yamls/*/fv3config.yml"]},

--- a/external/loaders/setup.py
+++ b/external/loaders/setup.py
@@ -6,7 +6,7 @@ setup(
     version="0.1.0",
     python_requires=">=3.6.9",
     author="Anna Kwa",
-    author_email="annak@vulcan.com",
+    author_email="annak@allenai.org",
     packages=find_packages(),
     package_dir={"": "."},
     package_data={},

--- a/external/synth/setup.py
+++ b/external/synth/setup.py
@@ -8,7 +8,7 @@ setup(
     version="0.1.0",
     python_requires="==3.*,>=3.7.0",
     author="Noah D. Brenowitz",
-    author_email="noahb@vulcan.com",
+    author_email="noahb@allenai.org",
     packages=["synth"],
     package_dir={"": "."},
     package_data={

--- a/external/vcm/setup.py
+++ b/external/vcm/setup.py
@@ -37,7 +37,7 @@ install_requirements = [
 
 setup(
     author="Vulcan Technologies, LLC",
-    author_email="noahb@vulcan.com",
+    author_email="noahb@allenai.org",
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/workflows/diagnostics/setup.py
+++ b/workflows/diagnostics/setup.py
@@ -32,7 +32,7 @@ install_requirements = [
 
 setup(
     author="Vulcan Technologies, LLC",
-    author_email="noahb@vulcan.com",
+    author_email="noahb@allenai.org",
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/workflows/post_process_run/setup.py
+++ b/workflows/post_process_run/setup.py
@@ -9,7 +9,7 @@ setup(
     version="0.1.0",
     python_requires=">=3.6.0",
     author="Oliver Watt-Meyer",
-    author_email="oliwm@vulcan.com",
+    author_email="oliverwm@allenai.org",
     packages=find_packages(),
     package_dir={"": "."},
     package_data={},

--- a/workflows/prognostic_c48_run/setup.py
+++ b/workflows/prognostic_c48_run/setup.py
@@ -20,7 +20,7 @@ test_requirements = ["pytest"]
 
 setup(
     author="Vulcan Technologies LLC",
-    author_email="noahb@vulcan.com",
+    author_email="noahb@allenai.org",
     python_requires=">=3.6",
     package_data={"": ["*.json"]},
     description="The prognostic run application code. Not a library.",


### PR DESCRIPTION
When we moved from Vulcan to AI2 we didn't update our e-mails in setup.py files. This PR does so.

Resolves #1842 