### PR TITLE
keep attrs in vcm.weighted_average

### DIFF
--- a/external/vcm/tests/test_calc.py
+++ b/external/vcm/tests/test_calc.py
@@ -222,3 +222,16 @@ def test_weighted_averaged_no_dims():
     expected = xr.DataArray(np.arange(1.0, 5.0), dims=["z"])
 
     xr.testing.assert_allclose(weighted_average(da, weights), expected)
+
+
+def test_weighted_averaged_keeps_attrs():
+    da = xr.DataArray(
+        [[[np.arange(1.0, 5.0)]]],
+        dims=["tile", "y", "x", "z"],
+        attrs={"units": "unit_name", "other": "foo"},
+    )
+    weights = xr.DataArray([[[[0.5, 0.5, 1, 1]]]], dims=["tile", "y", "x", "z"])
+    expected = xr.DataArray(
+        np.arange(1.0, 5.0), dims=["z"], attrs={"units": "unit_name", "other": "foo"}
+    )
+    xr.testing.assert_identical(weighted_average(da, weights), expected)

--- a/external/vcm/vcm/calc/calc.py
+++ b/external/vcm/vcm/calc/calc.py
@@ -47,11 +47,12 @@ def weighted_average(
         kwargs = {"axis": tuple(range(-len(dims), 0))}
     else:
         kwargs = {}
-    return xr.apply_ufunc(
-        _weighted_average,
-        array,
-        weights,
-        input_core_dims=[dims, dims],
-        kwargs=kwargs,
-        dask="allowed",
-    )
+    with xr.set_options(keep_attrs=True):
+        return xr.apply_ufunc(
+            _weighted_average,
+            array,
+            weights,
+            input_core_dims=[dims, dims],
+            kwargs=kwargs,
+            dask="allowed",
+        )


### PR DESCRIPTION
This PR updates `vcm.weighted_average` so it retains attributes.

Refactored public API:
- `vcm.weighted_average` now retains attributes

- [x] Tests added

Resolves #1846 
