### PR TITLE
Add tapering transform

### DIFF
--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -232,7 +232,7 @@ class TransformedPredictor(Predictor):
     def load(cls, path: str) -> "TransformedPredictor":
         with fsspec.open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
             config = yaml.safe_load(f)
-        base_model = io.load(config["base_model"])
+        base_model = io.load(os.path.join(path, cls._BASE_MODEL_SUBDIR))
         transform_configs = [
             dacite.from_dict(vcm.DataTransform, x) for x in config["transforms"]
         ]

--- a/external/vcm/tests/test_calc.py
+++ b/external/vcm/tests/test_calc.py
@@ -15,7 +15,7 @@ from vcm.calc.thermo.vertically_dependent import (
     _add_coords_to_interface_variable,
     mass_streamfunction,
 )
-from vcm.calc.calc import local_time, weighted_average
+from vcm.calc.calc import local_time, weighted_average, vertical_scale_factors
 from vcm.cubedsphere.constants import COORD_Z_CENTER, COORD_Z_OUTER
 from vcm.calc.thermo.constants import _GRAVITY, _RDGAS, _RVGAS
 import vcm
@@ -222,3 +222,17 @@ def test_weighted_averaged_no_dims():
     expected = xr.DataArray(np.arange(1.0, 5.0), dims=["z"])
 
     xr.testing.assert_allclose(weighted_average(da, weights), expected)
+
+
+@pytest.mark.parametrize(
+    "cutoff, rate, expected",
+    [
+        (0, 5, np.array([1.0, 1.0, 1.0, 1.0])),
+        (2, 5, np.array([np.exp(-2.0 / 5), np.exp(-1.0 / 5), 1.0, 1.0])),
+    ],
+)
+def test_vertical_scale_factors(cutoff, rate, expected):
+    x = np.ones(4)
+    np.testing.assert_array_almost_equal(
+        x * vertical_scale_factors(4, cutoff=cutoff, rate=rate), expected
+    )

--- a/external/vcm/vcm/calc/calc.py
+++ b/external/vcm/vcm/calc/calc.py
@@ -55,3 +55,10 @@ def weighted_average(
         kwargs=kwargs,
         dask="allowed",
     )
+
+
+def vertical_scale_factors(n_levels: int, cutoff: int, rate: float):
+    z_arr = np.arange(n_levels)
+    scaled = np.exp((z_arr[slice(None, cutoff)] - cutoff) / rate)
+    unscaled = np.ones(n_levels - cutoff)
+    return np.hstack([scaled, unscaled])

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -33,6 +33,8 @@ TransformName = Literal[
     "Q2_tendency_from_Q2_flux",
     "implied_surface_precipitation_rate",
     "implied_downward_radiative_flux_at_surface",
+    "taper_dQ1",
+    "taper_dQ2",
 ]
 
 

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -8,6 +8,7 @@ from .calc.flux_form import (
     _flux_to_tendency,
     _tendency_to_implied_surface_downward_flux,
 )
+from .calc.calc import vertical_scale_factors
 
 
 @dataclasses.dataclass
@@ -59,6 +60,26 @@ def register(
         func=func, inputs=inputs, outputs=outputs
     )
     return func
+
+
+@register(["dQ1"], ["dQ1"])
+def taper_dQ1(ds, cutoff: int, rate: float):
+    n_levels = len(ds["z"])
+    scaling = xr.DataArray(
+        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
+    )
+    ds["dQ1"] = scaling * ds["dQ1"]
+    return ds
+
+
+@register(["dQ2"], ["dQ2"])
+def taper_dQ2(ds, cutoff: int, rate: float):
+    n_levels = len(ds["z"])
+    scaling = xr.DataArray(
+        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
+    )
+    ds["dQ2"] = scaling * ds["dQ2"]
+    return ds
 
 
 @register(["Q1", "Q2"], ["Qm"])

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -35,8 +35,6 @@ TransformName = Literal[
     "implied_downward_radiative_flux_at_surface",
     "tapered_dQ1",
     "tapered_dQ2",
-    "tapered_dQu",
-    "tapered_dQv",
 ]
 
 
@@ -83,26 +81,6 @@ def tapered_dQ2(ds, cutoff: int, rate: float):
         vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
     )
     ds["tapered_dQ2"] = scaling * ds["dQ2"]
-    return ds
-
-
-@register(["dQu"], ["tapered_dQu"])
-def tapered_dQu(ds, cutoff: int, rate: float):
-    n_levels = len(ds["z"])
-    scaling = xr.DataArray(
-        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
-    )
-    ds["tapered_dQu"] = scaling * ds["dQu"]
-    return ds
-
-
-@register(["dQv"], ["tapered_dQv"])
-def tapered_dQv(ds, cutoff: int, rate: float):
-    n_levels = len(ds["z"])
-    scaling = xr.DataArray(
-        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
-    )
-    ds["tapered_dQv"] = scaling * ds["dQv"]
     return ds
 
 

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -64,23 +64,23 @@ def register(
     return func
 
 
-@register(["dQ1"], ["dQ1"])
+@register(["dQ1"], ["tapered_dQ1"])
 def taper_dQ1(ds, cutoff: int, rate: float):
     n_levels = len(ds["z"])
     scaling = xr.DataArray(
         vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
     )
-    ds["dQ1"] = scaling * ds["dQ1"]
+    ds["tapered_dQ1"] = scaling * ds["dQ1"]
     return ds
 
 
-@register(["dQ2"], ["dQ2"])
+@register(["dQ2"], ["tapered_dQ2"])
 def taper_dQ2(ds, cutoff: int, rate: float):
     n_levels = len(ds["z"])
     scaling = xr.DataArray(
         vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
     )
-    ds["dQ2"] = scaling * ds["dQ2"]
+    ds["tapered_dQ2"] = scaling * ds["dQ2"]
     return ds
 
 

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -33,8 +33,10 @@ TransformName = Literal[
     "Q2_tendency_from_Q2_flux",
     "implied_surface_precipitation_rate",
     "implied_downward_radiative_flux_at_surface",
-    "taper_dQ1",
-    "taper_dQ2",
+    "tapered_dQ1",
+    "tapered_dQ2",
+    "tapered_dQu",
+    "tapered_dQv",
 ]
 
 
@@ -65,7 +67,7 @@ def register(
 
 
 @register(["dQ1"], ["tapered_dQ1"])
-def taper_dQ1(ds, cutoff: int, rate: float):
+def tapered_dQ1(ds, cutoff: int, rate: float):
     n_levels = len(ds["z"])
     scaling = xr.DataArray(
         vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
@@ -75,12 +77,32 @@ def taper_dQ1(ds, cutoff: int, rate: float):
 
 
 @register(["dQ2"], ["tapered_dQ2"])
-def taper_dQ2(ds, cutoff: int, rate: float):
+def tapered_dQ2(ds, cutoff: int, rate: float):
     n_levels = len(ds["z"])
     scaling = xr.DataArray(
         vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
     )
     ds["tapered_dQ2"] = scaling * ds["dQ2"]
+    return ds
+
+
+@register(["dQu"], ["tapered_dQu"])
+def tapered_dQu(ds, cutoff: int, rate: float):
+    n_levels = len(ds["z"])
+    scaling = xr.DataArray(
+        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
+    )
+    ds["tapered_dQu"] = scaling * ds["dQu"]
+    return ds
+
+
+@register(["dQv"], ["tapered_dQv"])
+def tapered_dQv(ds, cutoff: int, rate: float):
+    n_levels = len(ds["z"])
+    scaling = xr.DataArray(
+        vertical_scale_factors(n_levels=n_levels, cutoff=cutoff, rate=rate), dims=["z"]
+    )
+    ds["tapered_dQv"] = scaling * ds["dQv"]
     return ds
 
 


### PR DESCRIPTION
This adds transforms for tapering dQ1 and dQ2 tendencies. This is the most straightforward way of configuring a model to output tendency predictions that are tapered. Note that in this implementation of tapering, if using the standard scaling of model levels in the loss, the upper levels still have the same contribution to the loss function as if they were not tapered at all.

An additional update (in progress) is still needed to the prognostic run in order for these models to be usable on line. Currently the prognostic run defaults to using outputs named `dQ1, dQ2` as the temperature and humidity tendency updates, so it would not recognize the transformed outputs `tapered_dQx` as the tendencies to apply. The upcoming PR would add a configuration option to specify which outputs to use as updates and whether they were either tendencies or state updates.


(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]
