### PR TITLE
Collapse offline report metadata

### DIFF
--- a/external/report/report/create_report.py
+++ b/external/report/report/create_report.py
@@ -28,15 +28,22 @@ HTML_TEMPLATE = Template(
     Report created {{now}}
 
     {% if metadata is not none %}
-        <h2>Metadata </h2>
-    <details>
-        <summary> Click to expand </summary>
-        <p class="abstract-text" style="font-size:.90em">
+    <h2>Metadata </h2>
+        {% if collapse_metadata is true %}
+            <details>
+                <summary> Click to expand </summary>
+                <p class="abstract-text" style="font-size:.90em">
+                    <pre id="json">
+                    {{ metadata }}
+                </pre>
+                </p>
+            </details>
+        {% else %}
             <pre id="json">
-            {{ metadata }}
-        </pre>
-        </p>
-    </details>
+                {{ metadata }}
+            </pre>
+        {% endif %}
+
 
     {% endif %}
 
@@ -170,6 +177,7 @@ def create_html(
     metadata=None,
     html_header: str = "",
     metrics: Metrics = None,
+    collapse_metadata: bool = False,
 ) -> str:
     """Return html report of figures described in sections.
 
@@ -203,5 +211,6 @@ def create_html(
         now=now_str,
         header=html_header,
         metrics_columns=metrics_columns,
+        collapse_metadata=collapse_metadata,
     )
     return html

--- a/external/report/report/create_report.py
+++ b/external/report/report/create_report.py
@@ -26,11 +26,18 @@ HTML_TEMPLATE = Template(
     <body>
     <h1>{{title}}</h1>
     Report created {{now}}
+
     {% if metadata is not none %}
-        <h2>Metadata</h2>
-<pre id="json">
-{{ metadata }}
-</pre>
+        <h2>Metadata </h2>
+    <details>
+        <summary> Click to expand </summary>
+        <p class="abstract-text" style="font-size:.90em">
+            <pre id="json">
+            {{ metadata }}
+        </pre>
+        </p>
+    </details>
+
     {% endif %}
 
     {% if metrics is not none %}

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -364,6 +364,7 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
         title="ML offline diagnostics",
         metadata=config,
         metrics=dict(metrics_formatted),
+        collapse_metadata=True,
     )
 
 


### PR DESCRIPTION
This collapses the configuration metadata so that you don't have to scroll past a long list of timesteps to get to the meat of the report. ex. https://storage.googleapis.com/vcm-ml-public/annak/2022-05-23/test-html-collapsible-3/index.html