### PR TITLE
Fix make enter_emulation entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,6 @@ pull_image_prognostic_run_base:
 pull_image_prognostic_run_base_gpu:
 	docker pull $(REGISTRY)/prognostic_run_base_gpu:$(PROGNOSTIC_BASE_VERSION)
 
-enter_emulation:
-	cd projects/microphysics && docker-compose run --rm -w /fv3net/external/emulation fv3 bash
-
 enter_prognostic_run:
 	docker run \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifneq ("$(wildcard .env)","")
 	DOCKER_INTERACTIVE_ARGS += --env-file=.env
 endif
 
+PROGNOSTIC_RUN_WORKDIR ?= /fv3net/workflows/prognostic_c48_run
+
 IMAGES = fv3net post_process_run prognostic_run
 
 .PHONY: build_images push_image run_integration_tests image_name_explicit
@@ -124,12 +126,15 @@ pull_image_prognostic_run_base:
 pull_image_prognostic_run_base_gpu:
 	docker pull $(REGISTRY)/prognostic_run_base_gpu:$(PROGNOSTIC_BASE_VERSION)
 
+enter_emulation:
+	PROGNOSTIC_RUN_WORKDIR=/fv3net/external/emulation $(MAKE) enter_prognostic_run
+
 enter_prognostic_run:
 	docker run \
 		--rm \
 		$(DOCKER_AUTH_ARGS) \
 		$(DOCKER_INTERACTIVE_ARGS) \
-		-w /fv3net/workflows/prognostic_c48_run \
+		-w $(PROGNOSTIC_RUN_WORKDIR) \
 		$(REGISTRY)/prognostic_run:$(VERSION) bash
 
 ############################################################


### PR DESCRIPTION
PR #1837 broke the `make enter_emulation` target. This PR restores its functionality by deferring its functionality to `make enter_prognostic_run`.

Resolves #1867 
