### PR TITLE
Make vcm compatible with py37

### DIFF
--- a/external/vcm/setup.py
+++ b/external/vcm/setup.py
@@ -29,6 +29,7 @@ install_requirements = [
     "pytest-regtest",
     "h5netcdf>=0.8",
     "intake-xarray>=0.3.1",
+    "typing_extensions",
     "dacite",
 ]
 
@@ -44,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     description="vcm contains general purposes tools for analyzing FV3 data",
     install_requires=install_requirements,

--- a/external/vcm/setup.py
+++ b/external/vcm/setup.py
@@ -24,7 +24,7 @@ install_requirements = [
     "xgcm",
     "cftime",
     "pytest",
-    "google-cloud-storage>=1.28.0",
+    "google-cloud-storage>=1.18.1",
     "google-api-core",
     "pytest-regtest",
     "h5netcdf>=0.8",

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -1,6 +1,7 @@
 import dataclasses
 from toolz.functoolz import curry
-from typing import Callable, Literal, MutableMapping, Sequence, Set
+from typing import Callable, MutableMapping, Sequence, Set
+from typing_extensions import Literal
 import xarray as xr
 import vcm
 from .calc.flux_form import (


### PR DESCRIPTION
Some slight adjustments to make vcm usable from google colab.

Here is a working example: https://colab.research.google.com/drive/1jLCfdUy667UQxJHfeTXhp1NmPJzumHN2?usp=sharing

Resolves #1853

I tried adding some testing infrastructure for python 3.7, but couldn't get it to work right away. We can add it later if we start using python3.7 environments more often.