### PR TITLE
Add rectified bias to offline training scores

### DIFF
--- a/external/fv3fit/fv3fit/emulation/scoring.py
+++ b/external/fv3fit/fv3fit/emulation/scoring.py
@@ -40,6 +40,20 @@ def score(target, prediction) -> ScoringOutput:
     return metrics, profiles
 
 
+def _append_rectified_cloud_if_available(targets, predictions, names):
+
+    qc_key = "cloud_water_mixing_ratio_after_gscond"
+    if qc_key in names:
+        idx = names.index(qc_key)
+        target = targets[idx]
+        prediction = predictions[idx]
+
+        rectified = np.where(prediction < 0, 0, prediction)
+        targets.append(target)
+        predictions.append(rectified)
+        names.append(f"{qc_key}_rectified")
+
+
 def score_multi_output(
     targets: Sequence[np.ndarray],
     predictions: Sequence[np.ndarray],
@@ -59,6 +73,12 @@ def score_multi_output(
 
     all_scores: Dict[str, float] = {}
     all_profiles: Dict[str, np.ndarray] = {}
+
+    targets = list(targets)
+    predictions = list(predictions)
+    names = list(names)
+
+    _append_rectified_cloud_if_available(targets, predictions, names)
 
     for target, prediction, name in zip(targets, predictions, names):
 

--- a/external/fv3fit/fv3fit/emulation/scoring.py
+++ b/external/fv3fit/fv3fit/emulation/scoring.py
@@ -40,43 +40,6 @@ def score(target, prediction) -> ScoringOutput:
     return metrics, profiles
 
 
-def score_single_output(
-    target: np.ndarray, prediction: np.ndarray, name: str
-) -> ScoringOutput:
-    """
-    Score a single named output from an emulation model. Returns
-    a flat dictionary with score/profile keys preceding variable
-    name for Weights & Biases chart grouping.
-
-    Precipitation scores are rescaled for backwards compatibility
-
-    Args:
-        target: truth values
-        prediction: emulated values
-        name: name of field being emulated to be added to the key
-            of each score
-    """
-
-    # including for backwards compatibility for precip scores
-    # precip has units meters/timestep, scaling assumes timestep is 900s
-    if name == "total_precipitation":
-        millimeters_in_meter = 1000
-        timestep_seconds = 900
-        seconds_in_day = 60 * 60 * 24
-        precip_scaling = (
-            millimeters_in_meter / timestep_seconds * seconds_in_day
-        )  # mm/day
-        target *= precip_scaling
-        prediction *= precip_scaling
-
-    scores, profiles = score(target, prediction)
-    # Keys use directory style for wandb chart grouping
-    flat_score = {f"{k}/{name}": v for k, v in scores.items()}
-    flat_profile = {f"{k}/{name}": v for k, v in profiles.items()}
-
-    return flat_score, flat_profile
-
-
 def score_multi_output(
     targets: Sequence[np.ndarray],
     predictions: Sequence[np.ndarray],
@@ -97,10 +60,26 @@ def score_multi_output(
     all_scores: Dict[str, float] = {}
     all_profiles: Dict[str, np.ndarray] = {}
 
-    for target, pred, name in zip(targets, predictions, names):
+    for target, prediction, name in zip(targets, predictions, names):
 
-        scores, profiles = score_single_output(target, pred, name)
-        all_scores.update(scores)
-        all_profiles.update(profiles)
+        # including for backwards compatibility for precip scores
+        # precip has units meters/timestep, scaling assumes timestep is 900s
+        if name == "total_precipitation":
+            millimeters_in_meter = 1000
+            timestep_seconds = 900
+            seconds_in_day = 60 * 60 * 24
+            precip_scaling = (
+                millimeters_in_meter / timestep_seconds * seconds_in_day
+            )  # mm/day
+            target *= precip_scaling
+            prediction *= precip_scaling
+
+        scores, profiles = score(target, prediction)
+        # Keys use directory style for wandb chart grouping
+        flat_score = {f"{k}/{name}": v for k, v in scores.items()}
+        flat_profile = {f"{k}/{name}": v for k, v in profiles.items()}
+
+        all_scores.update(flat_score)
+        all_profiles.update(flat_profile)
 
     return all_scores, all_profiles

--- a/external/fv3fit/tests/emulation/test_scoring.py
+++ b/external/fv3fit/tests/emulation/test_scoring.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-from fv3fit.emulation.scoring import score, score_single_output, score_multi_output
+from fv3fit.emulation.scoring import score, score_multi_output
 
 
 def _get_tensor():
@@ -32,17 +32,6 @@ def prediction(arraylike_input):
 def test_score(target, prediction):
 
     scores, profiles = score(target, prediction)
-
-    for v in scores.values():
-        assert v == 1.0
-
-    for v in profiles.values():
-        np.testing.assert_array_equal(v, np.ones(2))
-
-
-def test_score_single_output_flat_scores(target, prediction):
-
-    scores, profiles = score_single_output(target, prediction, "field")
 
     for v in scores.values():
         assert v == 1.0

--- a/external/fv3fit/tests/emulation/test_scoring.py
+++ b/external/fv3fit/tests/emulation/test_scoring.py
@@ -2,7 +2,11 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-from fv3fit.emulation.scoring import score, score_multi_output
+from fv3fit.emulation.scoring import (
+    score,
+    score_multi_output,
+    _append_rectified_cloud_if_available,
+)
 
 
 def _get_tensor():
@@ -53,3 +57,18 @@ def test_score_multi_output_flat_scores(target, prediction):
 
     for v in profiles.values():
         np.testing.assert_array_equal(v, np.ones(2))
+
+
+def test__append_rectified_cloud_if_available():
+
+    targets = [np.array([1, 1, 1])]
+    predictions = [np.array([-1, 0, 1])]
+    names = ["cloud_water_mixing_ratio_after_gscond"]
+
+    _append_rectified_cloud_if_available(targets, predictions, names)
+
+    for _list in [targets, predictions, names]:
+        assert len(_list) == 2
+
+    np.testing.assert_array_equal(predictions[1], np.array([0, 0, 1]))
+    np.testing.assert_array_equal(targets[0], targets[1])


### PR DESCRIPTION
The bias of the gscond-only models does not tell the whole story when the subsequent fortran call removes negative cloud water values.  This PR adds a "rectified" bias term which compares the prediction of condensate after gscond where all values < 0 = 0 to a target.

- [x] tested