### PR TITLE
Revert "Extend fhmax default (#1877)"

### DIFF
--- a/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
+++ b/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
@@ -23,7 +23,7 @@ namelist:
     chksum_debug: false
     dycore_only: false
     fdiag: 0.0
-    fhmax: 99999
+    fhmax: 1024.0
     fhmaxhf: -1.0
     fhout: 0.25
     fhouthf: 0.0

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
@@ -150,7 +150,7 @@ namelist:
     chksum_debug: false
     dycore_only: false
     fdiag: 0.0
-    fhmax: 99999
+    fhmax: 1024.0
     fhmaxhf: -1.0
     fhout: 0.25
     fhouthf: 0.0

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
@@ -150,7 +150,7 @@ namelist:
     chksum_debug: false
     dycore_only: false
     fdiag: 0.0
-    fhmax: 99999
+    fhmax: 1024.0
     fhmaxhf: -1.0
     fhout: 0.25
     fhouthf: 0.0


### PR DESCRIPTION
The last PR caused seg faults for prognostic runs with lower physics diagnostics save intervals- they ran out of space in their `fdiag` arrays. Reverting to the previous default for fhmax, and [the issue with physics diags not saving after ~40d](https://github.com/ai2cm/fv3net/issues/1876) will instead be fixed on the fortran side (solution proposed [here](https://github.com/ai2cm/fv3gfs-fortran/issues/301)). 

Instead of changing the default, in the meantime if we are saving data for longer than 1024 hr, fhmax can be manually updated to be larger in the user config.