### PR TITLE
Append coverage data from tox runs to unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,12 @@ test_%:
 
 test_unit: test_fv3kube test_vcm test_fv3fit test_artifacts
 	coverage run -m pytest -m "not regression" --mpl --mpl-baseline-path=tests/baseline_images $(ARGS)
+	coverage combine \
+		--append \
+		external/fv3kube/.coverage \
+		external/vcm/.coverage \
+		external/fv3fit/.coverage \
+		external/artifacts/.coverage
 
 test_regression:
 	pytest -vv -m regression -s $(ARGS)

--- a/external/artifacts/tox.ini
+++ b/external/artifacts/tox.ini
@@ -10,8 +10,9 @@ envlist = py38
 install_command = pip install -c ../../constraints.txt {opts} {packages}
 deps =
     pytest
+    coverage
 commands =
-    pytest
+    coverage run -m pytest
 passenv =
     GOOGLE_APPLICATION_CREDENTIALS
     NIX_SSL_CERT_FILE

--- a/external/fv3fit/tox.ini
+++ b/external/fv3fit/tox.ini
@@ -10,13 +10,14 @@ envlist = py38
 install_command = pip install -c ../../constraints.txt {opts} {packages}
 deps =
     pytest
+    coverage
     hypothesis
     ../vcm
     ../synth
     ../loaders
     ../artifacts
 commands =
-    pytest {posargs}
+    coverage run -m pytest {posargs}
 passenv =
     GOOGLE_APPLICATION_CREDENTIALS
     NIX_SSL_CERT_FILE

--- a/external/fv3kube/tox.ini
+++ b/external/fv3kube/tox.ini
@@ -4,7 +4,8 @@ skipsdist = true
 
 [testenv]
 deps =
+    coverage
     -rrequirements.txt
 
-commands = pytest {posargs}
+commands = coverage run -m pytest {posargs}
 

--- a/external/vcm/tox.ini
+++ b/external/vcm/tox.ini
@@ -10,9 +10,10 @@ envlist = py3
 install_command = pip install -c ../../constraints.txt {opts} {packages}
 deps =
     pytest
+    coverage
     ../mappm
 commands =
-    pytest {posargs}
+    coverage run -m pytest {posargs}
 passenv =
     GOOGLE_APPLICATION_CREDENTIALS
     NIX_SSL_CERT_FILE


### PR DESCRIPTION
Presently, coverage from tox commands is not included in the unit test coverage report. This PR updates those commands to produce coverage data, and updates the test_unit make target to combine the coverage output.

Resolves #1880
