### PR TITLE
Use smaller version of sample prog run data

### DIFF
--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -13,7 +13,7 @@ cd workflows/diagnostics
 
 # compute diagnostics/mterics for a short sample prognostic run
 mkdir -p /tmp/$random
-prognostic_run_diags save $RUN /tmp/$random/diags.nc --n-jobs=4
+prognostic_run_diags save $RUN /tmp/$random/diags.nc --n-jobs=2
 prognostic_run_diags metrics /tmp/$random/diags.nc > /tmp/$random/metrics.json
 gsutil cp /tmp/$random/diags.nc $OUTPUT/run1/diags.nc
 gsutil cp /tmp/$random/metrics.json $OUTPUT/run1/metrics.json

--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -4,7 +4,7 @@ set -xe
 
 [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]] && gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
 
-RUN=gs://vcm-ml-code-testing-data/sample-prognostic-run-output
+RUN=gs://vcm-ml-code-testing-data/sample-prognostic-run-output-v2
 
 random=$(openssl rand --hex 6)
 OUTPUT=gs://vcm-ml-scratch/test-prognostic-report/$random

--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -13,7 +13,7 @@ cd workflows/diagnostics
 
 # compute diagnostics/mterics for a short sample prognostic run
 mkdir -p /tmp/$random
-prognostic_run_diags save $RUN /tmp/$random/diags.nc --n-jobs=2
+prognostic_run_diags save $RUN /tmp/$random/diags.nc --n-jobs=4
 prognostic_run_diags metrics /tmp/$random/diags.nc > /tmp/$random/metrics.json
 gsutil cp /tmp/$random/diags.nc $OUTPUT/run1/diags.nc
 gsutil cp /tmp/$random/metrics.json $OUTPUT/run1/metrics.json

--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -4,7 +4,7 @@ set -xe
 
 [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]] && gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
 
-RUN=gs://vcm-ml-code-testing-data/sample-prognostic-run-output-v2
+RUN=gs://vcm-ml-code-testing-data/sample-prognostic-run-output-v3
 
 random=$(openssl rand --hex 6)
 OUTPUT=gs://vcm-ml-scratch/test-prognostic-report/$random


### PR DESCRIPTION
The prognostic run report test is slow and sometimes fails (we think due to OOM issues). This PR updates that test to use a lighter-weight version of the test data. Specifically the new data has a time dimension that is about 1/4 as long, and it has fewer data variables. It should hopefully resolve #1885 