### PR TITLE
Add PIRE 1yr and SHiELD 40d v wind  verification

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -273,6 +273,22 @@ sources:
       urlpath: "gs://vcm-ml-intermediate/2020-05-coarsen-c384-diagnostics/coarsen_diagnostics/atmos_8xdaily_add_vars_corrected_wind.zarr"
       consolidated: True
 
+  40day_c48_atmos_vwinds:
+    description: Additional v wind 2D dycore variables interpolated to pressure levels from 40-day nudged simulation (May 27 2020 SHiELD),
+      coarsened to C48 resolution. Created by script https://github.com/ai2cm/explore/blob/master/annak/2022-06-17-save-vwind-verif/save_vwind_netcdfs_shield_40d.py
+    driver: zarr
+    metadata:
+      grid: c48
+      simulation: 40day_may2020
+      category: 2d
+      variables:
+        - VGRD500
+        - VGRD850
+        - VGRD1000
+    args:
+      urlpath: "gs://vcm-ml-intermediate/2020-05-coarsen-c384-diagnostics/coarsen_diagnostics/shield_40d_additional_northward_wind_plev.zarr"
+      consolidated: True
+
   40day_c48_fine_res_apparent_sources_15min_may2020:
     description: >-
       Fine res apparent sources of heat and moisture, coarsened to C48 resolution, with time coordinate shifted to beginning of 15-minute
@@ -291,6 +307,7 @@ sources:
         access: read_only
       urlpath: 'gs://vcm-ml-intermediate/2021-09-09-fine-res-Q1-Q2-from-40-day-X-SHiELD-simulation-2020-05-27.zarr'
       consolidated: True
+
 
   40day_c48_fine_res_apparent_sources_3hrly_may2020:
     description: >-
@@ -716,6 +733,23 @@ sources:
     args:
       urlpath: "gs://vcm-ml-intermediate/2021-10-12-PIRE-c48-post-spinup-verification/pire_atmos_phys_3h_coarse.zarr"
       consolidated: True
+
+  2020_1yr_pire_vwinds:
+    description: Additional v wind 2D dycore variables interpolated to pressure levels from 1 year PIRE simulation post-spinup,
+      coarsened to C48 resolution. Created by script https://github.com/ai2cm/explore/blob/master/annak/2022-06-17-save-vwind-verif/save_vwind_netcdfs_pire.py
+    driver: zarr
+    metadata:
+      grid: c48
+      simulation: 1yr_pire_postspinup
+      category: 2d
+      variables:
+        - VGRD500
+        - VGRD850
+        - VGRD1000
+    args:
+      urlpath: "gs://vcm-ml-intermediate/2021-10-12-PIRE-c48-post-spinup-verification/additional_northward_wind_plev.zarr"
+      consolidated: True
+
 
   2020_1yr_pire_dyn_plev:
     description: 2D dycore variables interpolated to pressure levels from 1 year PIRE simulation post-spinup, coarsened to C48 resolution.

--- a/workflows/diagnostics/tests/prognostic/_regtest_outputs/test_load_diag_data.test_Simulations[simulation1].out
+++ b/workflows/diagnostics/tests/prognostic/_regtest_outputs/test_load_diag_data.test_Simulations[simulation1].out
@@ -233,6 +233,15 @@ variables:
 	float32 q500(time, tile, y, x) ;
 		q500:long_name = specific humidity ;
 		q500:units = kg / kg ;
+	float32 VGRD1000(time, tile, y, x) ;
+		VGRD1000:long_name = VGRD1000 ;
+		VGRD1000:units = unspecified ;
+	float32 VGRD500(time, tile, y, x) ;
+		VGRD500:long_name = VGRD500 ;
+		VGRD500:units = unspecified ;
+	float32 VGRD850(time, tile, y, x) ;
+		VGRD850:long_name = VGRD850 ;
+		VGRD850:units = unspecified ;
 
 // global attributes:
 }


### PR DESCRIPTION
Adds VGRD200, 500, 850 verification data to the catalog for 40 day SHiELD fine res and 1 year PIRE fine res reference.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/bac7fca9-4742-41d1-98bb-37588cefcaab\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)