### PR TITLE
Use v3.3.7 argo CLI for e2e test submission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             mv kustomize /usr/local/bin/
 
             # Install argo
-            curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v2.11.6/argo-linux-amd64.gz
+            curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.3.7/argo-linux-amd64.gz
             gunzip argo-linux-amd64.gz
             chmod +x argo-linux-amd64
             mv ./argo-linux-amd64 /usr/local/bin/argo


### PR DESCRIPTION
We updated the argo version installed on the cluster to v3.3.7, so it seems wise to update the CLI version used to submit the e2e integration test to match this.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/34b0b212-a289-464b-99c5-705defd10360\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)