### PR TITLE
Allow Hyperparameters with enums in fv3fit.train

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -18,6 +18,7 @@ from typing import (
     MutableMapping,
 )
 from fv3fit.typing import Dataclass
+from fv3fit.emulation.layers.normalization2 import MeanMethod, StdDevMethod
 import xarray as xr
 from .predictor import Predictor
 from .hyperparameters import Hyperparameters
@@ -113,10 +114,13 @@ class TrainingConfig:
                 "output_variables"
             )
         hyperparameter_class = get_hyperparameter_class(kwargs["model_type"])
+        dacite_config = dacite.Config(
+            strict=True, cast=[bool, str, int, float, StdDevMethod, MeanMethod]
+        )
         kwargs["hyperparameters"] = dacite.from_dict(
             data_class=hyperparameter_class,
             data=kwargs.get("hyperparameters", {}),
-            config=dacite.Config(strict=True),
+            config=dacite_config,
         )
         return dacite.from_dict(
             data_class=cls, data=kwargs, config=dacite.Config(strict=True)

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -114,6 +114,7 @@ class TrainingConfig:
                 "output_variables"
             )
         hyperparameter_class = get_hyperparameter_class(kwargs["model_type"])
+        # custom enums must be specified for dacite to handle correctly
         dacite_config = dacite.Config(
             strict=True, cast=[bool, str, int, float, StdDevMethod, MeanMethod]
         )

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -7,9 +7,7 @@ from fv3fit._shared.config import (
     to_flat_dict,
     to_nested_dict,
 )
-from fv3fit.dataclasses import asdict_with_enum
 import yaml
-import dataclasses
 import fsspec
 
 import fv3fit.keras

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -7,6 +7,7 @@ from fv3fit._shared.config import (
     to_flat_dict,
     to_nested_dict,
 )
+from fv3fit.dataclasses import asdict_with_enum
 import yaml
 import dataclasses
 import fsspec
@@ -184,9 +185,7 @@ def main(args, unknown_args=None):
         if unknown_args is not None:
             # converting to TrainingConfig and then back to dict allows command line to
             # update fields that are not present in original configuration file
-            config_dict = dataclasses.asdict(
-                fv3fit.TrainingConfig.from_dict(config_dict)
-            )
+            config_dict = asdict_with_enum(fv3fit.TrainingConfig.from_dict(config_dict))
             config_dict = get_arg_updated_config_dict(
                 args=unknown_args, config_dict=config_dict
             )


### PR DESCRIPTION
Currently the `fv3fit.train` entrypoint will fail if the `hyperparameters` part of the provided training config uses enums, which is the case for the `TransformedParameters` model type. This PR adds code similar to what is in `fv3fit.train_microphysics` to allow such a case. It would be better if it were not necessary to explicitly specify the enum types in the dacite config.

Resolves #1893 

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/2622c20a-348a-4b81-a94b-ad7fec0b5306/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)