### PR TITLE
Use masked area weights when pressure-coarsening 3D restart files

### DIFF
--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -385,7 +385,9 @@ def _coarse_grain_fv_core_on_pressure(
         edge="y",
     )
 
-    return xr.merge([area_weighted, masked_area_weighted, edge_weighted_x, edge_weighted_y])
+    return xr.merge(
+        [area_weighted, masked_area_weighted, edge_weighted_x, edge_weighted_y]
+    )
 
 
 def _coarse_grain_fv_tracer(ds, delp, area, coarsening_factor):


### PR DESCRIPTION
In the original implementation (#87), the default method for coarse-graining 3D fields in the restart files was to first vertically remap them to a common set of pressure levels within a coarse grid cell, and then take a masked-mass-weighted average (masking is to take into account the fact that some fine-grid cells do not have air at pressures we are interpolating to, so we ignore them in averaging).  Here the masked mass was computed as the product of the masked fine-grid cell area and the original fine-grid cell pressure thickness.  In reality though, since we have interpolated the fine-grid fields to constant pressure surfaces, for the pressure thickness we should use the updated pressure thickness field (i.e. "delp_coarse_on_fine"), or better yet, no pressure thickness at all, since it will be constant within a coarse grid box and so will not contribute anything meaningful to the weighting.

This PR addresses this by switching to using just the masked area as weights when pressure-level coarse-graining restart files.  

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/816ee135-7947-4bbd-aab7-9505cabc3030\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)