### PR TITLE
Online prognostic run with classifier based masking

### DIFF
--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -140,9 +140,9 @@ class MicrophysicsHook:
                 dimensions or [sample]
         """
 
-        model_outputs = predict(self.model, state)
+        model_outputs = _predict(self.model, state)
         if self.classifier is not None:
-            classifier_outputs = predict(self.classifier, state)
+            classifier_outputs = _predict(self.classifier, state)
             model_outputs.update(classifier_outputs)
 
         # fields stay in global state so check overwrites on first step

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -79,7 +79,7 @@ def always_emulator(state: FortranState, emulator: FortranState):
     return emulator
 
 
-def predict(model: tf.keras.Model, state: FortranState) -> FortranState:
+def _predict(model: tf.keras.Model, state: FortranState) -> FortranState:
     # grab model-required variables and
     # switch state to model-expected [sample, feature]
     inputs = {name: state[name].T for name in model.input_names}

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -141,9 +141,8 @@ class MicrophysicsHook:
         """
 
         model_outputs = predict(self.model, state)
-
         if self.classifier is not None:
-            classifier_outputs = predict(self.model, state)
+            classifier_outputs = predict(self.classifier, state)
             model_outputs.update(classifier_outputs)
 
         # fields stay in global state so check overwrites on first step

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -25,21 +25,27 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-@print_errors
 def _load_tf_model(model_path: str) -> tf.keras.Model:
     logger.info(f"Loading keras model: {model_path}")
     with get_dir(model_path) as local_model_path:
-        model = tf.keras.models.load_model(local_model_path)
-        # These following two adapters are for backwards compatibility
-        dict_output_model = adapters.ensure_dict_output(model)
-        return adapters.rename_dict_output(
-            dict_output_model,
-            translation={
-                "air_temperature_output": "air_temperature_after_precpd",
-                "specific_humidity_output": "specific_humidity_after_precpd",
-                "cloud_water_mixing_ratio_output": "cloud_water_mixing_ratio_after_precpd",  # noqa: E501
-            },
-        )
+        return tf.keras.models.load_model(local_model_path)
+
+
+@print_errors
+def _load_tf_model_compatibility(model_path: str) -> tf.keras.Model:
+
+    model = _load_tf_model(model_path)
+
+    # These following two adapters are for backwards compatibility
+    dict_output_model = adapters.ensure_dict_output(model)
+    return adapters.rename_dict_output(
+        dict_output_model,
+        translation={
+            "air_temperature_output": "air_temperature_after_precpd",
+            "specific_humidity_output": "specific_humidity_after_precpd",
+            "cloud_water_mixing_ratio_output": "cloud_water_mixing_ratio_after_precpd",  # noqa: E501
+        },
+    )
 
 
 @dataclass
@@ -73,6 +79,18 @@ def always_emulator(state: FortranState, emulator: FortranState):
     return emulator
 
 
+def predict(model: tf.keras.Model, state: FortranState) -> FortranState:
+    # grab model-required variables and
+    # switch state to model-expected [sample, feature]
+    inputs = {name: state[name].T for name in model.input_names}
+
+    predictions = model.predict(inputs)
+    # tranpose back to FV3 conventions
+    model_outputs = {name: tensor.T for name, tensor in predictions.items()}
+
+    return model_outputs
+
+
 class MicrophysicsHook:
     """Object that applies a ML model to the fortran state"""
 
@@ -81,6 +99,7 @@ class MicrophysicsHook:
         model_path: str,
         mask: Mask = always_emulator,
         garbage_collection_interval: int = 10,
+        classifier_path: str = None,
     ) -> None:
         """
 
@@ -92,11 +111,15 @@ class MicrophysicsHook:
         """
 
         self.name = "microphysics emulator"
-        self.model = _load_tf_model(model_path)
+        self.model = _load_tf_model_compatibility(model_path)
         self.orig_outputs = None
         self.garbage_collection_interval = garbage_collection_interval
         self.mask = mask
         self._calls_since_last_collection = 0
+
+        self.classifier = (
+            _load_tf_model(classifier_path) if classifier_path is not None else None
+        )
 
     def _maybe_garbage_collect(self):
         if self._calls_since_last_collection % self.garbage_collection_interval:
@@ -117,13 +140,11 @@ class MicrophysicsHook:
                 dimensions or [sample]
         """
 
-        # grab model-required variables and
-        # switch state to model-expected [sample, feature]
-        inputs = {name: state[name].T for name in self.model.input_names}
+        model_outputs = predict(self.model, state)
 
-        predictions = self.model.predict(inputs)
-        # tranpose back to FV3 conventions
-        model_outputs = {name: tensor.T for name, tensor in predictions.items()}
+        if self.classifier is not None:
+            classifier_outputs = predict(self.model, state)
+            model_outputs.update(classifier_outputs)
 
         # fields stay in global state so check overwrites on first step
         if self.orig_outputs is None:

--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -75,7 +75,7 @@ class ModelConfig:
     """
 
     path: str
-    classifier_path: str = None
+    classifier_path: Optional[str] = None
     online_schedule: Optional[IntervalSchedule] = None
     ranges: Mapping[str, Range] = dataclasses.field(default_factory=dict)
     mask_emulator_levels: Mapping[str, LevelSlice] = dataclasses.field(

--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -167,7 +167,8 @@ class EmulationConfig:
                 type_hooks={
                     cftime.DatetimeJulian: from_datetime,
                     datetime.timedelta: lambda x: datetime.timedelta(seconds=x),
-                }
+                },
+                strict=True,
             ),
         )
 

--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -75,6 +75,7 @@ class ModelConfig:
     """
 
     path: str
+    classifier_path: str = None
     online_schedule: Optional[IntervalSchedule] = None
     ranges: Mapping[str, Range] = dataclasses.field(default_factory=dict)
     mask_emulator_levels: Mapping[str, LevelSlice] = dataclasses.field(
@@ -85,9 +86,13 @@ class ModelConfig:
     mask_gscond_identical_cloud: bool = False
     mask_gscond_zero_cloud: bool = False
     enforce_conservative: bool = False
+    mask_gscond_zero_cloud_classifier: bool = False
+    mask_gscond_no_tend_classifier: bool = False
 
     def build(self) -> MicrophysicsHook:
-        return MicrophysicsHook(self.path, mask=self._build_mask())
+        return MicrophysicsHook(
+            self.path, mask=self._build_mask(), classifier_path=self.classifier_path
+        )
 
     def _build_mask(self) -> Mask:
         return compose_masks(self._build_masks())
@@ -115,6 +120,12 @@ class ModelConfig:
 
         if self.mask_gscond_zero_cloud:
             yield emulation.zhao_carr.mask_where_fortran_cloud_vanishes_gscond
+
+        if self.mask_gscond_no_tend_classifier:
+            yield emulation.zhao_carr.mask_zero_tend_classifier
+
+        if self.mask_gscond_zero_cloud_classifier:
+            yield emulation.zhao_carr.mask_zero_cloud_classifier
 
         if self.enforce_conservative:
             yield emulation.zhao_carr.enforce_conservative_gscond

--- a/external/emulation/emulation/zhao_carr.py
+++ b/external/emulation/emulation/zhao_carr.py
@@ -98,12 +98,12 @@ def mask_where_fortran_cloud_identical(state, emulator):
     return _update_with_net_condensation(cloud_out, state, emulator)
 
 
-def _get_classify_output(emulator, class_name):
+def _get_classify_output(emulator, class_name, one_hot_axis=0):
     names = sorted(CLASS_NAMES)
     idx = names.index(class_name)
     logit_classes = emulator["gscond_classes"]
     # TODO this should probably be in transforms
-    one_hot = logit_classes == np.max(logit_classes, axis=0, keepdims=True)
+    one_hot = logit_classes == np.max(logit_classes, axis=one_hot_axis, keepdims=True)
     return one_hot[idx]
 
 

--- a/external/emulation/emulation/zhao_carr.py
+++ b/external/emulation/emulation/zhao_carr.py
@@ -98,18 +98,16 @@ def mask_where_fortran_cloud_identical(state, emulator):
     return _update_with_net_condensation(cloud_out, state, emulator)
 
 
-def _get_classify_output(emulator, class_name, one_hot_axis=0):
+def _get_classify_output(emulator, one_hot_axis=0):
     names = sorted(CLASS_NAMES)
-    idx = names.index(class_name)
     logit_classes = emulator["gscond_classes"]
-    # TODO this should probably be in transforms
     one_hot = logit_classes == np.max(logit_classes, axis=one_hot_axis, keepdims=True)
-    return one_hot[idx]
+    return {name: one_hot[i] for i, name in enumerate(names)}
 
 
 def mask_zero_cloud_classifier(state, emulator):
     cloud_out = np.where(
-        _get_classify_output(emulator, ZERO_CLOUD),
+        _get_classify_output(emulator)[ZERO_CLOUD],
         0,
         emulator[GscondOutput.cloud_water],
     )
@@ -118,7 +116,7 @@ def mask_zero_cloud_classifier(state, emulator):
 
 def mask_zero_tend_classifier(state, emulator):
     cloud_out = np.where(
-        _get_classify_output(emulator, ZERO_TENDENCY),
+        _get_classify_output(emulator)[ZERO_TENDENCY],
         state[Input.cloud_water],
         emulator[GscondOutput.cloud_water],
     )

--- a/external/emulation/emulation/zhao_carr.py
+++ b/external/emulation/emulation/zhao_carr.py
@@ -109,7 +109,9 @@ def _get_classify_output(emulator, class_name):
 
 def mask_zero_cloud_classifier(state, emulator):
     cloud_out = np.where(
-        _get_classify_output(emulator, ZERO_CLOUD), 0, state[GscondOutput.cloud_water]
+        _get_classify_output(emulator, ZERO_CLOUD),
+        0,
+        emulator[GscondOutput.cloud_water],
     )
     return _update_with_net_condensation(cloud_out, state, emulator)
 

--- a/external/emulation/emulation/zhao_carr.py
+++ b/external/emulation/emulation/zhao_carr.py
@@ -103,8 +103,8 @@ def _get_classify_output(emulator, class_name):
     idx = names.index(class_name)
     logit_classes = emulator["gscond_classes"]
     # TODO this should probably be in transforms
-    one_hot = logit_classes == np.max(logit_classes, axis=-1, keepdims=True)
-    return one_hot[..., idx]
+    one_hot = logit_classes == np.max(logit_classes, axis=0, keepdims=True)
+    return one_hot[idx]
 
 
 def mask_zero_cloud_classifier(state, emulator):

--- a/projects/microphysics/experiments/classify-online.py
+++ b/projects/microphysics/experiments/classify-online.py
@@ -19,7 +19,7 @@ mask_levels = {
 }
 
 
-def _get_job():
+def _get_job(classify_zero_cloud, classify_zero_tend):
     config = load_yaml("../configs/default.yaml")
 
     config = set_prognostic_emulation_model(
@@ -28,15 +28,19 @@ def _get_job():
     gscond_config = config["zhao_carr_emulation"]["gscond"]
     gscond_config["classifier_path"] = CLASSIFIER
     gscond_config["mask_emulator_levels"] = mask_levels
-    gscond_config["mask_gscond_zero_cloud_classifier"] = True
-    gscond_config["mask_gscond_zero_tend_classifier"] = True
+    gscond_config["mask_gscond_zero_cloud_classifier"] = classify_zero_cloud
+    gscond_config["mask_gscond_zero_tend_classifier"] = classify_zero_tend
     gscond_config["enforce_conservative"] = True
 
+    zcloud_tag = "zcloud-" if classify_zero_cloud else ""
+    ztend_tag = "ztend-" if classify_zero_tend else ""
+
     return PrognosticJob(
-        name=f"gscond-only-classifier-zcloud-ztend-online-10d-v1",
-        image_tag="ea5443c7b008f6435cec24c32132be35a1613204",
+        name=f"gscond-only-classifier-{zcloud_tag}{ztend_tag}online-10d-v2",
+        image_tag="59317e157f079dee5de07244695c96e6c6f38215",
         config=config,
     )
 
 
-submit_jobs([_get_job()], f"test-online-classifier")
+jobs = [_get_job(zc, zt) for zc, zt in [(False, True), (True, False), (True, True)]]
+submit_jobs(jobs, f"test-online-classifier")

--- a/projects/microphysics/experiments/classify-online.py
+++ b/projects/microphysics/experiments/classify-online.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.path.insert(0, "../argo")
+
+from end_to_end import (
+    PrognosticJob,
+    load_yaml,
+    submit_jobs,
+    set_prognostic_emulation_model,
+)  # noqa: E402
+
+MODEL = "gs://vcm-ml-experiments/microphysics-emulation/2022-05-12/gscond-only-tscale-dense-local-41b1c1-v1/model.tf"  # noqa
+CLASSIFIER = "gs://vcm-ml-experiments/microphysics-emulation/2022-06-09/gscond-classifier-v1/model.tf"  # noqa
+
+mask_levels = {
+    "cloud_water_mixing_ratio_after_gscond": dict(start=74, stop=None),
+    "specific_humidity_after_gscond": dict(start=74, stop=None),
+    "air_temperature_after_gscond": dict(start=74, stop=None),
+}
+
+
+def _get_job():
+    config = load_yaml("../configs/default.yaml")
+
+    config = set_prognostic_emulation_model(
+        config, MODEL, gscond_only=True, gscond_conservative=True
+    )
+    gscond_config = config["zhao_carr_emulation"]["gscond"]
+    gscond_config["classifier_path"] = CLASSIFIER
+    gscond_config["mask_emulator_levels"] = mask_levels
+    gscond_config["mask_gscond_zero_cloud_classifier"] = True
+    gscond_config["mask_gscond_zero_tend_classifier"] = True
+    gscond_config["enforce_conservative"] = True
+
+    return PrognosticJob(
+        name=f"gscond-only-classifier-zcloud-ztend-online-10d-v1",
+        image_tag="ea5443c7b008f6435cec24c32132be35a1613204",
+        config=config,
+    )
+
+
+submit_jobs([_get_job()], f"test-online-classifier")

--- a/projects/microphysics/experiments/classify-online.py
+++ b/projects/microphysics/experiments/classify-online.py
@@ -29,7 +29,7 @@ def _get_job(classify_zero_cloud, classify_no_tend):
     gscond_config["classifier_path"] = CLASSIFIER
     gscond_config["mask_emulator_levels"] = mask_levels
     gscond_config["mask_gscond_zero_cloud_classifier"] = classify_zero_cloud
-    gscond_config["mask_gscond_zero_tend_classifier"] = classify_no_tend
+    gscond_config["mask_gscond_no_tend_classifier"] = classify_no_tend
     gscond_config["enforce_conservative"] = True
 
     zcloud_tag = "zcloud-" if classify_zero_cloud else ""
@@ -37,7 +37,7 @@ def _get_job(classify_zero_cloud, classify_no_tend):
 
     return PrognosticJob(
         name=f"gscond-only-classifier-{zcloud_tag}{ztend_tag}online-10d-v3",
-        image_tag="59317e157f079dee5de07244695c96e6c6f38215",
+        image_tag="f580dfd909dd9e785131b4b34861b2224bc0b34a",
         config=config,
     )
 

--- a/projects/microphysics/experiments/classify-online.py
+++ b/projects/microphysics/experiments/classify-online.py
@@ -19,7 +19,7 @@ mask_levels = {
 }
 
 
-def _get_job(classify_zero_cloud, classify_zero_tend):
+def _get_job(classify_zero_cloud, classify_no_tend):
     config = load_yaml("../configs/default.yaml")
 
     config = set_prognostic_emulation_model(
@@ -29,14 +29,14 @@ def _get_job(classify_zero_cloud, classify_zero_tend):
     gscond_config["classifier_path"] = CLASSIFIER
     gscond_config["mask_emulator_levels"] = mask_levels
     gscond_config["mask_gscond_zero_cloud_classifier"] = classify_zero_cloud
-    gscond_config["mask_gscond_zero_tend_classifier"] = classify_zero_tend
+    gscond_config["mask_gscond_zero_tend_classifier"] = classify_no_tend
     gscond_config["enforce_conservative"] = True
 
     zcloud_tag = "zcloud-" if classify_zero_cloud else ""
-    ztend_tag = "ztend-" if classify_zero_tend else ""
+    ztend_tag = "ztend-" if classify_no_tend else ""
 
     return PrognosticJob(
-        name=f"gscond-only-classifier-{zcloud_tag}{ztend_tag}online-10d-v2",
+        name=f"gscond-only-classifier-{zcloud_tag}{ztend_tag}online-10d-v3",
         image_tag="59317e157f079dee5de07244695c96e6c6f38215",
         config=config,
     )

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -440,12 +440,15 @@ tendency_prescriber: null
 zhao_carr_emulation:
   gscond: null
   model:
+    classifier_path: null
     cloud_squash: null
     enforce_conservative: false
     gscond_cloud_conservative: false
     mask_emulator_levels: {}
     mask_gscond_identical_cloud: false
+    mask_gscond_no_tend_classifier: false
     mask_gscond_zero_cloud: false
+    mask_gscond_zero_cloud_classifier: false
     online_schedule:
       initial_time: 2016-06-01 00:00:00
       period: 21600


### PR DESCRIPTION
Add options to use a classifier model to mask zero_cloud or zero_tendency cloud water output cases.

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/67aec395-4c79-4ac6-9cfc-7e88f90d2268/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)