### PR TITLE
Initial cloud ml project scripts

### DIFF
--- a/projects/cloud_ml/.gitignore
+++ b/projects/cloud_ml/.gitignore
@@ -1,0 +1,1 @@
+*kustomize

--- a/projects/cloud_ml/README.md
+++ b/projects/cloud_ml/README.md
@@ -1,0 +1,7 @@
+# Cloud ML Project
+
+This directory contains scripts and workflows to generate data for the fine-grid cloud ML project:
+
+- The `argo` directory contains make directives and scripts to run cloud workflow steps.
+- The `scripts` directory contains postprocessing and data piping scripts.
+- Exploratory notebooks are in the `explore` repo in appropriate personal directories.

--- a/projects/cloud_ml/argo/Makefile
+++ b/projects/cloud_ml/argo/Makefile
@@ -1,0 +1,10 @@
+
+
+nudge_to_fine_run: deploy
+	cd nudge-to-fine-run && ./run.sh nudge-to-fine
+
+deploy: kustomize
+	./kustomize build . | kubectl apply -f -
+
+kustomize:
+	./install_kustomize.sh 3.10.0

--- a/projects/cloud_ml/argo/install_kustomize.sh
+++ b/projects/cloud_ml/argo/install_kustomize.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# If no argument is given -> Downloads the most recently released
+# kustomize binary to your current working directory.
+# (e.g. 'install_kustomize.sh')
+#
+# If an argument is given -> Downloads the specified version of the
+# kustomize binary to your current working directory.
+# (e.g. 'install_kustomize.sh 3.8.2')
+#
+# Fails if the file already exists.
+
+if [ -n "$1" ]; then
+    version=v$1
+  else
+    version=$(curl -sL -o /dev/null -w %{url_effective} \
+    https://github.com/kubernetes-sigs/kustomize/releases/latest | rev | cut -d/ -f1 | rev)
+fi
+
+where=$PWD
+if [ -f $where/kustomize ]; then
+  echo "A file named kustomize already exists (remove it first)."
+  exit 1
+fi
+
+tmpDir=`mktemp -d`
+if [[ ! "$tmpDir" || ! -d "$tmpDir" ]]; then
+  echo "Could not create temp dir."
+  exit 1
+fi
+
+function cleanup {
+  rm -rf "$tmpDir"
+}
+
+trap cleanup EXIT
+
+pushd $tmpDir >& /dev/null
+
+opsys=windows
+if [[ "$OSTYPE" == linux* ]]; then
+  opsys=linux
+elif [[ "$OSTYPE" == darwin* ]]; then
+  opsys=darwin
+fi
+
+curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${version}/kustomize_${version}_${opsys}_amd64.tar.gz
+
+if [ -e ./kustomize_v*_${opsys}_amd64.tar.gz ]; then
+    tar xzf ./kustomize_v*_${opsys}_amd64.tar.gz
+else
+    echo "Error: kustomize binary with the version ${version#v} does not exist!"
+    exit 1
+fi
+
+cp ./kustomize $where
+
+popd >& /dev/null
+
+./kustomize version
+
+echo kustomize installed to current directory.

--- a/projects/cloud_ml/argo/kustomization.yaml
+++ b/projects/cloud_ml/argo/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- ../../../workflows/argo
+kind: Kustomization
+images:
+- name: us.gcr.io/vcm-ml/fv3net
+  newTag: 6fc50248c00f9fd8e49034b75a858e233b9d969d
+- name: us.gcr.io/vcm-ml/post_process_run
+  newTag: 6fc50248c00f9fd8e49034b75a858e233b9d969d
+- name: us.gcr.io/vcm-ml/prognostic_run
+  newTag: 6fc50248c00f9fd8e49034b75a858e233b9d969d

--- a/projects/cloud_ml/argo/nudge-to-fine-run/nudge-to-fine-config.yaml
+++ b/projects/cloud_ml/argo/nudge-to-fine-run/nudge-to-fine-config.yaml
@@ -1,0 +1,254 @@
+base_version: v0.7
+field_table: gs://vcm-fv3config/config/field_table/TKE-EDMF/v1.0/field_table
+prephysics:
+  - dataset_key: "gs://vcm-ml-intermediate/2021-03-fine-res-surface-radiative-fluxes/C3072-surface-radiative-fluxes-precip.zarr"
+    variables:
+      - override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface
+      - override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface
+      - override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface
+      - total_precipitation
+initial_conditions:
+  base_url: gs://vcm-ml-experiments/2020-06-02-fine-res/coarsen_restarts
+  timestep: "20160805.000000"
+nudging:
+  restarts_path: gs://vcm-ml-experiments/2020-06-02-fine-res/coarsen_restarts
+  timescale_hours:
+    air_temperature: 3
+    specific_humidity: 3
+    x_wind: 3
+    y_wind: 3
+    pressure_thickness_of_atmospheric_layer: 3
+namelist:
+  atmos_model_nml:
+    fhmax: 1024  # max hours of simulation (over all segments) for which fortran physics diags are saved
+  coupler_nml:
+    days: 5
+    hours: 0
+    minutes: 0
+    months: 0
+    seconds: 0
+  gfs_physics_nml:
+    fhlwr: 1800.0
+    fhswr: 1800.0
+    override_surface_radiative_fluxes: true
+    hybedmf: false
+    satmedmf: true
+  namsfc:
+    faisl: 99999 # Persist land / sea / sea-ice mask from the initial conditions instead of using climatology forcing files
+    faiss: 99999 # Persist land / sea / sea-ice mask from the initial conditions instead of using climatology forcing files
+    fsicl: 99999 # Persist the sea ice fraction from the initial conditiond instead of using climatology forcing files
+    fsics: 99999 # Persist the sea ice fraction from the initial conditiond instead of using climatology forcing files
+diagnostics:
+- name: state_after_timestep.zarr
+  chunks:
+    time: 8
+  times:
+    frequency: 10800
+    kind: interval
+  variables:
+  - x_wind
+  - y_wind
+  - eastward_wind
+  - northward_wind
+  - vertical_wind
+  - air_temperature
+  - specific_humidity
+  - pressure_thickness_of_atmospheric_layer
+  - vertical_thickness_of_atmospheric_layer
+  - land_sea_mask
+  - surface_temperature
+  - surface_geopotential
+  - surface_diffused_shortwave_albedo
+  - sensible_heat_flux
+  - latent_heat_flux
+  - total_precipitation
+  - surface_precipitation_rate
+  - total_soil_moisture
+  - total_sky_downward_shortwave_flux_at_surface
+  - total_sky_upward_shortwave_flux_at_surface
+  - total_sky_downward_longwave_flux_at_surface
+  - total_sky_upward_longwave_flux_at_surface
+  - total_sky_downward_shortwave_flux_at_top_of_atmosphere
+  - total_sky_upward_shortwave_flux_at_top_of_atmosphere
+  - total_sky_upward_longwave_flux_at_top_of_atmosphere
+  - clear_sky_downward_shortwave_flux_at_surface
+  - clear_sky_upward_shortwave_flux_at_surface
+  - clear_sky_downward_longwave_flux_at_surface
+  - clear_sky_upward_longwave_flux_at_surface
+  - clear_sky_upward_shortwave_flux_at_top_of_atmosphere
+  - clear_sky_upward_longwave_flux_at_top_of_atmosphere
+  - latitude
+  - longitude
+  - cloud_water_mixing_ratio
+  - cloud_ice_mixing_ratio 
+  - rain_mixing_ratio
+  - snow_mixing_ratio
+  - graupel_mixing_ratio
+  - cloud_amount
+- name: physics_tendencies.zarr
+  chunks:
+    time: 16
+  times:
+    frequency: 5400
+    kind: interval
+  variables:
+  - tendency_of_air_temperature_due_to_fv3_physics
+  - tendency_of_specific_humidity_due_to_fv3_physics
+  - tendency_of_eastward_wind_due_to_fv3_physics
+  - tendency_of_northward_wind_due_to_fv3_physics
+- name: nudging_tendencies.zarr
+  chunks:
+    time: 8
+  times:
+    frequency: 10800
+    kind: interval-average
+  variables:
+  - air_temperature_tendency_due_to_nudging
+  - specific_humidity_tendency_due_to_nudging
+  - x_wind_tendency_due_to_nudging
+  - y_wind_tendency_due_to_nudging
+  - pressure_thickness_of_atmospheric_layer_tendency_due_to_nudging
+- name: diags.zarr
+  chunks:
+    time: 96
+  times:
+    frequency: 900
+    kind: interval
+  variables:
+  - net_moistening_due_to_nudging
+  - column_heating_due_to_nudging
+  - net_mass_tendency_due_to_nudging
+  - total_precipitation_rate
+  - water_vapor_path
+  - physics_precip
+- name: reference_state.zarr
+  chunks:
+    time: 8
+  times:
+    frequency: 10800
+    kind: interval-average
+  variables:
+  - air_temperature_reference
+  - specific_humidity_reference
+  - x_wind_reference
+  - y_wind_reference
+  - pressure_thickness_of_atmospheric_layer_reference
+fortran_diagnostics:
+- name: sfc_dt_atmos.zarr
+  chunks:
+    time: 96
+  times:
+    frequency: 900
+    kind: interval
+  variables:
+  - {module_name: dynamics, field_name: grid_lont, output_name: lon}
+  - {module_name: dynamics, field_name: grid_latt, output_name: lat}
+  - {module_name: dynamics, field_name: grid_lon, output_name: lonb}
+  - {module_name: dynamics, field_name: grid_lat, output_name: latb}
+  - {module_name: dynamics, field_name: area, output_name: area}
+  - {module_name: gfs_phys, field_name: dusfci, output_name: uflx}
+  - {module_name: gfs_phys, field_name: dvsfci, output_name: vflx}
+  - {module_name: gfs_phys, field_name: cnvprcpb_ave, output_name: CPRATsfc}
+  - {module_name: gfs_phys, field_name: totprcpb_ave, output_name: PRATEsfc}
+  - {module_name: gfs_phys, field_name: toticeb_ave, output_name: ICEsfc}
+  - {module_name: gfs_phys, field_name: totsnwb_ave, output_name: SNOWsfc}
+  - {module_name: gfs_phys, field_name: totgrpb_ave, output_name: GRAUPELsfc}
+  - {module_name: gfs_phys, field_name: DSWRF, output_name: DSWRFsfc}
+  - {module_name: gfs_phys, field_name: DSWRF_from_rrtmg, output_name: DSWRFsfc_from_RRTMG}
+  - {module_name: gfs_phys, field_name: USWRF, output_name: USWRFsfc}
+  - {module_name: gfs_phys, field_name: USWRF_from_rrtmg, output_name: USWRFsfc_from_RRTMG}
+  - {module_name: gfs_phys, field_name: DSWRFtoa, output_name: DSWRFtoa}
+  - {module_name: gfs_phys, field_name: USWRFtoa, output_name: USWRFtoa}
+  - {module_name: gfs_phys, field_name: ULWRFtoa, output_name: ULWRFtoa}
+  - {module_name: gfs_phys, field_name: ULWRF, output_name: ULWRFsfc}
+  - {module_name: gfs_phys, field_name: DLWRF, output_name: DLWRFsfc}
+  - {module_name: gfs_phys, field_name: DLWRF_from_rrtmg, output_name: DLWRFsfc_from_RRTMG}
+  - {module_name: gfs_phys, field_name: lhtfl_ave, output_name: LHTFLsfc}
+  - {module_name: gfs_phys, field_name: shtfl_ave, output_name: SHTFLsfc}
+  - {module_name: gfs_phys, field_name: hpbl, output_name: HPBLsfc}
+  - {module_name: gfs_sfc, field_name: fice, output_name: ICECsfc}
+  - {module_name: gfs_sfc, field_name: SLMSKsfc, output_name: SLMSKsfc}
+  - {module_name: gfs_sfc, field_name: q2m, output_name: SPFH2m}
+  - {module_name: gfs_sfc, field_name: t2m, output_name: TMP2m}
+  - {module_name: gfs_sfc, field_name: tsfc, output_name: TMPsfc}
+  - {module_name: gfs_phys, field_name: dpt2m, output_name: DPT2m}
+  - {module_name: gfs_phys, field_name: u10m, output_name: UGRD10m}
+  - {module_name: gfs_phys, field_name: v10m, output_name: VGRD10m}
+  - {module_name: gfs_phys, field_name: tmpmax2m, output_name: TMAX2m}
+  - {module_name: gfs_phys, field_name: wind10mmax, output_name: MAXWIND10m}
+  - {module_name: gfs_phys, field_name: soilm, output_name: SOILM}
+  - {module_name: gfs_sfc, field_name: SOILT1, output_name: SOILT1}
+  - {module_name: gfs_sfc, field_name: SOILT2, output_name: SOILT2}
+  - {module_name: gfs_sfc, field_name: SOILT3, output_name: SOILT3}
+  - {module_name: gfs_sfc, field_name: SOILT4, output_name: SOILT4}
+- name: atmos_dt_atmos.zarr
+  chunks:
+    time: 96
+  times:
+    frequency: 900
+    kind: interval
+  variables:
+  - {module_name: dynamics, field_name: grid_lont, output_name: lon}
+  - {module_name: dynamics, field_name: grid_latt, output_name: lat}
+  - {module_name: dynamics, field_name: grid_lon, output_name: lonb}
+  - {module_name: dynamics, field_name: grid_lat, output_name: latb}
+  - {module_name: dynamics, field_name: area, output_name: area}
+  - {module_name: dynamics, field_name: us, output_name: UGRDlowest}
+  - {module_name: dynamics, field_name: u850, output_name: UGRD850}
+  - {module_name: dynamics, field_name: u500, output_name: UGRD500}
+  - {module_name: dynamics, field_name: u200, output_name: UGRD200}
+  - {module_name: dynamics, field_name: u50, output_name: UGRD50}
+  - {module_name: dynamics, field_name: vs, output_name: VGRDlowest}
+  - {module_name: dynamics, field_name: v850, output_name: VGRD850}
+  - {module_name: dynamics, field_name: v500, output_name: VGRD500}
+  - {module_name: dynamics, field_name: v200, output_name: VGRD200}
+  - {module_name: dynamics, field_name: v50, output_name: VGRD50}
+  - {module_name: dynamics, field_name: tm, output_name: TMP500_300}
+  - {module_name: dynamics, field_name: tb, output_name: TMPlowest}
+  - {module_name: dynamics, field_name: t850, output_name: TMP850}
+  - {module_name: dynamics, field_name: t500, output_name: TMP500}
+  - {module_name: dynamics, field_name: t200, output_name: TMP200}
+  - {module_name: dynamics, field_name: w850, output_name: w850}
+  - {module_name: dynamics, field_name: w500, output_name: w500}
+  - {module_name: dynamics, field_name: w200, output_name: w200}
+  - {module_name: dynamics, field_name: w50, output_name: w50}
+  - {module_name: dynamics, field_name: vort850, output_name: VORT850}
+  - {module_name: dynamics, field_name: vort500, output_name: VORT500}
+  - {module_name: dynamics, field_name: vort200, output_name: VORT200}
+  - {module_name: dynamics, field_name: z850, output_name: h850}
+  - {module_name: dynamics, field_name: z500, output_name: h500}
+  - {module_name: dynamics, field_name: z200, output_name: h200}
+  - {module_name: dynamics, field_name: rh1000, output_name: RH1000}
+  - {module_name: dynamics, field_name: rh925, output_name: RH925}
+  - {module_name: dynamics, field_name: rh850, output_name: RH850}
+  - {module_name: dynamics, field_name: rh700, output_name: RH700}
+  - {module_name: dynamics, field_name: rh500, output_name: RH500}
+  - {module_name: dynamics, field_name: rh200, output_name: RH200}
+  - {module_name: dynamics, field_name: q1000, output_name: q1000}
+  - {module_name: dynamics, field_name: q925, output_name: q925}
+  - {module_name: dynamics, field_name: q850, output_name: q850}
+  - {module_name: dynamics, field_name: q700, output_name: q700}
+  - {module_name: dynamics, field_name: q500, output_name: q500}
+  - {module_name: dynamics, field_name: q200, output_name: q200}
+  - {module_name: dynamics, field_name: slp, output_name: PRMSL}
+  - {module_name: dynamics, field_name: ps, output_name: PRESsfc}
+  - {module_name: dynamics, field_name: tq, output_name: PWAT}
+  - {module_name: dynamics, field_name: lw, output_name: VIL}
+  - {module_name: dynamics, field_name: iw, output_name: iw}
+  - {module_name: dynamics, field_name: ke, output_name: kinetic_energy}
+  - {module_name: dynamics, field_name: te, output_name: total_energy}
+  - {module_name: dynamics, field_name: column_fv_sat_adj_heating, output_name: column_fv_sat_adj_heating}
+  - {module_name: dynamics, field_name: column_fv_sat_adj_moistening, output_name: column_fv_sat_adj_moistening}
+- name: atmos_dt_atmos_3d.zarr
+  chunks:
+    time: 16
+  times:
+    frequency: 5400
+    kind: interval
+  variables:
+  - {module_name: dynamics, field_name: grid_lont, output_name: lon}
+  - {module_name: dynamics, field_name: grid_latt, output_name: lat}
+  - {module_name: dynamics, field_name: grid_lon, output_name: lonb}
+  - {module_name: dynamics, field_name: grid_lat, output_name: latb}
+  - {module_name: dynamics, field_name: fv_sat_adj_qv_dt, output_name: fv_sat_adj_qv_dt}
+  - {module_name: dynamics, field_name: fv_sat_adj_t_dt, output_name: fv_sat_adj_t_dt}

--- a/projects/cloud_ml/argo/nudge-to-fine-run/nudge-to-fine-config.yaml
+++ b/projects/cloud_ml/argo/nudge-to-fine-run/nudge-to-fine-config.yaml
@@ -80,7 +80,7 @@ diagnostics:
   - latitude
   - longitude
   - cloud_water_mixing_ratio
-  - cloud_ice_mixing_ratio 
+  - cloud_ice_mixing_ratio
   - rain_mixing_ratio
   - snow_mixing_ratio
   - graupel_mixing_ratio

--- a/projects/cloud_ml/argo/nudge-to-fine-run/run.sh
+++ b/projects/cloud_ml/argo/nudge-to-fine-run/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+CONFIG=$1
+
+PROJECT=cloud-ml
+
+EXPERIMENT="cloud-ml-training-data"
+TRIAL="trial-0"
+TAG=${EXPERIMENT}
+NAME="${TAG}-nudge-to-fine-run"
+
+argo submit --from workflowtemplate/prognostic-run \
+    -p project=${PROJECT} \
+    -p tag=${TAG} \
+    -p config="$(< ${CONFIG}-config.yaml)" \
+    -p segment-count="2" \
+    --name "${NAME}" \
+    --labels "project=${PROJECT},experiment=${EXPERIMENT},trial=${TRIAL}"

--- a/projects/cloud_ml/scripts/fine-coarse-3d-merged.py
+++ b/projects/cloud_ml/scripts/fine-coarse-3d-merged.py
@@ -1,0 +1,116 @@
+import intake
+import xarray as xr
+import os
+from dask.diagnostics import ProgressBar
+import fsspec
+
+from vcm.catalog import catalog as CATALOG
+from vcm.fv3.metadata import standardize_fv3_diagnostics
+from vcm import convert_timestamps
+from vcm.cubedsphere import center_and_rotate_xy_winds
+from vcm.safe import get_variables
+
+
+WIND_ROTATION_MATRIX = CATALOG["wind_rotation/c48"].to_dask()
+GRID = CATALOG["grid/c48"].to_dask()
+COARSE_NUDGED_PATH = "gs://vcm-ml-experiments/cloud-ml/2022-06-24/cloud-ml-training-data-trial-0/fv3gfs_run"  # noqa: E501
+FINE_RESTARTS_KEY = "40day_c48_restarts_as_zarr_may2020"
+FINE_TO_COARSE_RENAME = {
+    "T": "air_temperature",
+    "sphum": "specific_humidity",
+    "eastward_wind": "eastward_wind",
+    "northward_wind": "northward_wind",
+    "DZ": "vertical_thickness_of_atmospheric_layer",
+    "delp": "pressure_thickness_of_atmospheric_layer",
+    "liq_wat": "cloud_water_mixing_ratio",
+    "ice_wat": "cloud_ice_mixing_ratio",
+    "rainwat": "rain_mixing_ratio",
+    "snowwat": "snow_mixing_ratio",
+    "graupel": "graupel_mixing_ratio",
+    "cld_amt": "cloud_amount",
+}
+RENAME_DIMS = {"pfull": "z"}
+COORD_VARS = ["x", "y", "z", "tile"]
+OUTPUT_CHUNKS = {"tile": 6}
+OUTPUT_PATH = "gs://vcm-ml-experiments/cloud-ml/2022-06-24/fine-coarse-3d-fields.zarr"
+
+
+def rotate_winds(ds):
+    eastward_wind, northward_wind = center_and_rotate_xy_winds(
+        WIND_ROTATION_MATRIX, ds.u, ds.v
+    )
+    ds["eastward_wind"] = eastward_wind
+    ds["northward_wind"] = northward_wind
+    return ds.drop_vars(["u", "v"])
+
+
+def get_fine_ds():
+    ds = CATALOG[FINE_RESTARTS_KEY].to_dask()
+    ds = ds.assign_coords({"time": convert_timestamps(ds.time)})
+    ds = standardize_fv3_diagnostics(ds).rename(RENAME_DIMS)
+    rotate_winds(ds)
+    ds_3d = xr.Dataset()
+    for restart_name, python_name in FINE_TO_COARSE_RENAME.items():
+        ds_3d[python_name] = ds[restart_name]
+    return ds_3d.drop_vars(COORD_VARS)
+
+
+def get_coarse_ds():
+    full_path = os.path.join(COARSE_NUDGED_PATH, "state_after_timestep.zarr")
+    ds = intake.open_zarr(full_path, consolidated=True).to_dask()
+    ds_3d = xr.Dataset()
+    for var in FINE_TO_COARSE_RENAME.values():
+        ds_3d[var] = ds[var]
+    return ds_3d
+
+
+def merge_coarse_fine(coarse, fine):
+    # subset times and variables to intersection
+    common_times = xr.DataArray(
+        data=sorted(list(set(coarse.time.values).intersection(set(fine.time.values)))),
+        dims=["time"],
+    )
+    coarse, fine = coarse.sel(time=common_times), fine.sel(time=common_times)
+    common_vars = set(coarse.data_vars).intersection(fine.data_vars)
+    coarse, fine = get_variables(coarse, common_vars), get_variables(fine, common_vars)
+
+    # add 'res' dimension and concatenate
+    merged = xr.concat(
+        [coarse.expand_dims({"res": ["coarse"]}), fine.expand_dims({"res": ["fine"]})],
+        dim="res",
+    )
+    # add grid variables back
+    return xr.merge([merged, GRID])
+
+
+def main():
+    """
+    Let's make a merged dataset of fine and coarse 3D (really, time-tile-x-y-z)
+    variables, including the water tracer species. Specifically:
+
+    - air temperature
+    - specific humidity
+    - northward wind
+    - eastward wind
+    - layer pressure thickness
+    - layer height thickness
+    - cloud water
+    - cloud ice
+    - graupel water
+    - rain water
+    - snow water
+    - cloud fraction
+
+    """
+
+    fine = get_fine_ds()
+    coarse = get_coarse_ds()
+    merged = merge_coarse_fine(coarse, fine)
+
+    merged = merged.unify_chunks().chunk(OUTPUT_CHUNKS)
+    with ProgressBar():
+        merged.to_zarr(fsspec.get_mapper(OUTPUT_PATH), consolidated=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Creating directories for argo and local scripts to the `cloud-ml` project. Adds a directive for a 10-day nudged-to-3km SHiELD run that includes full 3D outputs of the water species. Also adds a postprocessing script for that run to create a merged coarse-fine dataset. 