### PR TITLE
Drop tile-only variables before coarsening

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -3,6 +3,10 @@ from typing import Mapping, Sequence
 
 MovieUrls = Mapping[str, Sequence[str]]
 
+# Added to atmos diags by fortran model if interval-averaged.
+# Removed before coarsening run data to avoid errors.
+FORTRAN_TILE_ONLY_VARS = ["average_T1", "average_T2", "average_DT"]
+
 # Renamed keys already have "_coarse" suffix removed prior to the renaming being applied
 VERIFICATION_RENAME_MAP = {
     "40day_may2020": {"2d": {"TB": "TMPlowest", "tsfc": "TMPsfc"}},
@@ -31,6 +35,7 @@ RMSE_VARS = [
     "water_vapor_path",
     "VIL",
     "iw",
+    "total_precip_to_surface",
 ]
 
 GLOBAL_AVERAGE_DYCORE_VARS = [


### PR DESCRIPTION
If time averaging is set for the fortran diagnostics in the user config, the fortran model inserts a few additional variables `average_T1, average_T2, average_DT` into the atmos diags which only have tile and time dimensions. This causes the coarsening step to choke during the prognostic run diags. This PR hard codes these variables as a list to drop before coarsening. I did this instead of automatically dropping any variables without the full {x, y, tile} dims because I wasn't sure if it was always the case that the coarse run data has all these dims and didn't want to accidentally drop more variables than this set.


Coverage reports (updated automatically):
