### PR TITLE
Drop fortran time averaging info variables

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -3,10 +3,6 @@ from typing import Mapping, Sequence
 
 MovieUrls = Mapping[str, Sequence[str]]
 
-# Added to atmos diags by fortran model if interval-averaged.
-# Removed before coarsening run data to avoid errors.
-FORTRAN_TILE_ONLY_VARS = ("average_T1", "average_T2", "average_DT")
-
 # Renamed keys already have "_coarse" suffix removed prior to the renaming being applied
 VERIFICATION_RENAME_MAP = {
     "40day_may2020": {"2d": {"TB": "TMPlowest", "tsfc": "TMPsfc"}},

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -18,7 +18,6 @@ from fv3net.diagnostics.prognostic_run import config
 from fv3net.diagnostics.prognostic_run import derived_variables
 from fv3net.diagnostics.prognostic_run import constants
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -120,10 +119,7 @@ def load_coarse_data(path, catalog) -> xr.Dataset:
     if len(ds) > 0:
         # drop interface vars to avoid broadcasting by coarsen func
         ds = ds.drop_vars(
-            constants.GRID_VARS
-            + constants.GRID_INTERFACE_COORDS
-            + constants.FORTRAN_TILE_ONLY_VARS,
-            errors="ignore",
+            constants.GRID_VARS + constants.GRID_INTERFACE_COORDS, errors="ignore"
         )
         ds = _coarsen_cell_centered_to_target_resolution(
             ds, target_resolution=48, catalog=catalog


### PR DESCRIPTION
If fortran diags are time averaged, additional variables `average_T1, average_T2, average_DT` are saved out. These cause issues later down in the online diagnostics pipelines as they are saved for each time and tile but not x/y. The information is also pretty redundant as the only useful part is the value of DT (which can be inferred from the time dimension anyhow). 
At first I tried just dropping these in the prog run diags loading function, but since these variables also cause issues in other code like the regridding, I'm moving the fix to the source and just dropping these variables during postprocessing. The dt information is saved in the dataset attribute `time_averaging_interval` so that there is still some record in the dataset that values are time averaged.


- [x] Tests added
 

Coverage reports (updated automatically):
