### PR TITLE
Min-max novelty detector and tests

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -421,3 +421,38 @@ class RandomForestHyperparameters(Hyperparameters):
             .union(self.output_variables)
             .union(additional_variables)
         )
+
+@dataclasses.dataclass
+class MinMaxNoveltyDetectorHyperparameters(Hyperparameters):
+    """
+    Configuration for training a min-max novelty detection algorithm.
+
+    Args:
+        input_variables: names of variables to use as inputs.
+        # cutoff: non-negative number specifying how much larger than the maximum 
+        #     or smaller than the minimum one coordinate must be to have a novelty.
+        #     Default is 0.
+        packer_config: configuration of dataset packing.
+    """
+
+    input_variables: List[str]
+    # cutoff: Union[int, float] = 0
+    packer_config: PackerConfig = dataclasses.field(
+        default_factory=lambda: PackerConfig({})
+    )
+
+    @property 
+    def variables(self) -> Set[str]:
+        return set(self.input_variables)
+
+    @classmethod
+    def init_testing(cls, input_variables, output_variables) -> "MinMaxNoveltyDetectorHyperparameters":
+        """Initialize a default instance for a given input/output problem"""
+        try:
+            hyperparameters = cls()
+        except TypeError:
+            hyperparameters = cls(
+                input_variables=input_variables
+            )
+        return hyperparameters
+

--- a/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
@@ -1,0 +1,131 @@
+from fv3fit._shared import stacking
+from .. import _shared
+from .._shared import (
+    match_prediction_to_input_coords,
+    pack,
+    pack_tfdataset,
+    Predictor,
+    register_training_function,
+    SAMPLE_DIM_NAME,
+    stack_non_vertical,
+)
+from .._shared.config import MinMaxNoveltyDetectorHyperparameters, PackerConfig
+
+import dataclasses
+import dacite
+import fsspec
+from fv3fit import tfdataset
+from fv3fit._shared.packer import PackingInfo, clip_sample, unpack
+from fv3fit.tfdataset import apply_to_mapping, ensure_nd
+from fv3fit.typing import Batch
+import io
+import joblib
+import logging
+import numpy as np
+from sklearn.preprocessing import MinMaxScaler
+import tensorflow as tf
+from typing import Optional, Iterable, Sequence
+from vcm import safe
+import xarray as xr
+import yaml
+
+@register_training_function("min_max_novelty_detector", MinMaxNoveltyDetectorHyperparameters)
+def train_min_max_novelty_detector(
+    hyperparameters: MinMaxNoveltyDetectorHyperparameters,
+    train_batches: tf.data.Dataset,
+    validation_batches: tf.data.Dataset
+):
+    train_batches = train_batches.map(
+        tfdataset.apply_to_mapping(tfdataset.float64_to_float32)
+    )
+    
+    model = MinMaxNoveltyDetector(hyperparameters)
+    model.fit(train_batches)
+    return model
+
+@_shared.io.register("minmax")
+class MinMaxNoveltyDetector(Predictor):
+
+    _PICKLE_NAME = "minmax.pkl"
+    _METADATA_NAME = "metadata.bin"
+
+    _NOVELTY_OUTPUT_VAR = "is_novelty"
+
+    dims = ["x", "y", "tile", "time"]
+
+    def __init__(
+        self,
+        hyperparameters: MinMaxNoveltyDetectorHyperparameters
+    ):
+        output_variables = [self._NOVELTY_OUTPUT_VAR]
+        super().__init__(hyperparameters.input_variables, output_variables)
+        self.packer_config = hyperparameters.packer_config
+
+    def fit(self, batches: tf.data.Dataset):
+        logger = logging.getLogger("MinMaxNoveltyDetector")
+        logger.info(f"Fitting min-max novelty detector.")
+
+        batches = batches.map(apply_to_mapping(ensure_nd(2)))
+        batches_clipped = batches.map(clip_sample(self.packer_config.clip))
+        x_dataset, self.input_features_ = pack_tfdataset(
+            batches_clipped, [str(item) for item in self.input_variables]
+        )
+        x_dataset = x_dataset.unbatch()
+
+        total_samples = sum(1 for _ in iter(x_dataset))
+        X: Batch = next(iter(x_dataset.batch(total_samples)))
+
+        self.scaler = MinMaxScaler()
+        self.scaler.fit(X)
+
+        logger.info(f"Min-max novelty detector done fitting.")
+
+    def predict(self, data: xr.Dataset) -> xr.Dataset:  
+        stack_dims = [dim for dim in data.dims if dim not in stacking.Z_DIM_NAMES]  
+        stacked_data = data.stack({SAMPLE_DIM_NAME: stack_dims}).transpose(SAMPLE_DIM_NAME, ...)
+
+        X, _ = pack(stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config)
+        scaled_X = self.scaler.transform(X)
+        larger_than_max = np.where(scaled_X.max(axis=1) > 1, 1, 0)
+        smaller_than_min = np.where(scaled_X.min(axis=1) < 0, 1, 0)
+        stacked_is_novelty = larger_than_max + smaller_than_min
+
+        new_coords = {k: v for (k, v) in stacked_data.coords.items() if k not in stacking.Z_DIM_NAMES}
+        stacked_is_novelty = xr.DataArray(stacked_is_novelty, dims=[SAMPLE_DIM_NAME], coords=new_coords)
+        is_novelty = stacked_is_novelty\
+            .to_dataset(name=self._NOVELTY_OUTPUT_VAR)\
+            .unstack(SAMPLE_DIM_NAME)
+
+        return match_prediction_to_input_coords(data, is_novelty)
+
+    def dump(self, path: str) -> None:
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
+        fs.makedirs(path, exist_ok=True)
+
+        mapper = fs.get_mapper(path)
+
+        f = io.BytesIO()
+        joblib.dump({"scaler": self.scaler}, f)
+        mapper[self._PICKLE_NAME] = f.getvalue()
+
+        metadata = {
+            "input_variables": self.input_variables,
+            "packer_config": dataclasses.asdict(self.packer_config),
+            "input_features_": dataclasses.asdict(self.input_features_),
+        }
+        mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
+
+    @classmethod
+    def load(cls, path: str) -> "Predictor":
+        mapper = fsspec.get_mapper(path)
+        components = joblib.load(io.BytesIO(mapper[cls._PICKLE_NAME]))
+        metadata = yaml.safe_load(mapper[cls._METADATA_NAME])
+
+        hyperparameters = MinMaxNoveltyDetectorHyperparameters(metadata["input_variables"])
+        obj = cls(hyperparameters)
+        obj.scaler = components["scaler"]
+        obj.input_features_ = dacite.from_dict(PackingInfo, data=metadata["input_features_"])
+        obj.packer_config = dacite.from_dict(PackerConfig, data=metadata.get("packer_config", {}))
+
+        return obj        
+

--- a/external/fv3fit/tests/training/test_train_novelty_detection.py
+++ b/external/fv3fit/tests/training/test_train_novelty_detection.py
@@ -1,0 +1,121 @@
+import fv3fit
+from fv3fit._shared.config import get_hyperparameter_class
+from fv3fit.tfdataset import tfdataset_from_batches
+from fv3fit.sklearn._min_max_novelty_detector import MinMaxNoveltyDetector
+import numpy as np
+import pytest
+import tensorflow as tf
+from typing import Callable, Sequence, Tuple
+import xarray as xr
+
+from tests.training.test_train import TrainingResult, get_dataset_default, get_uniform_sample_func, unstack_test_dataset
+
+# novelty detection predictors that can be tested on any input data, but whose outputs will
+# not correspond to the labels of standard supervised prediction tasks
+NOVELTY_TRAINING_TYPES = [
+    "min_max_novelty_detector",
+]
+
+@pytest.fixture(params=NOVELTY_TRAINING_TYPES)
+def model_type(request):
+    return request.param
+
+
+def get_dataset(
+    model_type, sample_func
+) -> Tuple[Sequence[str], Sequence[str], tf.data.Dataset]:
+    return get_dataset_default(sample_func, labeled=False)
+
+
+def train_novelty_detector(model_type, sample_func, hyperparameters=None):
+    input_variables, output_variables, train_dataset = get_dataset(
+        model_type, sample_func
+    )
+    if hyperparameters is None:
+        cls = get_hyperparameter_class(model_type)
+        hyperparameters = cls.init_testing(input_variables, output_variables)
+    input_variables, _, test_dataset = get_dataset(
+        model_type, sample_func
+    )
+    train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(10)])
+    # val_tfdataset is discarded and not used for training
+    val_tfdataset = tfdataset_from_batches([test_dataset])
+    train = fv3fit.get_training_function(model_type)
+    model = train(hyperparameters, train_tfdataset, val_tfdataset)
+    test_dataset = unstack_test_dataset(test_dataset)
+    output_variables = MinMaxNoveltyDetector._NOVELTY_OUTPUT_VAR
+    return TrainingResult(model, output_variables, test_dataset, hyperparameters)
+
+
+def scale_test_sample(test_dataset: xr.Dataset, scaling=100):
+    for data_var in test_dataset.data_vars:
+        test_dataset[data_var] = scaling * test_dataset[data_var]
+    return test_dataset
+
+
+def assert_correct_output(
+    model_type,
+    sample_func: Callable[[], xr.DataArray]
+):
+    """
+    Args:
+        model_type: type of model to train
+        sample_func: function that returns example DataArrays for training and
+            validation, should return different data on subsequent calls
+    """
+    result = train_novelty_detector(model_type, sample_func)
+    out_dataset = result.model.predict(result.test_dataset)
+    # dimensions are the same, except for "z"
+    output_dimensions = set(out_dataset.dims.keys())
+    output_dimensions.add("z")
+    test_dataset_dimensions = set(result.test_dataset.dims.keys())
+    assert output_dimensions == test_dataset_dimensions
+    # output is is_novelty
+    assert set(out_dataset.data_vars.keys()) == set([MinMaxNoveltyDetector._NOVELTY_OUTPUT_VAR])
+    # outputs are either 0 or 1 (and at least one output is not a novelty)
+    assert out_dataset[MinMaxNoveltyDetector._NOVELTY_OUTPUT_VAR].max() <= 1
+    assert out_dataset[MinMaxNoveltyDetector._NOVELTY_OUTPUT_VAR].min() == 0
+
+
+def assert_extreme_novelties(
+    model_type,
+    sample_func: Callable[[], xr.DataArray],
+    scaling=100,
+    epsilon=0.01
+):
+    """
+    Args:
+        model_type: type of model to train
+        sample_func: function that returns example DataArrays for training and
+            validation, should return different data on subsequent calls
+        scaling: multiplicative scaling applied to force a sample to be an outlier
+        epsilon: acceptable percentage of false negatives
+    """
+    result = train_novelty_detector(model_type, sample_func)
+    scaled_test_dataset = scale_test_sample(result.test_dataset, scaling=scaling)
+    out_dataset = result.model.predict(scaled_test_dataset)
+    # almost every output is a novelty
+    assert out_dataset[MinMaxNoveltyDetector._NOVELTY_OUTPUT_VAR].mean() >= 1 - epsilon
+
+
+@pytest.mark.slow
+def test_train_novelty_default_correct_output(model_type, regtest):
+    """
+    The model has properly formatted output, including (1) thesame dimensions as the input
+    (besides the vertical dimension), (2) the correct data variable, and (3) outputs in the
+    correct [0, 1] range.
+    """
+    n_sample, n_tile, nx, ny, n_feature = 10, 6, 12, 12, 2
+    sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
+    assert_correct_output(model_type, sample_func)
+
+
+@pytest.mark.slow
+def test_train_novelty_default_extreme_novelties(model_type, regtest):
+    """
+    When testing coordinates are scaled by a very large amount, nearly every sample is deemed a
+    novelty.
+    """
+    n_sample, n_tile, nx, ny, n_feature = 10, 6, 12, 12, 2
+    sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
+    assert_extreme_novelties(model_type, sample_func)


### PR DESCRIPTION
This PR creates the blueprint for novelty detection algorithms by introducing the simplest novelty detection predictor, which identifies whether a column is out-of-sample by comparing coordinate-wise to the maximum and minimum values. It also introduces new unit tests for this that can be applied for all such predictors.

Significant internal changes:
- Added MinMaxNoveltyDetector, a Predictor that identifies out-of-sample points.

- [ ] Tests for novelty detectors in test_train_novelty_detection.py that ensures that outputs are properly configured and that  extreme scalings of toy inputs are classified as novelties.
- [ ] Segments tests in test_train.py into two categories: those that apply to all learning algorithms (supervised and unsupervised) and those that only apply to supervised tasks. That way, tests of things like the ability to properly save and load models extend to all, but explicitly supervised tests are not applied to the novelty detection algorithms. If this isn't organized the way others would like, I'm happy to rearrange.

Coverage reports (updated automatically):
