### PR TITLE
Add podlogs CLI

### DIFF
--- a/tools/podlogs
+++ b/tools/podlogs
@@ -2,7 +2,7 @@
 
 function usage {
     >&2 echo "Usage:"
-    >&2 echo "google_log_cat [-n numrecords ] <podname>"
+    >&2 echo "podlogs [--freshness AGE] [-n numrecords ] <podname>"
 }
 
 if [[ $# -lt 1 ]]
@@ -12,8 +12,14 @@ then
 fi
 
 args=()
+freshness=10d
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --freshness)
+            freshness=$2
+            shift
+            shift
+            ;;
         -n)
             args+=("--limit")
             args+=("$2")
@@ -30,4 +36,7 @@ done
 gcloud logging read \
 "resource.labels.pod_name=$pod" \
 "${args[@]}" \
---format='value(jsonPayload.message)' | grep -v '^$' | tac
+--freshness="$freshness" \
+--format='json' \
+ | jq -r '.[] | "\(.textPayload // .jsonPayload.message)"'  \
+ | tac

--- a/tools/podlogs
+++ b/tools/podlogs
@@ -5,17 +5,18 @@ function usage {
     >&2 echo "google_log_cat [-n numrecords ] <podname>"
 }
 
-if [[ $# < 1 ]]
+if [[ $# -lt 1 ]]
 then
     usage
     exit 1
 fi
 
-args=""
-while [[ $# > 0 ]]; do
+args=()
+while [[ $# -gt 0 ]]; do
     case $1 in
         -n)
-            n="--limit $2"
+            args+=("--limit")
+            args+=("$2")
             shift
             shift
             ;;
@@ -28,5 +29,5 @@ done
 
 gcloud logging read \
 "resource.labels.pod_name=$pod" \
-$n \
+"${args[@]}" \
 --format='value(jsonPayload.message)' | grep -v '^$' | tac

--- a/tools/podlogs
+++ b/tools/podlogs
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function usage {
+    >&2 echo "Usage:"
+    >&2 echo "google_log_cat [-n numrecords ] <podname>"
+}
+
+if [[ $# < 1 ]]
+then
+    usage
+    exit 1
+fi
+
+args=""
+while [[ $# > 0 ]]; do
+    case $1 in
+        -n)
+            n="--limit $2"
+            shift
+            shift
+            ;;
+        *)
+            pod=$1
+            shift
+            ;;
+    esac
+done
+
+gcloud logging read \
+"resource.labels.pod_name=$pod" \
+$n \
+--format='value(jsonPayload.message)' | grep -v '^$' | tac

--- a/tools/podlogs
+++ b/tools/podlogs
@@ -38,5 +38,5 @@ gcloud logging read \
 "${args[@]}" \
 --freshness="$freshness" \
 --format='json' \
- | jq -r '.[] | "\(.textPayload // .jsonPayload.message)"'  \
+| jq -r '.[] | .textPayload // .jsonPayload.message | select( . != null)'  \
  | tac


### PR DESCRIPTION
This simple bash script makes it easier to view the non-json formatted logs for a given workflow. It is especially useful to view tracebacks spread across multiple lines (as happens with the prognostic run).

Example to try:
   
    $ podlogs gscond-routed-reg-v3-prog-v2-2688347109 -n 1000

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/84997d6b-4f8b-437a-b7b1-2acd50764126\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)