### PR TITLE
Allow loading fv3fit data directly to tf.data.Dataset

### DIFF
--- a/external/fv3fit/fv3fit/__init__.py
+++ b/external/fv3fit/fv3fit/__init__.py
@@ -32,6 +32,12 @@ from .keras._models.convolutional import ConvolutionalHyperparameters
 from .keras._models.dense import DenseHyperparameters
 from . import keras, sklearn, testing
 from fv3fit._py_function import py_function_dict_output
+from .data import (
+    register_tfdataset_loader,
+    TFDatasetLoader,
+    tfdataset_loader_from_dict,
+    FromBatches,
+)
 
 # need to import this to register the training func
 import fv3fit.train_microphysics

--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -1,3 +1,3 @@
-from .base import TFDatasetLoader
+from .base import TFDatasetLoader, tfdataset_loader_from_dict, register_tfdataset_loader
 from .batches import FromBatches
 from .tfdataset import WindowedZarrLoader

--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -1,1 +1,3 @@
+from .base import TFDatasetLoader
 from .batches import FromBatches
+from .tfdataset import WindowedZarrLoader

--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -1,0 +1,1 @@
+from .batches import FromBatches

--- a/external/fv3fit/fv3fit/data/base.py
+++ b/external/fv3fit/fv3fit/data/base.py
@@ -25,6 +25,7 @@ class TFDatasetLoader(abc.ABC):
         except (TypeError, AttributeError):
             pass
         for subclass in cls.__subclasses__():
+            print(subclass)
             try:
                 # if the subclass defines its own from_dict use that,
                 # otherwise use dacite
@@ -35,6 +36,11 @@ class TFDatasetLoader(abc.ABC):
                     return subclass.from_dict(kwargs)
                 else:
                     return dacite.from_dict(data_class=subclass, data=kwargs)
-            except (TypeError, AttributeError, dacite.exceptions.MissingValueError):
+            except (
+                TypeError,
+                ValueError,
+                AttributeError,
+                dacite.exceptions.MissingValueError,
+            ):
                 pass
         raise ValueError("invalid TFDatasetLoader dictionary")

--- a/external/fv3fit/fv3fit/data/base.py
+++ b/external/fv3fit/fv3fit/data/base.py
@@ -1,6 +1,7 @@
 import abc
 import tensorflow as tf
 from typing import Optional, Sequence
+import dacite
 
 
 class TFDatasetLoader(abc.ABC):
@@ -16,3 +17,24 @@ class TFDatasetLoader(abc.ABC):
             dataset containing requested variables
         """
         ...
+
+    @classmethod
+    def from_dict(cls, kwargs) -> "TFDatasetLoader":
+        try:
+            return dacite.from_dict(data_class=cls, data=kwargs)
+        except (TypeError, AttributeError):
+            pass
+        for subclass in cls.__subclasses__():
+            try:
+                # if the subclass defines its own from_dict use that,
+                # otherwise use dacite
+                if (
+                    hasattr(subclass, "from_dict")
+                    and subclass.from_dict is not cls.from_dict
+                ):
+                    return subclass.from_dict(kwargs)
+                else:
+                    return dacite.from_dict(data_class=subclass, data=kwargs)
+            except (TypeError, AttributeError, dacite.exceptions.MissingValueError):
+                pass
+        raise ValueError("invalid TFDatasetLoader dictionary")

--- a/external/fv3fit/fv3fit/data/base.py
+++ b/external/fv3fit/fv3fit/data/base.py
@@ -30,6 +30,8 @@ class TFDatasetLoader(abc.ABC):
 def register_tfdataset_loader(loader_class: Type[TFDatasetLoader]):
     """
     Register a TFDatasetLoader subclass as a factory for TFDatasetLoaders.
+
+    This allows the subclass to be initialized using `tfdataset_loader_from_dict`.
     """
     global _TFDATASET_LOADERS
     _TFDATASET_LOADERS.append(loader_class)
@@ -37,6 +39,11 @@ def register_tfdataset_loader(loader_class: Type[TFDatasetLoader]):
 
 
 def tfdataset_loader_from_dict(d: dict) -> TFDatasetLoader:
+    """
+    Initializes a registered TFDatasetLoader subclass.
+
+    To add a new subclass, use `register_tfdataset_loader`.
+    """
     for cls in _TFDATASET_LOADERS:
         try:
             return cls.from_dict(d)

--- a/external/fv3fit/fv3fit/data/base.py
+++ b/external/fv3fit/fv3fit/data/base.py
@@ -1,0 +1,18 @@
+import abc
+import tensorflow as tf
+from typing import Optional, Sequence
+
+
+class TFDatasetLoader(abc.ABC):
+    @abc.abstractmethod
+    def get_data(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        """
+        Args:
+            local_download_path: if provided, cache data locally at this path
+            variable_names: names of variables to include when loading data
+        Returns:
+            dataset containing requested variables
+        """
+        ...

--- a/external/fv3fit/fv3fit/data/batches.py
+++ b/external/fv3fit/fv3fit/data/batches.py
@@ -1,0 +1,53 @@
+import dataclasses
+import os
+from typing import Optional, Sequence
+import loaders
+import loaders.typing
+from loaders.batches.save import save_batches
+from fv3fit.tfdataset import tfdataset_from_batches
+import tensorflow as tf
+import logging
+from .base import TFDatasetLoader
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class FromBatches(TFDatasetLoader):
+
+    batches_loader: loaders.BatchesLoader
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FromBatches":
+        return FromBatches(loaders.BatchesLoader.from_dict(d))
+
+    def get_data(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        """
+        Args:
+            local_download_path: if provided, cache data locally at this path
+            variable_names: names of variables to include when loading data
+        Returns:
+            dataset containing requested variables
+        """
+        batches = self.batches_loader.load_batches(variables=variable_names)
+        if local_download_path is not None:
+            batches = cache(batches, local_download_path, variable_names)
+        batches = loaders.batches.shuffle(batches)
+        return tfdataset_from_batches(batches)
+
+
+def cache(
+    batches: loaders.typing.Batches,
+    local_download_path: str,
+    variable_names: Sequence[str],
+) -> loaders.typing.Batches:
+    logger.info("saving batches data to %s", local_download_path)
+    os.makedirs(local_download_path, exist_ok=True)
+    save_batches(
+        batches, output_path=local_download_path,
+    )
+    return loaders.batches_from_netcdf(
+        path=local_download_path, variable_names=variable_names
+    )

--- a/external/fv3fit/fv3fit/data/batches.py
+++ b/external/fv3fit/fv3fit/data/batches.py
@@ -7,11 +7,12 @@ from loaders.batches.save import save_batches
 from fv3fit.tfdataset import tfdataset_from_batches
 import tensorflow as tf
 import logging
-from .base import TFDatasetLoader
+from .base import TFDatasetLoader, register_tfdataset_loader
 
 logger = logging.getLogger(__name__)
 
 
+@register_tfdataset_loader
 @dataclasses.dataclass
 class FromBatches(TFDatasetLoader):
 

--- a/external/fv3fit/fv3fit/data/batches.py
+++ b/external/fv3fit/fv3fit/data/batches.py
@@ -30,7 +30,9 @@ class FromBatches(TFDatasetLoader):
             local_download_path: if provided, cache data locally at this path
             variable_names: names of variables to include when loading data
         Returns:
-            dataset containing requested variables
+            dataset containing requested variables, each record is a mapping from
+                variable name to variable value, and each value is a tensor whose
+                first dimension is the batch dimension
         """
         batches = self.batches_loader.load_batches(variables=variable_names)
         if local_download_path is not None:

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -1,0 +1,43 @@
+import dataclasses
+from typing import Mapping, Sequence, Optional
+import tensorflow as tf
+from .base import TFDatasetLoader
+
+
+@dataclasses.dataclass
+class VariableConfig:
+    unstacked_dims: Sequence[str]
+
+
+@dataclasses.dataclass
+class WindowedZarrLoader(TFDatasetLoader):
+    """
+    A tfdataset loader that loads directly from zarr and supports time windows.
+
+    Attributes:
+        data_path: path to zarr data
+        window_size: number of timesteps to include in time windows
+        default_variable_config: default configuration for variables
+        variable_configs: configuration for variables by name
+    """
+
+    data_path: str
+    window_size: int
+    default_variable_config: VariableConfig
+    variable_configs: Mapping[str, VariableConfig] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def get_data(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        """
+        Args:
+            local_download_path: if provided, cache data locally at this path
+            variable_names: names of variables to include when loading data
+        Returns:
+            dataset containing requested variables
+        """
+        # if local_download_path is given, cache on disk
+        # using tfdataset.cache(local_download_path)
+        raise NotImplementedError()

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -1,7 +1,8 @@
 import dataclasses
 from typing import Mapping, Sequence, Optional
 import tensorflow as tf
-from .base import TFDatasetLoader
+from .base import TFDatasetLoader, register_tfdataset_loader
+import dacite
 
 
 @dataclasses.dataclass
@@ -9,6 +10,7 @@ class VariableConfig:
     unstacked_dims: Sequence[str]
 
 
+@register_tfdataset_loader
 @dataclasses.dataclass
 class WindowedZarrLoader(TFDatasetLoader):
     """
@@ -41,3 +43,9 @@ class WindowedZarrLoader(TFDatasetLoader):
         # if local_download_path is given, cache on disk
         # using tfdataset.cache(local_download_path)
         raise NotImplementedError()
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WindowedZarrLoader":
+        return dacite.from_dict(
+            data_class=cls, data=d, config=dacite.Config(strict=True)
+        )

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -38,7 +38,9 @@ class WindowedZarrLoader(TFDatasetLoader):
             local_download_path: if provided, cache data locally at this path
             variable_names: names of variables to include when loading data
         Returns:
-            dataset containing requested variables
+            dataset containing requested variables, each record is a mapping from
+                variable name to variable value, and each value is a tensor whose
+                first dimension is the batch dimension
         """
         # if local_download_path is given, cache on disk
         # using tfdataset.cache(local_download_path)

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -15,7 +15,7 @@ import fsspec
 import fv3fit.keras
 import fv3fit.sklearn
 import fv3fit
-from .data import TFDatasetLoader
+from .data import tfdataset_loader_from_dict, TFDatasetLoader
 import tempfile
 from fv3fit.dataclasses import asdict_with_enum
 import wandb
@@ -129,13 +129,13 @@ def main(args, unknown_args=None):
 
     with open(args.training_data_config, "r") as f:
         config_dict = yaml.safe_load(f)
-        training_data_config = TFDatasetLoader.from_dict(config_dict)
+        training_data_config = tfdataset_loader_from_dict(config_dict)
         if args.no_wandb is False:
             wandb.config["training_data_config"] = config_dict
     if args.validation_data_config is not None:
         with open(args.validation_data_config, "r") as f:
             config_dict = yaml.safe_load(f)
-            validation_data_config = TFDatasetLoader.from_dict(config_dict)
+            validation_data_config = tfdataset_loader_from_dict(config_dict)
             if args.no_wandb is False:
                 wandb.config["validation_data_config"] = config_dict
     else:

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -15,7 +15,7 @@ import fsspec
 import fv3fit.keras
 import fv3fit.sklearn
 import fv3fit
-from .data import FromBatches
+from .data import TFDatasetLoader
 import tempfile
 from fv3fit.dataclasses import asdict_with_enum
 import wandb
@@ -74,8 +74,8 @@ def maybe_join_path(base: Optional[str], append: str) -> Optional[str]:
 
 def load_data(
     variables: Sequence[str],
-    training_data_config: FromBatches,
-    validation_data_config: Optional[FromBatches],
+    training_data_config: TFDatasetLoader,
+    validation_data_config: Optional[TFDatasetLoader],
     cache_config: CacheConfig,
 ) -> Tuple[tf.data.Dataset, Optional[tf.data.Dataset]]:
     train_tfdataset = training_data_config.get_data(
@@ -129,13 +129,13 @@ def main(args, unknown_args=None):
 
     with open(args.training_data_config, "r") as f:
         config_dict = yaml.safe_load(f)
-        training_data_config = FromBatches.from_dict(config_dict)
+        training_data_config = TFDatasetLoader.from_dict(config_dict)
         if args.no_wandb is False:
             wandb.config["training_data_config"] = config_dict
     if args.validation_data_config is not None:
         with open(args.validation_data_config, "r") as f:
             config_dict = yaml.safe_load(f)
-            validation_data_config = FromBatches.from_dict(config_dict)
+            validation_data_config = TFDatasetLoader.from_dict(config_dict)
             if args.no_wandb is False:
                 wandb.config["validation_data_config"] = config_dict
     else:

--- a/external/fv3fit/tests/data/test_data_base.py
+++ b/external/fv3fit/tests/data/test_data_base.py
@@ -1,12 +1,20 @@
 import fv3fit.data
 import dataclasses
+import unittest.mock
 
 
 def test_loader_from_dict():
+    mock_result = unittest.mock.MagicMock()
+
+    @fv3fit.data.register_tfdataset_loader
     @dataclasses.dataclass
     class MyLoaderSubclass(fv3fit.data.TFDatasetLoader):
         foo: int
         bar: float
+
+        @classmethod
+        def from_dict(cls, d):
+            return mock_result
 
         def get_data(
             self, local_download_path, variable_names,
@@ -14,7 +22,5 @@ def test_loader_from_dict():
             raise NotImplementedError()
 
     config = {"foo": 1, "bar": 2.0}
-    result = fv3fit.data.TFDatasetLoader.from_dict(config)
-    assert isinstance(result, MyLoaderSubclass)
-    assert result.foo == 1
-    assert result.bar == 2.0
+    result = fv3fit.data.tfdataset_loader_from_dict(config)
+    assert result is mock_result

--- a/external/fv3fit/tests/data/test_data_base.py
+++ b/external/fv3fit/tests/data/test_data_base.py
@@ -1,0 +1,20 @@
+import fv3fit.data
+import dataclasses
+
+
+def test_loader_from_dict():
+    @dataclasses.dataclass
+    class MyLoaderSubclass(fv3fit.data.TFDatasetLoader):
+        foo: int
+        bar: float
+
+        def get_data(
+            self, local_download_path, variable_names,
+        ):
+            raise NotImplementedError()
+
+    config = {"foo": 1, "bar": 2.0}
+    result = fv3fit.data.TFDatasetLoader.from_dict(config)
+    assert isinstance(result, MyLoaderSubclass)
+    assert result.foo == 1
+    assert result.bar == 2.0

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -122,7 +122,7 @@ def mock_shuffle():
 @pytest.fixture
 def mock_tfdataset_from_batches():
     with mock.patch(
-        "fv3fit.train.tfdataset_from_batches"
+        "fv3fit.data.batches.tfdataset_from_batches"
     ) as tfdataset_from_batches_mock:
         yield tfdataset_from_batches_mock
 

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -15,7 +15,7 @@ import vcm.testing
 import tempfile
 from fv3fit.keras._models.precipitative import LV, CPD, GRAVITY
 from fv3fit._shared.stacking import stack, stack_non_vertical, SAMPLE_DIM_NAME
-from fv3fit.train import tfdataset_from_batches
+from fv3fit.tfdataset import tfdataset_from_batches
 import tensorflow as tf
 
 

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -48,6 +48,10 @@ def main(data_config: str, output_path: str, variable_names: Sequence[str]):
     loader = BatchesLoader.from_dict(config)
     logger.info("configuration loaded, creating batches object")
     batches = loader.load_batches(variables=variable_names)
+    save_batches(batches, output_path)
+
+
+def save_batches(batches, output_path):
     n_batches = len(batches)
     logger.info(f"batches object created, saving {n_batches} batches to {output_path}")
     os.makedirs(output_path, exist_ok=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,6 @@ markers =
     regression: marks regression tests (deselect with '-m "not regression"')
     network: marks tests requiring network access
     slow: marks tests as slow (approx >1s) (deselect with '-m "not slow"')
+
+filterwarnings =
+    ignore:distutils Version classes are deprecated:DeprecationWarning


### PR DESCRIPTION
Currently the `fv3fit.train` script assumes all loaded data will be loaded through `loaders.BatchesLoader`, which makes assumptions about the form of the data and requires data be stored in xarray formats. This prevents us from being able to load data directly to tf.data.Dataset.

This PR refactors the existing loading code into a `FromBatches` class, which allows replacing this implementation with alternative implementations that can load directly to `tf.data.Dataset`. This will be useful when loading timeseries data for full model replacement.

Added public API:
- Added TFDatasetLoader class to fv3fit, which loads a tf.data.Dataset based on a dataset configuration
- Added `register_tfdataset_loader` and `tfdataset_loader_from_dict` functions to initialize TFDatasetLoader subclasses from configuration dictionaries
- Added FromBatches implementation of TFDatasetLoader to handle all existing dataset configurations
- Added unimplemented WindowedZarrLoader class for loading windowed data from zarr stores into tf.data.Dataset

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/e4a01350-f629-45b5-bd28-a1c725ff1b45/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)