### PR TITLE
[fv3fit] Implement WindowedZarrLoader

### DIFF
--- a/external/fv3fit/fv3fit/__init__.py
+++ b/external/fv3fit/fv3fit/__init__.py
@@ -32,6 +32,7 @@ from .keras._models.convolutional import ConvolutionalHyperparameters
 from .keras._models.dense import DenseHyperparameters
 from . import keras, sklearn, testing
 from fv3fit._py_function import py_function_dict_output
+from .data import WindowedZarrLoader
 
 # need to import this to register the training func
 import fv3fit.train_microphysics

--- a/external/fv3fit/fv3fit/_shared/stacking.py
+++ b/external/fv3fit/fv3fit/_shared/stacking.py
@@ -13,12 +13,15 @@ def stack(ds: xr.Dataset, unstacked_dims: Sequence[str]):
     stack_dims = [dim for dim in ds.dims if dim not in unstacked_dims]
     unstacked_dims = [dim for dim in ds.dims if dim in unstacked_dims]
     unstacked_dims.sort()  # needed to always get [x, y, z] dimensions
-    ds_stacked = safe.stack_once(
-        ds,
-        SAMPLE_DIM_NAME,
-        stack_dims,
-        allowed_broadcast_dims=list(unstacked_dims) + ["time", "dataset"],
-    )
+    if len(stack_dims) == 0:
+        ds_stacked = ds.expand_dims(dim=SAMPLE_DIM_NAME, axis=0)
+    else:
+        ds_stacked = safe.stack_once(
+            ds,
+            SAMPLE_DIM_NAME,
+            stack_dims,
+            allowed_broadcast_dims=list(unstacked_dims) + ["time", "dataset"],
+        )
     return ds_stacked.transpose(SAMPLE_DIM_NAME, *unstacked_dims)
 
 

--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -1,3 +1,3 @@
 from .base import TFDatasetLoader
 from .batches import FromBatches
-from .tfdataset import WindowedZarrLoader
+from .tfdataset import WindowedZarrLoader, VariableConfig

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -2,11 +2,41 @@ import dataclasses
 from typing import Mapping, Sequence, Optional
 import tensorflow as tf
 from .base import TFDatasetLoader
+from ..tfdataset import iterable_to_tfdataset
+import tempfile
+import xarray as xr
+import numpy as np
+from fv3fit._shared.stacking import stack
 
 
 @dataclasses.dataclass
 class VariableConfig:
-    unstacked_dims: Sequence[str]
+    """
+    Configuration for a variable to retrieve from a dataset.
+
+    Attributes:
+        times: time indices to use, must be one of "window" or "start", which
+            will use either the full window or just the initial time of that window
+    """
+
+    times: str = "window"
+
+    def __post_init__(self):
+        if self.times not in ("window", "start"):
+            raise TypeError("times must be one of 'window' or 'start'")
+
+    def get_record(self, name: str, ds: xr.Dataset, unstacked_dims: Sequence[str]):
+        if self.times == "start":
+            ds = ds.isel(time=0)
+        data = stack(ds[name], unstacked_dims=unstacked_dims).values
+        return data
+
+
+def open_zarr(url: str):
+    cachedir = tempfile.mkdtemp()
+    return xr.open_zarr(
+        "filecache::" + url, storage_options={"filecache": {"cache_storage": cachedir}}
+    )
 
 
 @dataclasses.dataclass
@@ -19,14 +49,17 @@ class WindowedZarrLoader(TFDatasetLoader):
         window_size: number of timesteps to include in time windows
         default_variable_config: default configuration for variables
         variable_configs: configuration for variables by name
+        batch_size: number of windows to include in each batch
     """
 
     data_path: str
+    unstacked_dims: Sequence[str]
     window_size: int
     default_variable_config: VariableConfig
     variable_configs: Mapping[str, VariableConfig] = dataclasses.field(
         default_factory=dict
     )
+    batch_size: int = 1
 
     def get_data(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -38,6 +71,29 @@ class WindowedZarrLoader(TFDatasetLoader):
         Returns:
             dataset containing requested variables
         """
-        # if local_download_path is given, cache on disk
         # using tfdataset.cache(local_download_path)
-        raise NotImplementedError()
+        ds = open_zarr(self.data_path)
+
+        def records():
+            n_times = ds.dims["time"]
+            n_windows = n_times // self.window_size
+            # must ensure n_windows is evenly divisible by self.batch_size
+            n_windows = int((n_windows // self.batch_size) * self.batch_size)
+            starts = np.random.randint(0, n_times - self.window_size, n_windows)
+            for i_start in starts:
+                record = {}
+                window_ds = ds.isel(time=range(i_start, i_start + self.window_size))
+                for name in variable_names:
+                    config = self.variable_configs.get(
+                        name, self.default_variable_config
+                    )
+                    record[name] = config.get_record(
+                        name, window_ds, self.unstacked_dims
+                    )
+                yield record
+
+        tfdataset = iterable_to_tfdataset(records())
+        # if local_download_path is given, cache on disk
+        if local_download_path is not None:
+            tfdataset = tfdataset.cache(local_download_path)
+        return tfdataset.unbatch().batch(self.batch_size)

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -32,7 +32,7 @@ class VariableConfig:
         return data
 
 
-def open_zarr(url: str):
+def open_zarr_using_filecache(url: str):
     cachedir = tempfile.mkdtemp()
     return xr.open_zarr(
         "filecache::" + url, storage_options={"filecache": {"cache_storage": cachedir}}
@@ -72,7 +72,7 @@ class WindowedZarrLoader(TFDatasetLoader):
             dataset containing requested variables
         """
         # using tfdataset.cache(local_download_path)
-        ds = open_zarr(self.data_path)
+        ds = open_zarr_using_filecache(self.data_path)
 
         def records():
             n_times = ds.dims["time"]

--- a/external/fv3fit/fv3fit/emulation/data/load.py
+++ b/external/fv3fit/fv3fit/emulation/data/load.py
@@ -5,7 +5,7 @@ import xarray as xr
 from toolz.functoolz import compose_left
 from typing import Callable, Mapping, Optional, Sequence
 
-from fv3fit.tfdataset import seq_to_tfdataset
+from fv3fit.tfdataset import iterable_to_tfdataset
 from .transforms import open_netcdf_dataset
 from .io import get_nc_files
 
@@ -27,7 +27,7 @@ def nc_files_to_tf_dataset(
     """
 
     transform = compose_left(*[open_netcdf_dataset, convert])
-    return seq_to_tfdataset(files, transform).prefetch(tf.data.AUTOTUNE)
+    return iterable_to_tfdataset(files, transform).prefetch(tf.data.AUTOTUNE)
 
 
 def nc_dir_to_tfdataset(

--- a/external/fv3fit/fv3fit/tfdataset.py
+++ b/external/fv3fit/fv3fit/tfdataset.py
@@ -1,7 +1,16 @@
 from fv3fit._shared.config import SliceConfig
 from fv3fit._shared.packer import clip_sample
 import tensorflow as tf
-from typing import Hashable, Mapping, Dict, Callable, Optional, Sequence, Tuple
+from typing import (
+    Hashable,
+    Iterable,
+    Mapping,
+    Dict,
+    Callable,
+    Optional,
+    Sequence,
+    Tuple,
+)
 from toolz.functoolz import curry
 import loaders.typing
 
@@ -75,17 +84,16 @@ def get_Xy_dataset(
     return tf.data.Dataset.zip((X, y))
 
 
-def seq_to_tfdataset(
-    source: Sequence,
+def iterable_to_tfdataset(
+    source: Iterable,
     transform: Optional[Callable] = None,
     varying_first_dim: bool = False,
 ) -> tf.data.Dataset:
     """
-    A general function to convert from a sequence into a tensorflow dataset.
+    A general function to convert from an iterable into a tensorflow dataset.
 
     Args:
-        source: A sequence of data items to be included in the
-            dataset.
+        source: data items to be included in the dataset
         transform: function to process data items into a Mapping[str, tf.Tensor],
             if needed.
         varying_first_dim: if True, the first dimension of the produced tensors
@@ -131,6 +139,6 @@ def dataset_to_tensor_dict(ds):
 
 
 def tfdataset_from_batches(batches: loaders.typing.Batches) -> tf.data.Dataset:
-    return seq_to_tfdataset(
+    return iterable_to_tfdataset(
         batches, transform=dataset_to_tensor_dict, varying_first_dim=True
     )

--- a/external/fv3fit/tests/data/test_windowed_zarr.py
+++ b/external/fv3fit/tests/data/test_windowed_zarr.py
@@ -1,0 +1,124 @@
+from fv3fit.data import WindowedZarrLoader, VariableConfig
+import tempfile
+import xarray as xr
+import numpy as np
+import pytest
+import contextlib
+
+NX, NY, NZ, NT = 5, 5, 8, 40
+
+
+@contextlib.contextmanager
+def temporary_zarr_path():
+    dir = tempfile.TemporaryDirectory()
+
+    ds = xr.Dataset(
+        data_vars={
+            "a": xr.DataArray(
+                np.random.randn(NT, NX, NY, NZ), dims=["time", "x", "y", "z"]
+            ),
+            "a_sfc": xr.DataArray(np.random.randn(NT, NX, NY), dims=["time", "x", "y"]),
+            "b": xr.DataArray(
+                np.random.randn(NT, NX, NY, NZ), dims=["time", "x", "y", "z"]
+            ),
+            "c": xr.DataArray(
+                np.random.randn(NT, NX, NY, NZ), dims=["time", "x", "y", "z"]
+            ),
+        }
+    )
+    ds.to_zarr(dir.name)
+    yield dir.name
+
+
+@pytest.mark.parametrize(
+    "variable_names",
+    [pytest.param(["a"], id="one_var"), pytest.param(["b", "c"], id="two_vars")],
+)
+def test_loader_gets_requested_variables(variable_names: str):
+    with temporary_zarr_path() as data_path:
+        loader = WindowedZarrLoader(
+            data_path=data_path,
+            window_size=10,
+            unstacked_dims=["time", "z"],
+            default_variable_config=VariableConfig(times="window"),
+            variable_configs={},
+            batch_size=1,
+        )
+        dataset = loader.get_data(
+            local_download_path=None, variable_names=variable_names
+        )
+        item = next(iter(dataset))
+        assert set(item.keys()) == set(variable_names)
+
+
+def test_loader_stacks_default_config():
+    variable_names = ["a", "a_sfc"]
+    batch_size = 1
+    with temporary_zarr_path() as data_path:
+        loader = WindowedZarrLoader(
+            data_path=data_path,
+            window_size=10,
+            unstacked_dims=["time", "z"],
+            default_variable_config=VariableConfig(times="window"),
+            variable_configs={},
+            batch_size=batch_size,
+        )
+        dataset = loader.get_data(
+            local_download_path=None, variable_names=variable_names
+        )
+        item = next(iter(dataset))
+        assert item["a"].shape[0] == batch_size
+        assert len(item["a"].shape) == 3
+        assert item["a"].shape[-1] == NZ
+        assert item["a_sfc"].shape[0] == batch_size
+        assert len(item["a_sfc"].shape) == 2
+
+
+def test_loader_stacks_default_config_without_stacked_dims():
+    """
+    Special case where all dimensions are included in unstacked_dims, relevant
+    because a "sample" dimension may or may not be created in this case.
+    """
+    variable_names = ["a", "a_sfc"]
+    batch_size = 1
+    window_size = 10
+    with temporary_zarr_path() as data_path:
+        loader = WindowedZarrLoader(
+            data_path=data_path,
+            window_size=10,
+            unstacked_dims=["time", "x", "y", "z"],
+            default_variable_config=VariableConfig(times="window"),
+            variable_configs={},
+            batch_size=batch_size,
+        )
+        dataset = loader.get_data(
+            local_download_path=None, variable_names=variable_names
+        )
+        item = next(iter(dataset))
+        assert item["a"].shape == [batch_size, window_size, NX, NY, NZ]
+        assert item["a_sfc"].shape == [batch_size, window_size, NX, NY]
+
+
+def test_loader_handles_window_start():
+    """
+    Special case where all dimensions are included in unstacked_dims, relevant
+    because a "sample" dimension may or may not be created in this case.
+    """
+    variable_names = ["a", "a_sfc"]
+    batch_size = 1
+    window_size = 10
+    with temporary_zarr_path() as data_path:
+        loader = WindowedZarrLoader(
+            data_path=data_path,
+            window_size=10,
+            unstacked_dims=["time", "x", "y", "z"],
+            default_variable_config=VariableConfig(times="window"),
+            variable_configs={"a_sfc": VariableConfig(times="start")},
+            batch_size=batch_size,
+        )
+        dataset = loader.get_data(
+            local_download_path=None, variable_names=variable_names
+        )
+        item = next(iter(dataset))
+        assert item["a"].shape == [batch_size, window_size, NX, NY, NZ]
+        assert item["a_sfc"].shape == [batch_size, NX, NY]

--- a/external/fv3fit/tests/test_tfdataset_ops.py
+++ b/external/fv3fit/tests/test_tfdataset_ops.py
@@ -218,7 +218,7 @@ def test__seq_to_tfdataset():
         out["a"] = out["a"] * 2
         return out
 
-    tf_ds = fv3fit.tfdataset.seq_to_tfdataset(batches, transform)
+    tf_ds = fv3fit.tfdataset.iterable_to_tfdataset(batches, transform)
     assert isinstance(tf_ds, tf.data.Dataset)
 
     result = next(tf_ds.as_numpy_iterator())


### PR DESCRIPTION
This PR implements WindowedZarrLoader which was added unimplemented by #1913.

Added public API:
- implemented WindowedZarrLoader, and added to top level namespace

Refactored public API:
- renamed `seq_to_tfdataset` to `iterable_to_tfdataset`, since it operates on iterables, and it is now used on an iterable

- [ ] Tests added

Coverage reports (updated automatically):
