### PR TITLE
Enable specifying `patch_files` in prognostic run configs

### DIFF
--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -5,7 +5,7 @@ import yaml
 import logging
 import sys
 from datetime import datetime, timedelta
-from typing import Any, Callable, Mapping, Sequence, Optional, TypeVar, Union
+from typing import Any, Callable, List, Mapping, Sequence, Optional, TypeVar, Union
 
 import dacite
 
@@ -59,6 +59,7 @@ class FV3Config:
     forcing: Any = None
     orographic_forcing: Any = None
     gfs_analysis_data: Any = None
+    patch_files: List = dataclasses.field(default_factory=list)
 
     def asdict(self):
         dict_ = dataclasses.asdict(self)
@@ -143,6 +144,7 @@ class HighLevelConfig(UserConfig, FV3Config):
             forcing=self.forcing,
             orographic_forcing=self.orographic_forcing,
             gfs_analysis_data=self.gfs_analysis_data,
+            patch_files=self.patch_files,
         )
 
     def to_runtime_config(self) -> UserConfig:

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -434,6 +434,7 @@ online_emulator:
   online: false
   train: true
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files: []
 prephysics: null
 scikit_learn: null
 tendency_prescriber: null

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -436,6 +436,7 @@ online_emulator:
   url:
   - some/path
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files: []
 prephysics: null
 scikit_learn: null
 tendency_prescriber: null

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
@@ -464,6 +464,12 @@ namelist:
 nudging: null
 online_emulator: null
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files:
+- copy_method: copy
+  source_location: gs://patch-file
+  source_name: patch.nc
+  target_location: INPUT/
+  target_name: patch.nc
 prephysics: null
 scikit_learn:
   diagnostic_ml: false

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
@@ -473,6 +473,7 @@ nudging:
     y_wind: 12
 online_emulator: null
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files: []
 prephysics: null
 scikit_learn: null
 tendency_prescriber: null

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2o].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2o].out
@@ -460,6 +460,7 @@ namelist:
 nudging: null
 online_emulator: null
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files: []
 prephysics: null
 scikit_learn: null
 tendency_prescriber: null

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/prognostic_config.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/prognostic_config.yml
@@ -20,3 +20,9 @@ namelist:
 scikit_learn:
   model:
   - gs://ml-model
+patch_files:
+- copy_method: copy
+  source_location: gs://patch-file
+  source_name: patch.nc
+  target_location: INPUT/
+  target_name: patch.nc


### PR DESCRIPTION
This PR enables specifying `patch_files` in prognostic run configs.

- [x] Tests added

Resolves #1919

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/fb34b2ce-94e5-4996-81cb-05efa1ee798a/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)