### PR TITLE
Add test to ensure outputs not added to input variables

### DIFF
--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -13,6 +13,7 @@ from fv3fit.emulation.losses import CustomLoss
 from fv3fit.emulation.models import MicrophysicsConfig
 from fv3fit.emulation.zhao_carr_fields import Field
 from fv3fit.emulation.transforms import GscondRoute
+from fv3fit.emulation.flux.transforms import TendencyToFlux
 from fv3fit.train_microphysics import (
     TrainConfig,
     TransformedParameters,
@@ -216,3 +217,14 @@ def test_TrainConfig_inputs_routed():
     assert "air_temperature_after_gscond" not in config.input_variables
     assert "specific_humidity_after_gscond" not in config.input_variables
     assert "cloud_water_mixing_ratio_after_gscond" not in config.input_variables
+
+
+def test_TrainConfig_input_variables_dont_include_model_output():
+    transform = TendencyToFlux("Q2", "Q2_flux", "precip", "evap", "delp")
+    config = TrainConfig(
+        tensor_transform=[transform],
+        model=MicrophysicsConfig(
+            input_variables=["air_temp", "evap"], direct_out_variables=["Q2"]
+        ),
+    )
+    assert "Q2" not in config.input_variables


### PR DESCRIPTION
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
