### PR TITLE
OCSVM novelty detector

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -434,7 +434,6 @@ class MinMaxNoveltyDetectorHyperparameters(Hyperparameters):
     """
 
     input_variables: List[str]
-    # cutoff: Union[int, float] = 0
     packer_config: PackerConfig = dataclasses.field(
         default_factory=lambda: PackerConfig({})
     )
@@ -447,6 +446,42 @@ class MinMaxNoveltyDetectorHyperparameters(Hyperparameters):
     def init_testing(
         cls, input_variables, output_variables
     ) -> "MinMaxNoveltyDetectorHyperparameters":
+        """Initialize a default instance for a given input/output problem"""
+        hyperparameters = cls(input_variables=input_variables)
+        return hyperparameters
+
+
+@dataclasses.dataclass
+class OCSVMNoveltyDetectorHyperparameters(Hyperparameters):
+    """
+    Configuration for training an OCSVM detection algorithm with an RBF kernel. See
+    https://scikit-learn.org/stable/modules/generated/sklearn.svm.OneClassSVM.html
+    for a discussion of some parameters for the sklearn model.
+
+    Args:
+        input_variables: names of variables to use as inputs.
+        packer_config: configuration of dataset packing.
+        gamma: kernel coefficient, default = 1 / #features
+        nu: fraction of training samples as support vectors, default = 0.1
+        max_iter: maximum number of iterations to convergence, default = -1 (unlimited)
+    """
+
+    input_variables: List[str]
+    packer_config: PackerConfig = dataclasses.field(
+        default_factory=lambda: PackerConfig({})
+    )
+    gamma: Union[int, float, str] = "auto"
+    nu: float = 0.1
+    max_iter: int = -1
+
+    @property
+    def variables(self) -> Set[str]:
+        return set(self.input_variables)
+
+    @classmethod
+    def init_testing(
+        cls, input_variables, output_variables
+    ) -> "OCSVMNoveltyDetectorHyperparameters":
         """Initialize a default instance for a given input/output problem"""
         hyperparameters = cls(input_variables=input_variables)
         return hyperparameters

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -471,7 +471,7 @@ class OCSVMNoveltyDetectorHyperparameters(Hyperparameters):
         default_factory=lambda: PackerConfig({})
     )
     gamma: Union[float, str] = "auto"
-    nu: float = 0.1
+    nu: float = 0.01
     max_iter: int = -1
 
     @property

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -470,7 +470,7 @@ class OCSVMNoveltyDetectorHyperparameters(Hyperparameters):
     packer_config: PackerConfig = dataclasses.field(
         default_factory=lambda: PackerConfig({})
     )
-    gamma: Union[int, float, str] = "auto"
+    gamma: Union[float, str] = "auto"
     nu: float = 0.1
     max_iter: int = -1
 

--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -25,9 +25,15 @@ class NoveltyDetector(Predictor, abc.ABC):
         super().__init__(input_variables, output_variables)
 
     def predict_novelties(
-        self, X: xr.Dataset, cutoff: Union[float, int] = 0
+        self, X: xr.Dataset, cutoff: Union[float, int] = None
     ) -> xr.Dataset:
+        if cutoff is None:
+            cutoff = self._get_default_cutoff()
         score_dataset = self.predict(X)
         is_novelty = xr.where(score_dataset[self._SCORE_OUTPUT_VAR] > cutoff, 1, 0)
         score_dataset[self._NOVELTY_OUTPUT_VAR] = is_novelty
         return score_dataset
+
+    @abc.abstractmethod
+    def _get_default_cutoff(self):
+        pass

--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Hashable, Iterable, Union
+from typing import Hashable, Iterable, Optional
 from fv3fit._shared.predictor import Predictor
 import xarray as xr
 
@@ -25,7 +25,7 @@ class NoveltyDetector(Predictor, abc.ABC):
         super().__init__(input_variables, output_variables)
 
     def predict_novelties(
-        self, X: xr.Dataset, cutoff: Union[float, int] = None
+        self, X: xr.Dataset, cutoff: Optional[float] = None
     ) -> xr.Dataset:
         if cutoff is None:
             cutoff = self._get_default_cutoff()

--- a/external/fv3fit/fv3fit/sklearn/__init__.py
+++ b/external/fv3fit/fv3fit/sklearn/__init__.py
@@ -1,1 +1,1 @@
-from . import _random_forest
+from . import _random_forest, _min_max_novelty_detector, _ocsvm_novelty_detector

--- a/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
@@ -24,6 +24,7 @@ import logging
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler
 import tensorflow as tf
+from vcm import safe
 import xarray as xr
 import yaml
 
@@ -116,10 +117,9 @@ class MinMaxNoveltyDetector(NoveltyDetector):
         return match_prediction_to_input_coords(data, score_dataset)
 
     def predict_pre_aggregation(self, data: xr.Dataset):
-        stack_dims = [dim for dim in data.dims if dim not in stacking.Z_DIM_NAMES]
-        stacked_data = data.stack({SAMPLE_DIM_NAME: stack_dims})
-        stacked_data = stacked_data.transpose(SAMPLE_DIM_NAME, ...)
-
+        stacked_data = stacking.stack_non_vertical(
+            safe.get_variables(data, self.input_variables)
+        )
         X, _ = pack(
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
         )

--- a/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_min_max_novelty_detector.py
@@ -85,6 +85,9 @@ class MinMaxNoveltyDetector(NoveltyDetector):
         model.is_trained = True
         return model
 
+    def _get_default_cutoff(self):
+        return 0
+
     def predict(self, data: xr.Dataset) -> xr.Dataset:
         """
         For each coordinate c, computes a score with the following expression:
@@ -120,7 +123,6 @@ class MinMaxNoveltyDetector(NoveltyDetector):
         X, _ = pack(
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
         )
-        stacked_data.coords
         return self.scaler.transform(X), stacked_data.coords
 
     def dump(self, path: str) -> None:

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -22,6 +22,7 @@ from fv3fit.tfdataset import apply_to_mapping, ensure_nd
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import OneClassSVM
 import tensorflow as tf
+from vcm import safe
 import xarray as xr
 
 from fv3fit._shared.predictor import Predictor
@@ -119,9 +120,9 @@ class OCSVMNoveltyDetector(NoveltyDetector):
         start_time = time.time()
         self.logger.info(f"Predicting with OCSVM novelty detector.")
 
-        stack_dims = [dim for dim in data.dims if dim not in stacking.Z_DIM_NAMES]
-        stacked_data = data.stack({SAMPLE_DIM_NAME: stack_dims})
-        stacked_data = stacked_data.transpose(SAMPLE_DIM_NAME, ...)
+        stacked_data = stacking.stack_non_vertical(
+            safe.get_variables(data, self.input_variables)
+        )
 
         X, _ = pack(
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -2,7 +2,7 @@ import dataclasses
 import io
 import logging
 import time
-]import dacite
+import dacite
 import fsspec
 import joblib
 import numpy as np

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -1,0 +1,191 @@
+
+from curses import meta
+import dataclasses
+import io
+import logging
+import time
+from typing import Union
+import dacite
+import fsspec
+import joblib
+import numpy as np
+from sklearn import pipeline
+
+from sklearn.pipeline import Pipeline, make_pipeline
+import yaml
+from fv3fit import _shared, tfdataset
+from fv3fit._shared import stacking, SAMPLE_DIM_NAME
+from fv3fit._shared.config import OCSVMNoveltyDetectorHyperparameters, PackerConfig, register_training_function
+from fv3fit._shared.novelty_detector import NoveltyDetector
+from fv3fit._shared.packer import PackingInfo, clip_sample, pack, pack_tfdataset
+from fv3fit.tfdataset import apply_to_mapping, ensure_nd
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import OneClassSVM
+import tensorflow as tf
+import xarray as xr
+
+from fv3fit._shared.predictor import Predictor
+from fv3fit.typing import Batch
+
+
+@register_training_function("ocsvm_novelty_detector", OCSVMNoveltyDetectorHyperparameters)
+def train_ocsvm_novelty_detector(
+    hyperparameters: OCSVMNoveltyDetectorHyperparameters,
+    train_batches: tf.data.Dataset,
+    validation_batches: tf.data.Dataset,
+):
+    train_batches = train_batches.map(
+        tfdataset.apply_to_mapping(tfdataset.float64_to_float32)
+    )
+
+    return OCSVMNoveltyDetector.fit(train_batches, hyperparameters)
+
+@_shared.io.register("ocsvm")
+class OCSVMNoveltyDetector(NoveltyDetector):
+
+    _PICKLE_NAME = "ocsvm.pkl"
+    _METADATA_NAME = "metadata.bin"
+    logger = logging.getLogger("OCSVMNoveltyDetector")
+
+    input_features_: PackingInfo
+    is_trained: bool = False
+    maximum_training_score: float
+    pipeline: Pipeline
+
+    def __init__(self, hyperparameters: OCSVMNoveltyDetectorHyperparameters):
+        super().__init__(hyperparameters.input_variables)
+        self.packer_config = hyperparameters.packer_config
+        self.gamma = hyperparameters.gamma
+        self.nu = hyperparameters.nu
+        self.max_iter = hyperparameters.max_iter
+
+    @classmethod
+    def fit(
+        self,
+        batches: tf.data.Dataset,
+        hyperparameters: OCSVMNoveltyDetectorHyperparameters,
+    ) -> "OCSVMNoveltyDetector":
+        model = OCSVMNoveltyDetector(hyperparameters)
+
+        start_time = time.time()
+        model.logger.info(f"Fitting OCSVM novelty detector.")
+
+        batches = batches.map(apply_to_mapping(ensure_nd(2)))
+        batches_clipped = batches.map(clip_sample(model.packer_config.clip))
+        x_dataset, model.input_features_ = pack_tfdataset(
+            batches_clipped, [str(item) for item in model.input_variables]
+        )
+        x_dataset = x_dataset.unbatch()
+
+        total_samples = sum(1 for _ in iter(x_dataset))
+        X: Batch = next(iter(x_dataset.batch(total_samples)))
+
+        scaler = StandardScaler()
+        ocsvm = OneClassSVM(
+            kernel="rbf", gamma=model.gamma, nu=model.nu, max_iter=model.max_iter
+        )
+        model.pipeline = make_pipeline(scaler, ocsvm)
+        model.pipeline.fit(X)
+        
+        seconds = time.time() - start_time
+        model.logger.info(f"OCSVM novelty detector done fitting in {seconds}s.")
+
+        model._compute_max_score_train(X)
+        model.is_trained = True
+        return model
+
+    def _compute_max_score_train(self, X):
+        self.logger.info(f"Computing maximum scores on training data.")
+        start_time = time.time()
+
+        # We negate the scores to ensure that larger scores correspond to a higher
+        # likelihood of being an outlier
+        scores = -1 * self.pipeline.score_samples(X)
+        max_score = np.max(scores)
+        self.maximum_training_score = float(max_score)
+
+        seconds = time.time() - start_time
+        self.logger.info(f"Computed largest score of {max_score} in {seconds}s.")
+
+    def _get_default_cutoff(self):
+        return self.maximum_training_score
+
+    def predict(self, data: xr.Dataset) -> xr.Dataset:
+        assert self.is_trained
+
+        start_time = time.time()
+        self.logger.info(f"Predicting with OCSVM novelty detector.")
+
+
+        stack_dims = [dim for dim in data.dims if dim not in stacking.Z_DIM_NAMES]
+        stacked_data = data.stack({SAMPLE_DIM_NAME: stack_dims})
+        stacked_data = stacked_data.transpose(SAMPLE_DIM_NAME, ...)
+
+        X, _ = pack(
+            stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
+        )
+        stacked_scores = -1 * self.pipeline.score_samples(X)
+
+        new_coords = {
+            k: v for (k, v) in stacked_data.coords.items() if k not in stacking.Z_DIM_NAMES
+        }
+        stacked_scores = xr.DataArray(
+            stacked_scores, dims=[SAMPLE_DIM_NAME], coords=new_coords
+        )
+        score_dataset = stacked_scores.to_dataset(name=self._SCORE_OUTPUT_VAR).unstack(
+            SAMPLE_DIM_NAME
+        )
+        
+        seconds = time.time() - start_time
+        self.logger.info(f"Finished predicting with OCSVM novelty detector in {seconds}s.")
+
+        return stacking.match_prediction_to_input_coords(data, score_dataset)
+
+    def dump(self, path: str) -> None:
+        assert self.is_trained
+
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
+        fs.makedirs(path, exist_ok=True)
+
+        mapper = fs.get_mapper(path)
+
+        f = io.BytesIO()
+        joblib.dump({"pipeline": self.pipeline}, f)
+        mapper[self._PICKLE_NAME] = f.getvalue()
+
+        metadata = {
+            "input_variables": self.input_variables,
+            "packer_config": dataclasses.asdict(self.packer_config),
+            "input_features_": dataclasses.asdict(self.input_features_),
+            "gamma": self.gamma,
+            "nu": self.nu,
+            "max_iter": self.max_iter,
+            "maximum_training_score": self.maximum_training_score
+        }
+        print(metadata)
+        mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
+
+    @classmethod
+    def load(cls, path: str) -> "Predictor":
+        mapper = fsspec.get_mapper(path)
+        components = joblib.load(io.BytesIO(mapper[cls._PICKLE_NAME]))
+        metadata = yaml.safe_load(mapper[cls._METADATA_NAME])
+
+        hyperparameters = OCSVMNoveltyDetectorHyperparameters(
+            metadata["input_variables"]
+        )
+        obj = cls(hyperparameters)
+        obj.pipeline = components["pipeline"]
+        obj.input_features_ = dacite.from_dict(
+            PackingInfo, data=metadata["input_features_"]
+        )
+        obj.packer_config = dacite.from_dict(
+            PackerConfig, data=metadata.get("packer_config", {})
+        )
+        obj.gamma = metadata["gamma"]
+        obj.nu = metadata["nu"]
+        obj.max_iter = metadata["max_iter"]
+        obj.maximum_training_score = metadata["maximum_training_score"]
+        obj.is_trained = True
+
+        return obj

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -163,12 +163,8 @@ class OCSVMNoveltyDetector(NoveltyDetector):
             "input_variables": self.input_variables,
             "packer_config": dataclasses.asdict(self.packer_config),
             "input_features_": dataclasses.asdict(self.input_features_),
-            "gamma": self.gamma,
-            "nu": self.nu,
-            "max_iter": self.max_iter,
             "maximum_training_score": self.maximum_training_score,
         }
-        print(metadata)
         mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
 
     @classmethod
@@ -188,9 +184,6 @@ class OCSVMNoveltyDetector(NoveltyDetector):
         obj.packer_config = dacite.from_dict(
             PackerConfig, data=metadata.get("packer_config", {})
         )
-        obj.gamma = metadata["gamma"]
-        obj.nu = metadata["nu"]
-        obj.max_iter = metadata["max_iter"]
         obj.maximum_training_score = metadata["maximum_training_score"]
         obj.is_trained = True
 

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -7,6 +7,7 @@ from fv3fit.keras._models.convolutional import ConvolutionalHyperparameters
 from fv3fit.keras._models.shared.convolutional_network import ConvolutionalNetworkConfig
 from fv3fit.keras._models.shared.pure_keras import PureKerasModel
 import fv3fit.sklearn._min_max_novelty_detector
+import fv3fit.sklearn._ocsvm_novelty_detector
 import pytest
 import xarray as xr
 import numpy as np
@@ -31,15 +32,13 @@ REGRESSION_TRAINING_TYPES = [
 
 # unlabeled models that can be tested on all model configuration tests, but not those
 # that actually depend on the quality of supervised learning that occurs
-NON_REGRESSION_TRAINING_TYPES = ["min_max_novelty_detector"]
+NON_REGRESSION_TRAINING_TYPES = ["min_max_novelty_detector", "ocsvm_novelty_detector"]
 
 # training functions that have restrictions on the datasets they support,
 # cannot be used in generic tests below
 # you must write a separate file that specializes each of the tests
 # for models in this list
-SPECIAL_TRAINING_TYPES = [
-    "min_max_novelty_detector",
-]
+SPECIAL_TRAINING_TYPES = ["min_max_novelty_detector", "ocsvm_novelty_detector"]
 
 
 # automatically test on every registered training class


### PR DESCRIPTION
Creates a one-class SVM novelty detector, which was widely explored in an offline manner so far. This follows the blueprint created in [this PR](https://github.com/ai2cm/fv3net/pull/1908) and passes the same tests.

Significant internal changes:
- Added OCSVMNoveltyDetector, a Predictor that identifies out-of-sample points with sklearn's OneClassSVM. Implements the Novelty Detector Class.

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/14622f37-542e-4618-9a40-3d414c3a975d/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)