### PR TITLE
Out-of-sample Predictor class for masking a predictor with a novelty detector

### DIFF
--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Hashable, Iterable, Union
+from typing import Hashable, Iterable, Optional, Union
 from fv3fit._shared.predictor import Predictor
 import xarray as xr
 
@@ -25,7 +25,7 @@ class NoveltyDetector(Predictor, abc.ABC):
         super().__init__(input_variables, output_variables)
 
     def predict_novelties(
-        self, X: xr.Dataset, cutoff: Union[float, int] = 0
+        self, X: xr.Dataset, cutoff: Optional[Union[float, int]] = 0
     ) -> xr.Dataset:
         score_dataset = self.predict(X)
         is_novelty = xr.where(score_dataset[self._SCORE_OUTPUT_VAR] > cutoff, 1, 0)

--- a/external/fv3fit/fv3fit/testing.py
+++ b/external/fv3fit/fv3fit/testing.py
@@ -1,8 +1,12 @@
+import fsspec
 from fv3fit._shared import (
     stack_non_vertical,
     match_prediction_to_input_coords,
+    stacking,
 )
 from typing import Any, Dict, Hashable, Iterable, Mapping, Optional, Union
+
+from fv3fit._shared.novelty_detector import NoveltyDetector
 from ._shared import Predictor, io, SAMPLE_DIM_NAME
 import numpy as np
 import xarray as xr
@@ -108,4 +112,41 @@ class ConstantOutputPredictor(Predictor):
             if value.ndim == 0:
                 outputs[key] = value.item()
         obj.set_outputs(**outputs)
+        return obj
+
+
+@io.register("constant-output-novelty")
+class ConstantOutputNoveltyDetector(NoveltyDetector):
+    """
+    A simple novelty detector to be used in testing. Its score outputs are always 0
+    and its novelty assessment can be changed by adjusting the score.
+    """
+
+    def __init__(self, input_variables: Iterable[Hashable]):
+        super().__init__(input_variables=input_variables)
+
+    def predict(self, data: xr.Dataset) -> xr.Dataset:
+        scores_unreduced = xr.zeros_like(data[next(iter(self.input_variables))])
+        unnecessary_coords = {
+            k: v
+            for (k, v) in scores_unreduced.coords.items()
+            if k in stacking.Z_DIM_NAMES
+        }
+        scores_reduced = scores_unreduced.max(unnecessary_coords)
+        score_dataset = scores_reduced.to_dataset(name=self._SCORE_OUTPUT_VAR)
+        return score_dataset
+
+    def dump(self, path: str) -> None:
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
+        fs.makedirs(path, exist_ok=True)
+
+        with open(os.path.join(path, "attrs.yaml"), "w") as f:
+            yaml.safe_dump({"input_variables": self.input_variables}, f)
+
+    @classmethod
+    def load(cls, path: str) -> "ConstantOutputNoveltyDetector":
+        """Load a serialized model from a directory."""
+        with open(os.path.join(path, "attrs.yaml"), "r") as f:
+            attrs = yaml.safe_load(f)
+        obj = cls(**attrs)
         return obj

--- a/external/fv3fit/tests/test_out_of_sample.py
+++ b/external/fv3fit/tests/test_out_of_sample.py
@@ -1,0 +1,117 @@
+import tempfile
+import fv3fit
+from fv3fit._shared.config import RandomForestHyperparameters
+from fv3fit._shared.models import OutOfSampleModel
+import numpy as np
+import pytest
+import xarray as xr
+from fv3fit.tfdataset import tfdataset_from_batches
+from fv3fit.sklearn._random_forest import train_random_forest
+
+from tests.training.test_train import get_dataset, get_uniform_sample_func, regression_model_type, train_identity_model, unstack_test_dataset
+
+@pytest.mark.parametrize(
+    "base_value, novelty_cutoff, output",
+    [(1, -1, 0), (1, 1, 1)]
+)
+def test_out_of_sample_model(base_value, novelty_cutoff, output):
+    input_variables = ["input"]
+    output_variables = ["output"]
+    base_model = fv3fit.testing.ConstantOutputPredictor(input_variables, output_variables)
+    base_model.set_outputs(output=base_value)
+    novelty_detector = fv3fit.testing.ConstantOutputNoveltyDetector(input_variables)
+    oosModel = OutOfSampleModel(base_model, novelty_detector, novelty_cutoff)
+
+    ds_in = xr.Dataset(
+        data_vars={"input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"],)}
+    )
+    ds_out = oosModel.predict(ds_in)
+    assert len(ds_out.data_vars) == 1
+    assert "output" in ds_out.data_vars
+    np.testing.assert_almost_equal(ds_out["output"].values, output)
+
+
+@pytest.mark.parametrize(
+    "base_value, novelty_cutoff, output",
+    [(1, -1, 0), (1, 1, 1)]
+)
+def test_out_of_sample_model_different_inputs(base_value, novelty_cutoff, output):
+    base_input_variables = ["shared_input", "base_input"]
+    novelty_input_variables = ["shared_input", "novelty_input"]
+    output_variables = ["output"]
+    base_model = fv3fit.testing.ConstantOutputPredictor(base_input_variables, output_variables)
+    base_model.set_outputs(output=base_value)
+    novelty_detector = fv3fit.testing.ConstantOutputNoveltyDetector(novelty_input_variables)
+    oosModel = OutOfSampleModel(base_model, novelty_detector, novelty_cutoff)
+
+    ds_in = xr.Dataset(
+        data_vars= {
+            "shared_input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"],),
+            "base_input": xr.DataArray(np.ones([3, 3]), dims=["x", "y"],),
+            "novelty_input": xr.DataArray(np.ones([3, 3, 5]), dims=["x", "y", "z"],)
+        }
+    )
+    ds_out = oosModel.predict(ds_in)
+    assert len(ds_out.data_vars) == 1
+    assert "output" in ds_out.data_vars
+    np.testing.assert_almost_equal(ds_out["output"].values, output)
+
+
+@pytest.mark.slow
+def test_out_of_sample_identity_same_output_when_in_sample():
+    fv3fit.set_random_seed(1)
+    n_sample, n_tile, nx, ny, n_feature = 5, 6, 12, 12, 2
+    sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
+    regression_model_type = "sklearn_random_forest"
+    input_variables, output_variables, train_dataset = get_dataset(
+        regression_model_type, sample_func
+    )
+    _, _, test_dataset = get_dataset(regression_model_type, sample_func)
+
+    hyperparameters = RandomForestHyperparameters(input_variables, output_variables)
+    train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(10)])
+    val_tfdataset = tfdataset_from_batches([test_dataset])
+    test_dataset = unstack_test_dataset(test_dataset)
+    
+    base_model = train_random_forest(hyperparameters, train_tfdataset, val_tfdataset)
+
+    novelty_detector = fv3fit.testing.ConstantOutputNoveltyDetector(input_variables)
+    never_oos_model = OutOfSampleModel(base_model, novelty_detector, 1)
+    always_oos_model = OutOfSampleModel(base_model, novelty_detector, -1)
+
+    base_output = base_model.predict(test_dataset)
+    never_oos_output = never_oos_model.predict(test_dataset)
+    always_oos_output = always_oos_model.predict(test_dataset)
+    xr.testing.assert_equal(base_output, never_oos_output)
+    for output_variable in output_variables:
+        np.testing.assert_almost_equal(always_oos_output[output_variable].values, 0)
+
+
+@pytest.mark.slow
+def test_out_of_sample_dump_and_load_default_maintains_prediction():
+    fv3fit.set_random_seed(1)
+    n_sample, n_tile, nx, ny, n_feature = 5, 6, 12, 12, 2
+    sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
+    regression_model_type = "sklearn_random_forest"
+    input_variables, output_variables, train_dataset = get_dataset(
+        regression_model_type, sample_func
+    )
+    _, _, test_dataset = get_dataset(regression_model_type, sample_func
+    )
+    hyperparameters = RandomForestHyperparameters(input_variables, output_variables)
+    train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(10)])
+    val_tfdataset = tfdataset_from_batches([test_dataset])
+    test_dataset = unstack_test_dataset(test_dataset)
+    
+    base_model = train_random_forest(hyperparameters, train_tfdataset, val_tfdataset)
+    novelty_detector = fv3fit.testing.ConstantOutputNoveltyDetector(input_variables)
+    original_model = OutOfSampleModel(base_model, novelty_detector, 1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fv3fit.dump(original_model, tmpdir)
+        loaded_model = fv3fit.load(tmpdir)
+
+    original_result = original_model.predict(test_dataset)
+    loaded_result = loaded_model.predict(test_dataset)
+
+    xr.testing.assert_allclose(loaded_result, original_result, rtol=1e-4)


### PR DESCRIPTION
Creates a new `OutOfSamplePredictor` class, which combines a `Predictor` and a `NoveltyDetector` to a hybrid predictor that predicts 0 for a sample if deemed a novelty. This approach can use the new `MinMaxNoveltyDetector` and `OCSVMNoveltyDetector` from [these](https://github.com/ai2cm/fv3net/pull/1908) [two](https://github.com/ai2cm/fv3net/pull/1929) PRs.

Significant internal changes:
- New class `OutOfSamplePredictor` that implements `Predictor` and is defined analogously to `EnsemblePredictor`.

- [ ] New suite of tests to verify that the output is correct (unchanged if not novelty,  zero if novelty) on synthetic data and that `dump` and `load` functionality works properly.

Coverage reports (updated automatically):
