### PR TITLE
Offline diags: use proper zonal mean in zonal mean variance

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -372,7 +372,8 @@ for mask_type in ["global", "sea", "land"]:
         zonal_mean_interp = xr.Dataset()
         for var in zonal_mean:
             da = zonal_mean[var]
-            interp_func = interp1d(da.lat, da.transpose(..., "lat"))
+            # Ignore extrapolation errors for test case with randomized lat data
+            interp_func = interp1d(da.lat, da.transpose(..., "lat"), bounds_error=False)
             zonal_mean_interp[var] = xr.DataArray(
                 interp_func(grid.lat.transpose(*HORIZONTAL_DIMS)),
                 dims=("pressure", *HORIZONTAL_DIMS),


### PR DESCRIPTION
The offline diags had a bug where the mean being used in the zonally averaged variance calculation was the global mean, not the zonal avg mean. This inflates zonal average variance, which in turn inflates R^2. dQ2 at the poles is particularly affected due to its range across multiple orders of magnitude.

ex. before and after bug fix
![image](https://user-images.githubusercontent.com/16710132/178779832-6db32b33-670f-4ad4-88b4-082d6edde1ab.png)
![image](https://user-images.githubusercontent.com/16710132/178779917-01b242db-6ebb-4e0f-9c3c-4d8abfa7caa0.png)




Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/a73fede4-9b98-4bbb-9885-cf1f691f4587\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)