### PR TITLE
Emulation-clip-zero

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
       files: |
         (?x)^(
         external/vcm/vcm/.+ |
+        external/emulation/.+ |
         workflows/dataflow/fv3net/pipelines/restarts_to_zarr/.+ |
         workflows/prognostic_c48_run/.+ |
         workflows/prognostic_c48_run/tests/.+ |

--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import datetime
-from typing import Callable
+from typing import Callable, Optional, Set
 import cftime
 import gc
 
@@ -65,7 +65,7 @@ class MicrophysicsHook:
         """
 
         self.name = "microphysics emulator"
-        self.orig_outputs = None
+        self.orig_outputs: Optional[Set[str]] = None
         self.garbage_collection_interval = garbage_collection_interval
         self.mask = mask
         self._calls_since_last_collection = 0

--- a/external/emulation/emulation/_typing.py
+++ b/external/emulation/emulation/_typing.py
@@ -4,4 +4,5 @@ from typing import MutableMapping
 # expected dimensions of state field directly from call_py_fort
 # are [feature, sample] where sample is the flattened x,y dim
 FortranStateField = np.ndarray
-FortranState = MutableMapping[str, FortranStateField]
+# FortranState = MutableMapping[str, FortranStateField]
+FortranState = MutableMapping[str, np.ndarray]

--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -79,10 +79,7 @@ class ModelConfig:
             The physics is used for the first half of the interval, and the ML
             for the second half.
         ranges: post-hoc limits to apply to the predicted values
-        mask_emulator_levels:  levels to mask the emulator tendencies at. If
-            ``level_mask_value`` is None override the emulator tendencies with the
-            fortran physics tendencies for a specified level range. Otherwise
-            fill with ``level_mask_value``.
+        mask_emulator_levels:  levels to mask the emulator tendencies at.
         cloud_squash: all cloud values less than this amount (including
             negative values) will be squashed to zero.
         gscond_cloud_conservative: infer the gscond cloud from conservation via

--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 import logging
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import Iterable, Mapping, Optional, Tuple, Union
 import os
 
 import cftime
@@ -55,8 +55,17 @@ class Range:
 
 @dataclasses.dataclass
 class LevelSlice:
+    """
+
+    Attributes:
+        fill_value: how to fill the values between start and stop. If a float,
+            then fill with fill_value. If a string, then fill with the values from
+            ``truth[fill_value]``.
+    """
+
     start: Optional[int] = None
     stop: Optional[int] = None
+    fill_value: Union[float, str, None] = None
 
 
 @dataclasses.dataclass
@@ -70,8 +79,10 @@ class ModelConfig:
             The physics is used for the first half of the interval, and the ML
             for the second half.
         ranges: post-hoc limits to apply to the predicted values
-        mask_emulator_levels:  override the emulator tendencies with the fortran
-            physics tendencies for a specified level range.
+        mask_emulator_levels:  levels to mask the emulator tendencies at. If
+            ``level_mask_value`` is None override the emulator tendencies with the
+            fortran physics tendencies for a specified level range. Otherwise
+            fill with ``level_mask_value``.
         cloud_squash: all cloud values less than this amount (including
             negative values) will be squashed to zero.
         gscond_cloud_conservative: infer the gscond cloud from conservation via
@@ -151,7 +162,9 @@ class ModelConfig:
             yield emulation.zhao_carr.enforce_conservative_gscond
 
         for key, _slice in self.mask_emulator_levels.items():
-            yield LevelMask(key, start=_slice.start, stop=_slice.stop)
+            yield LevelMask(
+                key, start=_slice.start, stop=_slice.stop, fill_value=_slice.fill_value
+            )
 
 
 @dataclasses.dataclass

--- a/external/emulation/tests/test_mask.py
+++ b/external/emulation/tests/test_mask.py
@@ -28,3 +28,20 @@ def test_LevelMask(start, stop):
     num_fortran_elements = zeros[sl_].size
     np.testing.assert_array_equal(result["foo"][sl_], zeros[sl_])
     assert np.sum(result["foo"]) == result["foo"].size - num_fortran_elements
+
+
+def test_LevelMask_fill_value():
+    fill_value = 0.5
+    mask = LevelMask("foo", 0, 2, fill_value=fill_value)
+    ones = np.ones((4, 2))
+    result = mask(state={}, emulator={"foo": ones})
+    np.testing.assert_array_equal(fill_value, result["foo"][:2])
+
+
+def test_LevelMask_fill_value_string():
+    mask = LevelMask("foo", 0, 2, fill_value="a")
+    ones = np.ones((4, 2))
+
+    a = ones * 1.1
+    result = mask(state={"a": a}, emulator={"foo": ones})
+    np.testing.assert_array_equal(a[:2], result["foo"][:2])

--- a/projects/microphysics/argo/argo.yaml
+++ b/projects/microphysics/argo/argo.yaml
@@ -380,23 +380,3 @@ spec:
       operator: "Equal"
       value: "med-sim-pool"
       effect: "NoSchedule"
-  - name: end-to-end
-    steps:
-      - - name: train-model-gpu
-          template: train-model-gpu
-          arguments:
-            parameters:
-            - name: training-config
-              value: "{{workflow.parameters.training-config}}"
-            - name: flags
-              value: "{{workflow.parameters.flags}}"
-      - - name: prognostic-run
-          template: prognostic-run
-        - name: score-model
-          template: score-model
-          arguments:
-            parameters:
-            - name: training-config
-              value: "{{workflow.parameters.training-config}}"
-            - name: flags
-              value: "{{workflow.parameters.flags}}"

--- a/projects/microphysics/argo/end_to_end.py
+++ b/projects/microphysics/argo/end_to_end.py
@@ -3,7 +3,6 @@
 import argparse
 import base64
 import dataclasses
-import os
 import pathlib
 import subprocess
 import sys
@@ -14,7 +13,6 @@ import dacite
 import yaml
 
 from fv3net.artifacts.resolve_url import resolve_url
-from emulation.config import EmulationConfig, ModelConfig
 
 WORKFLOW_FILE = pathlib.Path(__file__).parent / "argo.yaml"
 
@@ -208,97 +206,6 @@ class TrainingJob:
     @property
     def entrypoint(self):
         return "training"
-
-
-def _insert_model_path_to_zhao_carr_config(
-    config: EmulationConfig, model_path: str, gscond_only: bool
-):
-
-    out = EmulationConfig.from_dict(dataclasses.asdict(config))
-    if gscond_only:
-        out.gscond.path = model_path
-    else:
-        out.model.path = model_path
-
-    return out
-
-
-@dataclasses.dataclass
-class EndToEndJob:
-    """A configuration for E2E training and prognostic
-
-    Currently only supports single model training + prognostic experiments
-
-    Notes:
-
-    A provided zhao_carr_config will override the gscond_conservative parameter.
-    If gscond only is true, then the model url will be inserted into the "gscond"
-    ModelConfig.  Otherwise, it is inserted into the "model" ModelConfig.
-
-    Examples:
-
-    A short configuration::
-
-        from end_to_end import EndToEndJob, load_yaml
-
-        job = EndToEndJob(
-            name="test-v5",
-            fv3fit_image_tag="d848e586db85108eb142863e600741621307502b",
-            image_tag="d848e586db85108eb142863e600741621307502b",
-            ml_config=load_yaml("../train/rnn.yaml"),
-            prog_config=load_yaml("../configs/default_short.yaml"),
-        )
-
-    """
-
-    name: str
-    ml_config: dict = dataclasses.field(repr=False)
-    prog_config: dict = dataclasses.field(repr=False)
-    fv3fit_image_tag: str
-    image_tag: str
-    bucket: str = "vcm-ml-experiments"
-    project: str = "microphysics-emulation"
-    gscond_only: bool = False
-    gscond_conservative: bool = False
-    zhao_carr_config: Optional[EmulationConfig] = None
-
-    @property
-    def entrypoint(self):
-        return "end-to-end"
-
-    @property
-    def parameters(self):
-        model_out_url = resolve_url(self.bucket, self.project, self.name)
-        assert model_out_url.startswith(
-            "gs://"
-        ), f"Must use a remote URL. Got {model_out_url}"
-
-        ml_config = deepcopy(self.ml_config)
-        ml_config["out_url"] = model_out_url
-
-        model_path = os.path.join(model_out_url, "model.tf")
-        config = deepcopy(self.prog_config)
-        config["namelist"]["gfs_physics_nml"]["emulate_gscond_only"] = self.gscond_only
-
-        if self.zhao_carr_config is None:
-            model_config = ModelConfig(
-                path=model_path, gscond_cloud_conservative=self.gscond_conservative
-            )
-            key = "gscond" if self.gscond_only else "model"
-            zc_config = EmulationConfig.from_dict({key: model_config})
-        else:
-            zc_config = _insert_model_path_to_zhao_carr_config(
-                self.zhao_carr_config, model_path, self.gscond_only
-            )
-
-        config["zhao_carr_emulation"] = dataclasses.asdict(zc_config)
-
-        return {
-            "training-config": _encode(ml_config),
-            "config": _encode(config),
-            "image_tag": self.image_tag,
-            "fv3fit_image_tag": self.fv3fit_image_tag,
-        }
 
 
 def _encode(dict):


### PR DESCRIPTION
Removes any emulator updates instead of "cheating" by looking up the true values.

I also added a command line tool `query-wandb.py reproduce` for grabbing ready-to-submit configurations from wandb. Currently it only supports the prognostic run.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/a2326983-3d96-48e8-a0db-420351abf6bd\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)