### PR TITLE
Emulation: score with transforms

### DIFF
--- a/projects/microphysics/scripts/score_training.py
+++ b/projects/microphysics/scripts/score_training.py
@@ -122,6 +122,9 @@ def main(config: TrainConfig, seed: int = 0, model_url: str = None):
     n = 80_000
     train_set = next(iter(train_ds.unbatch().shuffle(2 * n).batch(n)))
     test_set = next(iter(test_ds.unbatch().shuffle(2 * n).batch(n)))
+    transform = config.build_transform(train_set)
+    train_set = transform.forward(train_set)
+    test_set = transform.forward(test_set)
 
     summary_metrics = {}
     all_profiles = {}


### PR DESCRIPTION
Allows computing skill scores for transformed quantities like the precpd
differences.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/b44a725b-b5fc-46e1-b083-6d7c5bceb2a4\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)