### PR TITLE
query-wandby.py: reproduce training jobs

### DIFF
--- a/projects/microphysics/scripts/end_to_end.py
+++ b/projects/microphysics/scripts/end_to_end.py
@@ -18,6 +18,7 @@ from fv3net.artifacts.resolve_url import resolve_url
 WORKFLOW_FILE = pathlib.Path(__file__).parent.parent / "argo" / "argo.yaml"
 
 PROGNOSTIC = "prognostic"
+TRAIN = "train"
 
 
 def load_yaml(path):
@@ -220,6 +221,11 @@ class TrainingJob(ToYaml):
     def entrypoint(self):
         return "training"
 
+    def to_yaml(self):
+        d = dataclasses.asdict(self)
+        d["kind"] = TRAIN
+        return yaml.safe_dump(d)
+
 
 def _encode(dict):
     s = yaml.safe_dump(dict).encode()
@@ -245,6 +251,6 @@ if __name__ == "__main__":
         config_ = yaml.safe_load(f)
         name = config_.pop("kind")
         experiment = config_.pop("experiment", "default")
-        cls = {"train": TrainingJob, PROGNOSTIC: PrognosticJob}[name]
+        cls = {TRAIN: TrainingJob, PROGNOSTIC: PrognosticJob}[name]
         job = dacite.from_dict(cls, config_)
         submit_jobs([job], experiment_name=experiment)

--- a/projects/microphysics/scripts/query-wandb.py
+++ b/projects/microphysics/scripts/query-wandb.py
@@ -30,6 +30,17 @@ def wandb2job(run: Any) -> end_to_end.ToYaml:
             project="microphysics-emulation",
             bucket="vcm-ml-experiments",
         )
+    if run.job_type == "train":
+        config = dict(run.config)
+        env = config.pop("env")
+        sha = env["COMMIT_SHA"]
+        return end_to_end.TrainingJob(
+            name=run.name,
+            config=config,
+            fv3fit_image_tag=sha,
+            project="microphysics-emulation",
+            bucket="vcm-ml-experiments",
+        )
     else:
         raise NotImplementedError(f"{run.job_type} not implemented.")
 


### PR DESCRIPTION
This makes it easier to modify a given wandb training job and submit a new job.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/f2bfc9d9-a999-48d6-98d8-a0a20468c52a\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)