### PR TITLE
 improve performance of funcphys.py

### DIFF
--- a/external/radiation/.gitignore
+++ b/external/radiation/.gitignore
@@ -13,3 +13,4 @@ python/radlw/taugb10
 fortran/progcld4
 fortran/setaer
 python/forcing
+*.prof

--- a/external/radiation/python/funcphys.py
+++ b/external/radiation/python/funcphys.py
@@ -45,6 +45,7 @@ def fpvs(t):
     c2xpvs = 1.0 / xinc
     c1xpvs = 1.0 - xmin * c2xpvs
 
+    ## this line can be call only one time when initialized 
     tbpvs = np.array([ fpvsx(xmin + jx * xinc) for jx in range(nxpvs)])
     
     xj = np.minimum(np.maximum(c1xpvs + c2xpvs * t, 1.0), nxpvs)

--- a/external/radiation/python/funcphys.py
+++ b/external/radiation/python/funcphys.py
@@ -1,7 +1,6 @@
 import numpy as np
 from phys_const import *
 
-
 def fpvs(t):
     # $$$     Subprogram Documentation Block
     #
@@ -25,7 +24,8 @@ def fpvs(t):
     # Usage:   pvs=fpvs(t)
     #
     #   Input argument list:
-    #     t          Real(krealfp) temperature in Kelvin
+    #     t        2 dimensional array Real(krealfp) temperature in Kelvin
+    #              [npoints, nlevels]
     #
     #   Output argument list:
     #     fpvs       Real(krealfp) saturation vapor pressure in Pascals
@@ -45,17 +45,14 @@ def fpvs(t):
     c2xpvs = 1.0 / xinc
     c1xpvs = 1.0 - xmin * c2xpvs
 
-    for jx in range(nxpvs):
-        x = xmin + jx * xinc
-        tt = x
-        tbpvs[jx] = fpvsx(tt)
+    tbpvs = np.array([ fpvsx(xmin + jx * xinc) for jx in range(nxpvs)])
+    
+    xj = np.minimum(np.maximum(c1xpvs + c2xpvs * t, 1.0), nxpvs)
+    jx = np.minimum(xj, nxpvs - 1).astype('int')
 
-    xj = min(max(c1xpvs + c2xpvs * t, 1.0), nxpvs)
-    jx = int(min(xj, nxpvs - 1))
     fpvs = tbpvs[jx - 1] + (xj - jx) * (tbpvs[jx] - tbpvs[jx - 1])
 
     return fpvs
-
 
 def fpvsx(t):
     # $$$     Subprogram Documentation Block

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -443,27 +443,19 @@ class RadiationDriver:
             lsk = LEVS - LM
 
         #           convert pressure unit from pa to mb
-        for k in range(LM):
-            k1 = k + kd
-            k2 = k + lsk
-            for i in range(IM):
-                plvl[i, k1 + kb] = Statein["prsi"][i, k2 + kb] * 0.01  # pa to mb (hpa)
-                plyr[i, k1] = Statein["prsl"][i, k2] * 0.01  # pa to mb (hpa)
-                tlyr[i, k1] = Statein["tgrs"][i, k2]
-                prslk1[i, k1] = Statein["prslk"][i, k2]
+        k1 = np.arange(LM) + kd
+        k2 = np.arange(LM) + lsk
+        #for i in range(IM):
+        plvl[:, k1 + kb] = Statein["prsi"][:, k2 + kb] * 0.01  # pa to mb (hpa)
+        plyr[:, k1] = Statein["prsl"][:, k2] * 0.01  # pa to mb (hpa)
+        tlyr[:, k1] = Statein["tgrs"][:, k2]
+        prslk1[:, k1] = Statein["prslk"][:, k2]
 
-                #  - Compute relative humidity.
-                es = min(
-                    Statein["prsl"][i, k2], fpvs(Statein["tgrs"][i, k2])
-                )  # fpvs and prsl in pa
-                qs = max(
-                    self.QMIN, con_eps * es / (Statein["prsl"][i, k2] + con_epsm1 * es)
-                )
-                rhly[i, k1] = max(
-                    0.0, min(1.0, max(self.QMIN, Statein["qgrs"][i, k2, 0]) / qs)
-                )
-                qstl[i, k1] = qs
-
+        #  - Compute relative humidity.
+        es = np.minimum(Statein["prsl"][:, k2], fpvs(Statein["tgrs"][:, k2]))  # fpvs and prsl in pa
+        qs = np.maximum(self.QMIN, con_eps * es / (Statein["prsl"][:, k2] + con_epsm1 * es))
+        rhly[:, k1] = np.maximum(0.0, np.minimum(1.0, np.maximum(self.QMIN, Statein["qgrs"][:, k2, 0]) / qs))
+        qstl[:, k1] = qs
         # --- recast remaining all tracers (except sphum) forcing them all to be positive
         for j in range(1, NTRAC):
             for k in range(LM):


### PR DESCRIPTION
Changes in funcphys:
- fpvs was modified to take 2D arrays 

Changes in radiation_driver:
- The section that uses fpvs was vectorized. 

Computing time is reduced from 205 to 51 seconds

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/d24b81d2-975e-40fd-bceb-0e255d761040\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)