### PR TITLE
Cloud ML: Rad port validated in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,7 @@ jobs:
           name: "Get data"
 #                       nix-shell --command "gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS"
           command: |
+            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
             nix-shell --command "cd external/radiation && ./get_data.sh"
       - run:
           name: "Validate radiation port"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,15 +215,17 @@ jobs:
           name: "gcloud auth"
           command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
       - run:
-          name: "Get data"
-          command: cd external/radiation && ./get_data.sh
-      - run:
           name: "Install nix and cachix"
           command: |
             sh <(curl -L https://nixos.org/nix/install) --no-daemon
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use vulcanclimatemodeling
+      - run:
+          name: "Get data"
+#                       nix-shell --command "gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS"
+          command: |
+            nix-shell --command "cd external/radiation && ./get_data.sh"
       - run:
           name: "Validate radiation port"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,7 @@ jobs:
           command: |
             sh <(curl -L https://nixos.org/nix/install) --no-daemon
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+            cd external/radiation
             nix-shell --command "cd python && python test_driver.py"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,6 @@ jobs:
           command: |
             sh <(curl -L https://nixos.org/nix/install) --no-daemon
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
-            nix-shell --help
       - gcp-cli/install
       - run:
           name: "gcloud auth"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,19 +214,19 @@ jobs:
     steps:
       - checkout
       - run:
-        name: "Install nix"
-        command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
+          name: "Install nix"
+          command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
       - gcp-cli/install
       - run:
-        name: "gcloud auth"
-        command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+          name: "gcloud auth"
+          command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
       - gcp-cli/initialize
       - run:
-        name: "Get data"
-        command: cd external/radiation && ./get_data.sh
+          name: "Get data"
+          command: cd external/radiation && ./get_data.sh
       - run:
-        name: "Validate rad port"
-        command: nix-shell --command "cd python && python test_driver.py"
+          name: "Validate rad port"
+          command: nix-shell --command "cd python && python test_driver.py"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,8 +221,12 @@ jobs:
           name: "Get data"
           command: cd external/radiation && ./get_data.sh
       - run:
-          name: "Install nix"
-          command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
+          name: "Install nix and cachix"
+          command: |
+            sh <(curl -L https://nixos.org/nix/install) --no-daemon
+            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+            nix-env -iA cachix -f https://cachix.org/api/v1/install
+            cachix use vulcanclimatemodeling
       - run:
           name: "Validate radiation port"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,9 @@ jobs:
       - checkout
       - run:
           name: "Install nix"
-          command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
+          command: |
+            sh <(curl -L https://nixos.org/nix/install) --no-daemon
+            . ~/.nix-profile/etc/profile.d/nix.sh
       - gcp-cli/install
       - run:
           name: "gcloud auth"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,8 +225,9 @@ jobs:
           name: "Get data"
 #                       nix-shell --command "gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS"
           command: |
+            cd external/radiation
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
-            nix-shell --command "cd external/radiation && ./get_data.sh"
+            nix-shell --command "./get_data.sh"
       - run:
           name: "Validate radiation port"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,11 +222,11 @@ jobs:
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use vulcanclimatemodeling
       - run:
-          name: "Get data"
-#                       nix-shell --command "gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS"
+          name: "Get data"         
           command: |
             cd external/radiation
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+            nix-shell --command "gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS"
             nix-shell --command "./get_data.sh"
       - run:
           name: "Validate radiation port"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,8 @@ jobs:
           name: "Install nix"
           command: |
             sh <(curl -L https://nixos.org/nix/install) --no-daemon
-            . ~/.nix-profile/etc/profile.d/nix.sh
+            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+            nix-shell --help
       - gcp-cli/install
       - run:
           name: "gcloud auth"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.0
+  gcp-cli: circleci/gcp-cli@2.4.1
   slack: circleci/slack@3.4.2
   gh: circleci/github-cli@2.1.0
   jq: circleci/jq@2.2.0
@@ -202,6 +203,32 @@ jobs:
       - slack/status:
           fail_only: true
           mentions: "channel"
+
+  validate_rad_port:
+    machine:
+      image: ubuntu-2004:202111-02
+    environment:
+      GOOGLE_PROJECT_ID: vcm-ml
+#       GOOGLE_COMPUTE_ZONE: us-central1
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+    steps:
+      - checkout
+      - run:
+        name: "Install nix"
+        command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
+      - gcp-cli/install
+      - run:
+        name: "gcloud auth"
+        command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+      - gcp-cli/initialize
+      - run:
+        name: "Get data"
+        command: cd external/radiation && ./get_data.sh
+      - run:
+        name: "Validate rad port"
+        command: nix-shell --command "cd python && python test_driver.py"
+
+
 workflows:
   version: 2
   test_and_lint:
@@ -274,3 +301,4 @@ workflows:
               only: /^v.*/
             branches:
               only: master
+      - validate_rad_port

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   slack: circleci/slack@3.4.2
   gh: circleci/github-cli@2.1.0
   jq: circleci/jq@2.2.0
-  nix: eld/nix@1.0.0
 jobs:
   pytest:
     parameters:
@@ -213,18 +212,20 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - checkout
-      - nix/install
       - gcp-cli/install
       - run:
           name: "gcloud auth"
           command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
       - gcp-cli/initialize
       - run:
-          name: "Validate radiation port"
-          command: nix-shell --command "cd python && python test_driver.py"
-      - run:
           name: "Get data"
           command: cd external/radiation && ./get_data.sh
+      - run:
+          name: "Validate radiation port"
+          command: |
+            sh <(curl -L https://nixos.org/nix/install) --no-daemon
+            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+            nix-shell --command "cd python && python test_driver.py"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,11 +221,13 @@ jobs:
           name: "Get data"
           command: cd external/radiation && ./get_data.sh
       - run:
+          name: "Install nix"
+          command: sh <(curl -L https://nixos.org/nix/install) --no-daemon
+      - run:
           name: "Validate radiation port"
           command: |
-            sh <(curl -L https://nixos.org/nix/install) --no-daemon
-            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
             cd external/radiation
+            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
             nix-shell --command "cd python && python test_driver.py"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use vulcanclimatemodeling
       - run:
-          name: "Get data"         
+          name: "Get data"
           command: |
             cd external/radiation
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.0
-  gcp-cli: circleci/gcp-cli@2.4.1
   slack: circleci/slack@3.4.2
   gh: circleci/github-cli@2.1.0
   jq: circleci/jq@2.2.0
@@ -212,11 +211,9 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - checkout
-      - gcp-cli/install
       - run:
           name: "gcloud auth"
           command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-      - gcp-cli/initialize
       - run:
           name: "Get data"
           command: cd external/radiation && ./get_data.sh
@@ -233,7 +230,6 @@ jobs:
             cd external/radiation
             . /home/circleci/.nix-profile/etc/profile.d/nix.sh
             nix-shell --command "cd python && python test_driver.py"
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
   slack: circleci/slack@3.4.2
   gh: circleci/github-cli@2.1.0
   jq: circleci/jq@2.2.0
+  nix: eld/nix@1.0.0
 jobs:
   pytest:
     parameters:
@@ -204,31 +205,26 @@ jobs:
           fail_only: true
           mentions: "channel"
 
-  validate_rad_port:
+  validate_radiation_port:
     machine:
       image: ubuntu-2004:202111-02
     environment:
       GOOGLE_PROJECT_ID: vcm-ml
-#       GOOGLE_COMPUTE_ZONE: us-central1
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - checkout
-      - run:
-          name: "Install nix"
-          command: |
-            sh <(curl -L https://nixos.org/nix/install) --no-daemon
-            . /home/circleci/.nix-profile/etc/profile.d/nix.sh
+      - nix/install
       - gcp-cli/install
       - run:
           name: "gcloud auth"
           command: echo $ENCODED_GOOGLE_CREDENTIALS | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
       - gcp-cli/initialize
       - run:
+          name: "Validate radiation port"
+          command: nix-shell --command "cd python && python test_driver.py"
+      - run:
           name: "Get data"
           command: cd external/radiation && ./get_data.sh
-      - run:
-          name: "Validate rad port"
-          command: nix-shell --command "cd python && python test_driver.py"
 
 
 workflows:
@@ -303,4 +299,4 @@ workflows:
               only: /^v.*/
             branches:
               only: master
-      - validate_rad_port
+      - validate_radiation_port

--- a/external/radiation/get_data.sh
+++ b/external/radiation/get_data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p fortran  
 if [ ! -z "$IS_DOCKER" ] ; then
     echo "This script cannot be run in the Docker image"
@@ -20,7 +22,7 @@ else
     fi
 
     if [ -z "$(ls -A ./fortran/data/LW)" ]; then
-        gsutil cp -r gs://vcm-fv3gfs-serialized-regression-data/physics/fv3gfs-fortran-output/lwrad/* ./fortran/data/LW/.
+        gsutil -m cp -r gs://vcm-fv3gfs-serialized-regression-data/physics/fv3gfs-fortran-output/lwrad/* ./fortran/data/LW/.
         cd ./fortran/data/LW
         tar -xzvf data.tar.gz
         cd $MYHOME
@@ -29,7 +31,7 @@ else
     fi
 
     if [ -z "$(ls -A ./fortran/data/SW)" ]; then
-        gsutil cp -r gs://vcm-fv3gfs-serialized-regression-data/physics/fv3gfs-fortran-output/swrad/* ./fortran/data/SW/.
+        gsutil -m cp -r gs://vcm-fv3gfs-serialized-regression-data/physics/fv3gfs-fortran-output/swrad/* ./fortran/data/SW/.
         cd ./fortran/data/SW
         tar -xzvf data.tar.gz
         cd $MYHOME
@@ -51,23 +53,21 @@ else
     fi
 
     if [ ! -d "./fortran/radlw/dump" ]; then
-        cd ./fortran/radlw
-        mkdir dump
+        mkdir -p ./fortran/radlw/dump
         cd $MYHOME
     else
         echo "LW standalone output directory already exists"
     fi
 
     if [ ! -d "./fortran/radsw/dump" ]; then
-        cd ./fortran/radsw
-        mkdir dump
+        mkdir -p ./fortran/radsw/dump
         cd $MYHOME
     else
         echo "SW standalone output directory already exists"
     fi
 
     if [ -z "$(ls -A ./fortran/radlw/dump)" ]; then
-        gsutil cp gs://vcm-fv3gfs-serialized-regression-data/physics/standalone-output/lwrad/* ./fortran/radlw/dump/.
+        gsutil -m cp gs://vcm-fv3gfs-serialized-regression-data/physics/standalone-output/lwrad/* ./fortran/radlw/dump/.
         cd ./fortran/radlw/dump
         tar -xzvf data.tar.gz
         cd $MYHOME
@@ -76,7 +76,7 @@ else
     fi
 
     if [ -z "$(ls -A ./fortran/radsw/dump)" ]; then
-        gsutil cp gs://vcm-fv3gfs-serialized-regression-data/physics/standalone-output/swrad/* ./fortran/radsw/dump/.
+        gsutil -m cp gs://vcm-fv3gfs-serialized-regression-data/physics/standalone-output/swrad/* ./fortran/radsw/dump/.
         cd ./fortran/radsw/dump
         tar -xzvf data.tar.gz
         cd $MYHOME
@@ -102,7 +102,7 @@ else
     fi
 
     if [ -z "$(ls -A ./python/forcing)" ]; then
-	    gsutil cp gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/* ./python/forcing/.
+	    gsutil -m cp gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/* ./python/forcing/.
 	    cd ./python/forcing
 	    tar -xzvf data.tar.gz
         cd $MYHOME

--- a/external/radiation/python/test_driver.py
+++ b/external/radiation/python/test_driver.py
@@ -4,6 +4,9 @@ from config import *
 from util import compare_data
 import serialbox as ser
 from radiation_driver import RadiationDriver
+import time
+
+startTime = time.time()
 
 rank = 0
 driver = RadiationDriver()
@@ -85,7 +88,9 @@ slag, sdec, cdec, solcon = driver.radupdate(
     updatedict["lsswr"],
 )
 
-for rank in range(6):
+columns_validated = 0
+
+for rank in range(1):
     serializer = ser.Serializer(
         ser.OpenModeKind.Read,
         "../fortran/data/radiation_driver",
@@ -313,3 +318,9 @@ for rank in range(6):
             outdict[var] = Diagout[var]
 
     compare_data(valdict, outdict)
+    
+    columns_validated += valdict[radtend_vars_out[0]].shape[0]
+
+executionTime = (time.time() - startTime)
+
+print(f'Execution time: {executionTime:.2f} seconds for {columns_validated} columns.')

--- a/external/radiation/python/test_driver.py
+++ b/external/radiation/python/test_driver.py
@@ -90,7 +90,7 @@ slag, sdec, cdec, solcon = driver.radupdate(
 
 columns_validated = 0
 
-for rank in range(1):
+for rank in range(6):
     serializer = ser.Serializer(
         ser.OpenModeKind.Read,
         "../fortran/data/radiation_driver",

--- a/external/radiation/shell.nix
+++ b/external/radiation/shell.nix
@@ -17,7 +17,7 @@ in pkgs.mkShell {
     pkgs.python38Packages.numpy
     pkgs.python38Packages.netcdf4
     pkgs.python38Packages.ipython
-
+    pkgs.google-cloud-sdk
   ];
   shellHook = ''
     export PYTHONPATH=${pkgs.serialbox}/python:$PYTHONPATH


### PR DESCRIPTION
Puts validation of the Python radiation port with the example dataset in CI. See example [output](https://app.circleci.com/pipelines/github/ai2cm/fv3net/12498/workflows/c46e4dba-40f3-4c8b-98e4-effbacee9b8a/jobs/112867/parallel-runs/0/steps/0-109).

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/1d37714c-3ab9-4193-a0ec-822f34ca25c4/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)