### PR TITLE
Add vertically integrated tracer diagnostics

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
@@ -1,0 +1,17 @@
+from typing import Mapping
+
+import fv3gfs.wrapper
+import vcm
+import xarray
+from runtime.names import DELP
+
+
+def compute_column_integrated_tracers(state: Mapping[str, xarray.DataArray]) -> dict:
+    out = {}
+    tracers = fv3gfs.wrapper.get_tracer_metadata()
+    for tracer in tracers:
+        path = vcm.mass_integrate(state[tracer], state[DELP], dim="z").assign_attrs(
+            description=f"column integrated {tracer}"
+        )
+        out[tracer + "_path"] = path
+    return out

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -30,6 +30,7 @@ from runtime.diagnostics.compute import (
     precipitation_accumulation,
     rename_diagnostics,
 )
+import runtime.diagnostics.tracers
 from runtime.monitor import Monitor
 from runtime.names import (
     TENDENCY_TO_STATE_NAME,
@@ -535,6 +536,9 @@ class TimeLoop(
         for i in range(self._fv3gfs.get_step_count()):
             diagnostics: Diagnostics = {}
             for substep in [
+                lambda: runtime.diagnostics.tracers.compute_column_integrated_tracers(
+                    self._state
+                ),
                 self.monitor("dynamics", self._step_dynamics),
                 self._step_prephysics,
                 self._compute_physics,

--- a/workflows/prognostic_c48_run/runtime/metrics-schema.json
+++ b/workflows/prognostic_c48_run/runtime/metrics-schema.json
@@ -368,6 +368,46 @@
             "examples": [
                 1.3542121849959635e-07
             ]
+        },
+        "snow_mixing_ratio_path": {
+            "type": "number",
+            "description": "column snow",
+            "units": "kg/m^2"
+        },
+        "cloud_water_mixing_ratio_path": {
+            "type": "number",
+            "description": "column cloud water",
+            "units": "kg/m^2"
+        },
+        "specific_humidity_path": {
+            "type": "number",
+            "description": "column water vapor",
+            "units": "kg/m^2"
+        },
+        "graupel_mixing_ratio_path": {
+            "type": "number",
+            "description": "column graupel",
+            "units": "kg/m^2"
+        },
+        "cloud_ice_mixing_ratio_path": {
+            "type": "number",
+            "description": "column cloud ice",
+            "units": "kg/m^2"
+        },
+        "rain_mixing_ratio_path": {
+            "type": "number",
+            "description": "column rain",
+            "units": "kg/m^2"
+        },
+        "ozone_mixing_ratio_path": {
+            "type": "number",
+            "description": "mass integrated ozone",
+            "units": "<unknown>"
+        },
+        "cloud_amount_path": {
+            "type": "number",
+            "description": "",
+            "units": "<unkown>"
         }
     },
     "additionalProperties": false


### PR DESCRIPTION
This will be computed every timestep and printed to the console with the other
diagnostics.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/f29fd349-70cd-41e3-af99-0fe8731ae7f8\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)