### PR TITLE
remove .load in for loops over variables

### DIFF
--- a/workflows/argo/prognostic_run_diags.yaml
+++ b/workflows/argo/prognostic_run_diags.yaml
@@ -159,6 +159,8 @@ spec:
         value: /secret/gcp-credentials/key.json
       - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
         value: /secret/gcp-credentials/key.json
+      - name: DIAG_COMPUTE_SIZE_LIMT_MB
+        value: 5000
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret

--- a/workflows/argo/prognostic_run_diags.yaml
+++ b/workflows/argo/prognostic_run_diags.yaml
@@ -160,7 +160,7 @@ spec:
       - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
         value: /secret/gcp-credentials/key.json
       - name: DIAG_COMPUTE_SIZE_LIMT_MB
-        value: 5000
+        value: 6000
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-key-secret

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -235,7 +235,7 @@ def zonal_means_2d(diag_arg: DiagArg):
         zonal_means.update(
             vcm.zonal_average_approximate(
                 grid.lat, prognostic_subset, lat_name="latitude"
-            )
+            ).load()
         )
     return time_mean(zonal_means)
 
@@ -255,7 +255,7 @@ def zonal_means_3d(diag_arg: DiagArg):
             zm = vcm.zonal_average_approximate(
                 grid.lat, prognostic_subset, lat_name="latitude"
             )
-            zonal_means.update(time_mean(zm))
+            zonal_means.update(time_mean(zm).load())
     return zonal_means
 
 
@@ -286,7 +286,7 @@ def zonal_bias_3d(diag_arg: DiagArg):
                 bias(verification[common_vars], prognostic_subset[common_vars]),
                 lat_name="latitude",
             )
-            zonal_means.update(time_mean(zm_bias))
+            zonal_means.update(time_mean(zm_bias).load())
     return zonal_means
 
 
@@ -315,7 +315,7 @@ def zonal_and_time_mean_biases_2d(diag_arg: DiagArg):
 
         zonal_mean_bias = vcm.zonal_average_approximate(
             grid.lat,
-            bias(verification[common_vars], prognostic[common_vars]),
+            bias(verification[common_vars], prognostic_subset[common_vars]),
             lat_name="latitude",
         )
         zonal_means.update(time_mean(zonal_mean_bias).load())
@@ -341,7 +341,7 @@ def zonal_mean_hovmoller(diag_arg: DiagArg):
         with xr.set_options(keep_attrs=True):
             zonal_means.update(
                 vcm.zonal_average_approximate(
-                    grid.lat, prognostic, lat_name="latitude"
+                    grid.lat, prognostic_subset, lat_name="latitude"
                 ).load()
             )
     return zonal_means
@@ -373,7 +373,7 @@ def zonal_mean_bias_hovmoller(diag_arg: DiagArg):
             zonal_means.update(
                 vcm.zonal_average_approximate(
                     grid.lat,
-                    bias(verification[common_vars], prognostic[common_vars]),
+                    bias(verification[common_vars], prognostic_subset[common_vars]),
                     lat_name="latitude",
                 ).load()
             )

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -213,15 +213,10 @@ def zonal_means_2d(diag_arg: DiagArg):
 def zonal_means_3d(diag_arg: DiagArg):
     logger.info("Preparing zonal+time means (3d)")
     prognostic, grid = diag_arg.prediction, diag_arg.grid
-    zonal_means = xr.Dataset()
-    for var in prognostic.data_vars:
-        logger.info(f"Computing zonal+time means (3d) for {var}")
-        with xr.set_options(keep_attrs=True):
-            zm = vcm.zonal_average_approximate(
-                grid.lat, prognostic[[var]], lat_name="latitude"
-            )
-            zm_time_mean = time_mean(zm)[var].load()
-            zonal_means[var] = zm_time_mean
+    logger.info(f"Computing zonal+time means (3d)")
+    with xr.set_options(keep_attrs=True):
+        zm = vcm.zonal_average_approximate(grid.lat, prognostic, lat_name="latitude")
+        zonal_means = time_mean(zm)
     return zonal_means
 
 
@@ -236,18 +231,16 @@ def zonal_bias_3d(diag_arg: DiagArg):
         diag_arg.verification,
         diag_arg.grid,
     )
-    zonal_means = xr.Dataset()
     common_vars = list(set(prognostic.data_vars).intersection(verification.data_vars))
-    for var in common_vars:
-        logger.info(f"Computing zonal+time mean biases (3d) for {var}")
-        with xr.set_options(keep_attrs=True):
-            zm_bias = vcm.zonal_average_approximate(
-                grid.lat,
-                bias(verification[[var]], prognostic[[var]]),
-                lat_name="latitude",
-            )
-            zm_bias_time_mean = time_mean(zm_bias)[var].load()
-            zonal_means[var] = zm_bias_time_mean
+
+    logger.info(f"Computing zonal+time mean biases (3d) for {common_vars}")
+    with xr.set_options(keep_attrs=True):
+        zm_bias = vcm.zonal_average_approximate(
+            grid.lat,
+            bias(verification[common_vars], prognostic[common_vars]),
+            lat_name="latitude",
+        )
+        zonal_means = time_mean(zm_bias)
     return zonal_means
 
 
@@ -263,12 +256,14 @@ def zonal_and_time_mean_biases_2d(diag_arg: DiagArg):
     logger.info("Preparing zonal+time mean biases (2d)")
     common_vars = list(set(prognostic.data_vars).intersection(verification.data_vars))
     zonal_means = xr.Dataset()
-    for var in common_vars:
-        logger.info("Computing zonal+time mean biases (2d)")
-        zonal_mean_bias = vcm.zonal_average_approximate(
-            grid.lat, bias(verification[[var]], prognostic[[var]]), lat_name="latitude"
-        )
-        zonal_means[var] = time_mean(zonal_mean_bias)[var].load()
+
+    logger.info("Computing zonal+time mean biases (2d)")
+    zonal_mean_bias = vcm.zonal_average_approximate(
+        grid.lat,
+        bias(verification[common_vars], prognostic[common_vars]),
+        lat_name="latitude",
+    )
+    zonal_means = time_mean(zonal_mean_bias).load()
     return zonal_means
 
 
@@ -280,12 +275,11 @@ def zonal_mean_hovmoller(diag_arg: DiagArg):
     logger.info(f"Preparing zonal mean values (2d)")
     prognostic, grid = diag_arg.prediction, diag_arg.grid
     zonal_means = xr.Dataset()
-    for var in prognostic.data_vars:
-        logger.info(f"Computing zonal mean (2d) over time for {var}")
-        with xr.set_options(keep_attrs=True):
-            zonal_means[var] = vcm.zonal_average_approximate(
-                grid.lat, prognostic[[var]], lat_name="latitude"
-            )[var].load()
+    logger.info(f"Computing zonal means over time (2d)")
+    with xr.set_options(keep_attrs=True):
+        zonal_means = vcm.zonal_average_approximate(
+            grid.lat, prognostic, lat_name="latitude"
+        ).load()
     return zonal_means
 
 
@@ -302,15 +296,13 @@ def zonal_mean_bias_hovmoller(diag_arg: DiagArg):
         diag_arg.grid,
     )
     common_vars = list(set(prognostic.data_vars).intersection(verification.data_vars))
-    zonal_means = xr.Dataset()
-    for var in common_vars:
-        logger.info(f"Computing zonal mean biases (2d) over time for {var}")
-        with xr.set_options(keep_attrs=True):
-            zonal_means[var] = vcm.zonal_average_approximate(
-                grid.lat,
-                bias(verification[[var]], prognostic[[var]]),
-                lat_name="latitude",
-            )[var].load()
+    logger.info(f"Computing zonal mean biases (2d) over time for {common_vars}")
+    with xr.set_options(keep_attrs=True):
+        zonal_means = vcm.zonal_average_approximate(
+            grid.lat,
+            bias(verification[common_vars], prognostic[common_vars]),
+            lat_name="latitude",
+        ).load()
     return zonal_means
 
 


### PR DESCRIPTION

```
# timing on master with .load called on each variable in for loop in zonal mean computations
2022-07-25 19:00:12,426 INFO     'zonal_means_3d' executed in 14.6005s
2022-07-25 19:00:21,717 INFO     'zonal_bias_3d' executed in 23.5899s
2022-07-25 19:00:08,702 INFO     'zonal_means_2d' executed in 9.8321s
2022-07-25 19:00:36,949 INFO     'zonal_and_time_mean_biases_2d' executed in 34.6455s
2022-07-25 19:00:42,175 INFO     'zonal_mean_hovmoller' executed in 28.9159s
2022-07-25 19:00:49,424 INFO     'zonal_mean_bias_hovmoller' executed in 31.9675s


# timings when for loop over variables removed
2022-07-25 18:54:00,010 INFO     'zonal_means_3d' executed in 2.5591s
2022-07-25 18:54:00,175 INFO     'zonal_bias_3d' executed in 2.3814s
2022-07-25 18:54:07,844 INFO     'zonal_means_2d' executed in 9.4742s
2022-07-25 18:54:19,726 INFO     'zonal_and_time_mean_biases_2d' executed in 18.2790s
2022-07-25 18:54:21,293 INFO     'zonal_mean_hovmoller' executed in 14.9118s
2022-07-25 18:54:30,908 INFO     'zonal_mean_bias_hovmoller' executed in 16.1679s
```

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/b723c376-0569-4cc1-bd57-e403189ea99e\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)