### PR TITLE
Add prognostic_run_diags shell CLI

### DIFF
--- a/external/vcm/vcm/fv3/metadata.py
+++ b/external/vcm/vcm/fv3/metadata.py
@@ -13,6 +13,7 @@ DIM_RENAME_INVERSE_MAP = {
     "tile": {"rank"},
     "x_interface": {"grid_x", "grid_x_coarse"},
     "y_interface": {"grid_y", "grid_y_coarse"},
+    "z": {"pfull"},
 }
 VARNAME_SUFFIX_TO_REMOVE = ["_coarse"]
 TIME_DIM_NAME = "time"

--- a/external/vcm/vcm/select.py
+++ b/external/vcm/vcm/select.py
@@ -52,6 +52,13 @@ def meridional_ring(lon=0, n=180):
     }
 
 
+def latlon(lat, lon):
+    return {
+        "lat": xr.DataArray([lat], dims="sample"),
+        "lon": xr.DataArray([lon], dims="sample"),
+    }
+
+
 def zonal_ring(lat=45, n=360):
     attrs = {"description": f"Lat = {lat}"}
     lon = np.linspace(0, 360, n)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/cli.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/cli.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
-from fv3net.diagnostics.prognostic_run import metrics, compute
-from fv3net.diagnostics.prognostic_run.views import movies, static_report
+
+from fv3net.diagnostics.prognostic_run import compute, metrics, shell
 from fv3net.diagnostics.prognostic_run.apps import log_viewer
 from fv3net.diagnostics.prognostic_run.emulation import single_run
+from fv3net.diagnostics.prognostic_run.views import movies, static_report
 
 
 def dissoc(namespace, key):
@@ -19,7 +20,15 @@ def get_parser():
         help="Prognostic run diagnostics", required=True, dest="command"
     )
 
-    for entrypoint in [compute, metrics, movies, static_report, log_viewer, single_run]:
+    for entrypoint in [
+        compute,
+        log_viewer,
+        metrics,
+        movies,
+        shell,
+        single_run,
+        static_report,
+    ]:
         entrypoint.register_parser(subparsers)
     return parser
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/iterm.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/iterm.py
@@ -1,0 +1,90 @@
+"""
+From https://github.com/wookayin/python-imgcat
+
+License:
+
+The MIT License
+
+Copyright (c) 2018 Jongwook Choi
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+import base64
+import os
+
+TMUX_WRAP_ST = b"\033Ptmux;"
+TMUX_WRAP_ED = b"\033\\"
+
+OSC = b"\033]"
+CSI = b"\033["
+ST = b"\a"  # \a = ^G (bell)
+
+
+def write_image(buf, fp, filename, width=None, height=None, preserve_aspect_ratio=None):
+    # need to detect tmux
+    is_tmux = "TMUX" in os.environ and "tmux" in os.environ["TMUX"]
+
+    # tmux: print some margin and the DCS escape sequence for passthrough
+    # In tmux mode, we need to first determine the number of actual lines
+    if is_tmux:
+        fp.write(b"\n" * height)
+        # move the cursers back
+        fp.write(CSI + b"?25l")
+        fp.write(CSI + str(height).encode() + b"F")  # PEP-461
+        fp.write(TMUX_WRAP_ST + b"\033")
+
+    # now starts the iTerm2 file transfer protocol.
+    fp.write(OSC)
+    fp.write(b"1337;File=inline=1")
+    fp.write(b";size=" + str(len(buf)).encode())
+    if filename:
+        if isinstance(filename, bytes):
+            filename_bytes = filename
+        else:
+            filename_bytes = filename.encode()
+        fp.write(b";name=" + base64.b64encode(filename_bytes))
+    if height is not None:
+        fp.write(b";height=" + str(height).encode())
+    if width is not None:
+        fp.write(b";width=" + str(width).encode())
+    if not preserve_aspect_ratio:
+        fp.write(b";preserveAspectRatio=0")
+
+    fp.write(b":")
+    fp.flush()
+
+    buf_base64 = base64.b64encode(buf)
+    fp.write(buf_base64)
+
+    fp.write(ST)
+
+    if is_tmux:
+        # terminate DCS passthrough mode
+        fp.write(TMUX_WRAP_ED)
+        # move back the cursor lines down
+        fp.write(CSI + str(height).encode() + b"E")
+        fp.write(CSI + b"?25h")
+    else:
+        fp.write(b"\n")
+
+    # flush is needed so that the cursor control sequence can take effect
+    fp.flush()

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -167,7 +167,7 @@ class ProgShell(cmd.Cmd):
 def register_parser(subparsers):
     parser = subparsers.add_parser("shell")
     parser.set_defaults(func=main)
-    parser.add_argument("script", default="")
+    parser.add_argument("script", default="", nargs="?")
 
 
 def main(args):

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -203,9 +203,17 @@ class ProgShell(cmd.Cmd):
 
 
 def register_parser(subparsers):
-    parser = subparsers.add_parser("shell")
+    parser = subparsers.add_parser(
+        "shell", help="Open an prognostic run browsing shell"
+    )
     parser.set_defaults(func=main)
-    parser.add_argument("script", default="", nargs="?")
+    parser.add_argument(
+        "script",
+        default="",
+        nargs="?",
+        help="If provided, a text file of commands to run instead of opening "
+        "an interactive shell.",
+    )
 
 
 def main(args):

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -158,6 +158,17 @@ class ProgShell(cmd.Cmd):
         transect[variable].plot(yincrease=False, y="pressure")
         loop_state.tape.save_plot()
 
+    def do_column(self, arg):
+        variable = arg
+        lon = float(state.get("lon", 0))
+        lat = float(state.get("lat", 0))
+
+        ds = loop_state.data_3d.merge(grid)
+        transect_coords = vcm.select.latlon(lat, lon)
+        transect = vcm.interpolate_unstructured(ds, transect_coords).squeeze()
+        transect[variable].plot(yincrease=False, y="pressure")
+        loop_state.tape.save_plot()
+
     def onecmd(self, line):
         try:
             super().onecmd(line)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -158,6 +158,14 @@ class ProgShell(cmd.Cmd):
         transect[variable].plot(yincrease=False, y="pressure")
         loop_state.tape.save_plot()
 
+    def do_zonalavg(self, arg):
+        variable = arg
+        time = int(state.get("time", "0"))
+        ds = loop_state.data_3d.isel(time=time)
+        transect = vcm.zonal_average_approximate(ds.lat, ds[variable])
+        transect.plot(yincrease=False, y="pressure")
+        loop_state.tape.save_plot()
+
     def do_column(self, arg):
         variable = arg
         lon = float(state.get("lon", 0))

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -66,12 +66,15 @@ class State:
 
     def load(self, url):
         prognostic = load_run_data.SegmentedRun(url, catalog)
-        self.data_3d = prognostic.data_3d
-        self.data_2d = prognostic.data_2d.merge(grid.drop("area"))
+        self.data_3d = prognostic.data_3d.merge(grid)
+        self.data_2d = prognostic.data_2d.merge(grid, compat="override")
 
     def print(self):
+        print("3D Variables:")
         for v in self.data_3d:
             print(v)
+        print()
+        print("2D Variables:")
         for v in self.data_2d:
             print(v)
 
@@ -102,9 +105,6 @@ def hovmoller(state: State, variable, vmin=None, vmax=None):
     vmax = None if vmax is None else float(vmax)
     avg.plot(x="time", vmin=vmin, vmax=vmax)
     state.tape.save_plot()
-
-
-commands = {"iterm": set_iterm_tape, "avg2d": avg2d, "hovmoller": hovmoller}
 
 
 class ProgShell(cmd.Cmd):

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -67,7 +67,7 @@ class State:
     def load(self, url):
         prognostic = load_run_data.SegmentedRun(url, catalog)
         self.data_3d = prognostic.data_3d.merge(grid)
-        self.data_2d = prognostic.data_2d.merge(grid, compat="override")
+        self.data_2d = grid.merge(prognostic.data_2d, compat="override")
 
     def print(self):
         print("3D Variables:")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -1,0 +1,178 @@
+import cmd
+from fv3net.diagnostics.prognostic_run import load_run_data
+import intake
+import vcm.catalog
+import vcm
+import xarray as xr
+import fv3viz
+import pathlib
+import matplotlib.pyplot as plt
+import sys
+import io
+import warnings
+
+from . import iterm
+
+warnings.filterwarnings("ignore")
+
+
+def meridional_transect(ds: xr.Dataset):
+    transect_coords = vcm.select.meridional_ring()
+    ds = vcm.interpolate_unstructured(ds, transect_coords)
+    return ds.swap_dims({"sample": "lat"})
+
+
+class PlotTape:
+    def __init__(self):
+        self.count = 0
+
+    def save_plot(self):
+        filename = f"image_{self.count}.png"
+        plt.savefig(filename)
+        plt.close(plt.gcf())
+        self.count += 1
+
+
+class OneFileTape:
+    """Useful for working in vscode...updates file in place"""
+
+    def save_plot(self):
+        filename = f"image.png"
+        plt.savefig(filename)
+        plt.close(plt.gcf())
+
+
+class ItermTape:
+    width = 70
+
+    def save_plot(self):
+        f = io.BytesIO()
+        plt.savefig(f)
+        iterm.write_image(
+            f.getvalue(),
+            sys.stderr.buffer,
+            filename="file",
+            width=self.width,
+            preserve_aspect_ratio=True,
+        )
+        plt.close(plt.gcf())
+
+
+class State:
+    def __init__(self):
+        self.data_3d = None
+        self.data_2d = None
+        self.tape = OneFileTape()
+
+    def load(self, url):
+        prognostic = load_run_data.SegmentedRun(url, catalog)
+        self.data_3d = prognostic.data_3d
+        self.data_2d = prognostic.data_2d.merge(grid.drop("area"))
+
+    def print(self):
+        for v in self.data_3d:
+            print(v)
+        for v in self.data_2d:
+            print(v)
+
+
+catalog_path = vcm.catalog.catalog_path
+catalog = intake.open_catalog(catalog_path)
+grid = load_run_data.load_grid(catalog)
+
+state = {}
+loop_state = State()
+
+
+def avg2d(state: State, variable):
+    x = state.data_2d
+    avg = vcm.weighted_average(x[variable], x.area, ["x", "y", "tile"])
+    avg.plot()
+    state.tape.save_plot()
+
+
+def set_iterm_tape(state: State):
+    state.tape = ItermTape()
+
+
+def hovmoller(state: State, variable, vmin=None, vmax=None):
+    z = state.data_2d[variable]
+    avg = vcm.zonal_average_approximate(state.data_2d.lat, z)
+    vmin = None if vmin is None else float(vmin)
+    vmax = None if vmax is None else float(vmax)
+    avg.plot(x="time", vmin=vmin, vmax=vmax)
+    state.tape.save_plot()
+
+
+commands = {"iterm": set_iterm_tape, "avg2d": avg2d, "hovmoller": hovmoller}
+
+
+class ProgShell(cmd.Cmd):
+    intro = (
+        "Welcome to the ProgRunDiag shell.   Type help or ? to list commands.\n"  # noqa
+    )
+
+    def do_avg2d(self, arg):
+        avg2d(loop_state, arg)
+
+    def do_iterm(self, arg):
+        set_iterm_tape(loop_state)
+
+    def do_hovmoller(self, arg):
+        hovmoller(loop_state, *arg.split())
+
+    def do_load(self, arg):
+        url = arg
+        loop_state.load(url)
+
+    def do_set(self, arg):
+        key, val = arg.split()
+        state[key] = val
+
+    def do_print(self, arg):
+        loop_state.print()
+
+    def do_meridional(self, arg):
+        variable = arg
+        time = int(state.get("time", "0"))
+        transect = meridional_transect(loop_state.data_3d.isel(time=time).merge(grid))
+        transect[variable].plot(yincrease=False, y="pressure")
+        loop_state.tape.save_plot()
+
+    def onecmd(self, line):
+        try:
+            super().onecmd(line)
+        except Exception as e:
+            print(e)
+
+    def do_map2d(self, arg):
+        variable = arg
+        time = int(state.get("time", "0"))
+        data = loop_state.data_2d.isel(time=time)
+        fv3viz.plot_cube(data, variable)
+        time_name = data.time.item().isoformat()
+        plt.title(f"{time_name} {variable}")
+        plt.tight_layout()
+        loop_state.tape.save_plot()
+
+    def do_exit(self, arg):
+        sys.exit(0)
+
+    def do_eval(self, arg):
+        f = pathlib.Path(arg)
+        for line in f.read_text().splitlines():
+            self.onecmd(line)
+
+
+def register_parser(subparsers):
+    parser = subparsers.add_parser("shell")
+    parser.set_defaults(func=main)
+    parser.add_argument("script", default="")
+
+
+def main(args):
+    shell = ProgShell()
+    if args.script:
+        shell.do_eval(args.script)
+    else:
+        shell.cmdloop()

--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -10,6 +10,25 @@ random=$(openssl rand --hex 6)
 OUTPUT=gs://vcm-ml-scratch/test-prognostic-report/$random
 
 cd workflows/diagnostics
+# test shell
+cat << EOF > report.script
+load $RUN
+print
+hovmoller PWAT
+avg2d PWAT
+map2d PWAT
+eval 3d.script
+EOF
+
+cat << EOF > 3d.script
+meridional specific_humidity
+zonal specific_humidity
+zonalavg specific_humidity
+column specific_humidity
+EOF
+prognostic_run_diags shell report.script
+# assert an image has been output
+[[ -f image.png ]]
 
 # compute diagnostics/mterics for a short sample prognostic run
 mkdir -p /tmp/$random


### PR DESCRIPTION
This CLI allows quickly exploring basic prognostic run data. It is just a
prototype right now, but is already pretty useful.

If you are using iterm on a mac it can display the image inline. Otherwise, it will write to "image.png".

Here is a screenshot of interactive use:
<img width="1008" alt="Screen Shot 2022-07-22 at 4 57 40 PM" src="https://user-images.githubusercontent.com/1386642/180581872-36fcecb9-2c35-4504-bffd-45368dcf6346.png">

It can also be run as a script
```
prognostic_run_diags shell <file with commands>
```

Give this example a try:
```
iterm
load gs://vcm-ml-experiments/microphysics-emulation/2022-07-22/precpd-diff-only-rnn-combined-v1-online
meridional specific_humidity
meridional cloud_water_mixing_ratio
set time -1
meridional specific_humidity
meridional cloud_water_mixing_ratio
map2d VIL
hovmoller PWAT
hovmoller VIL 0 0.5
``` 

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/ac8760b9-1357-4994-87f0-fff36df48108\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)