### PR TITLE
Vectorize radlw main

### DIFF
--- a/external/radiation/python/radlw/radlw_bands.py
+++ b/external/radiation/python/radlw/radlw_bands.py
@@ -96,6 +96,7 @@ def taugb01(
         fracrefb,
         nspa,
         nspb,
+        npts,
     ):
         #  ------------------------------------------------------------------  !
         #  written by eli j. mlawer, atmospheric & environmental research.     !
@@ -115,8 +116,8 @@ def taugb01(
 
         #  --- ...  lower atmosphere loop
 
-        taug = np.zeros((ngptlw, nlay))
-        fracs = np.zeros((ngptlw, nlay))
+        taug = np.zeros((ngptlw, nlay, npts))
+        fracs = np.zeros((ngptlw, nlay, npts))
 
         ind0 = ((jp - 1) * 5 + (jt - 1)) * nspa[0]
         ind1 = (jp * 5 + (jt1 - 1)) * nspa[0]

--- a/external/radiation/python/radlw/radlw_main.py
+++ b/external/radiation/python/radlw/radlw_main.py
@@ -1790,53 +1790,41 @@ class RadLWClass:
             colamt[:, 2] = np.maximum(temcol[:], coldry[:] * o3vmr[:])  # o3
 
             if ilwrgas > 0:
-                for k in range(nlay):
-                    colamt[k, 3] = max(
-                        temcol[k], coldry[k] * gasvmr[iplon, k, 1]
-                    )  # n2o
-                    colamt[k, 4] = max(
-                        temcol[k], coldry[k] * gasvmr[iplon, k, 2]
-                    )  # ch4
-                    colamt[k, 5] = max(0.0, coldry[k] * gasvmr[iplon, k, 3])  # o2
-                    colamt[k, 6] = max(0.0, coldry[k] * gasvmr[iplon, k, 4])  # co
+                colamt[:, 3] =  np.maximum(temcol[:], coldry[:] * gasvmr[iplon, :, 1])  # n2o
+                colamt[:, 4] =  np.maximum(temcol[:], coldry[:] * gasvmr[iplon, :, 2])  # ch4
+                colamt[:, 5] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 3])  # o2
+                colamt[:, 6] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 4])  # co
 
-                    wx[k, 0] = max(0.0, coldry[k] * gasvmr[iplon, k, 8])  # ccl4
-                    wx[k, 1] = max(0.0, coldry[k] * gasvmr[iplon, k, 5])  # cf11
-                    wx[k, 2] = max(0.0, coldry[k] * gasvmr[iplon, k, 6])  # cf12
-                    wx[k, 3] = max(0.0, coldry[k] * gasvmr[iplon, k, 7])  # cf22
+                wx[:, 0] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 8])  # ccl4
+                wx[:, 1] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 5])  # cf11
+                wx[:, 2] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 6])  # cf12
+                wx[:, 3] =  np.maximum(0.0, coldry[:] * gasvmr[iplon, :, 7])  # cf22
             else:
-                for k in range(nlay):
-                    colamt[k, 3] = 0.0  # n2o
-                    colamt[k, 4] = 0.0  # ch4
-                    colamt[k, 5] = 0.0  # o2
-                    colamt[k, 6] = 0.0  # co
+                colamt[:, 3] = 0.0  # n2o
+                colamt[:, 4] = 0.0  # ch4
+                colamt[:, 5] = 0.0  # o2
+                colamt[:, 6] = 0.0  # co
 
-                    wx[k, 0] = 0.0
-                    wx[k, 1] = 0.0
-                    wx[k, 2] = 0.0
-                    wx[k, 3] = 0.0
+                wx[:, 0] = 0.0
+                wx[:, 1] = 0.0
+                wx[:, 2] = 0.0
+                wx[:, 3] = 0.0
 
-            for k in range(nlay):
-                for j in range(nbands):
-                    tauaer[j, k] = aerosols[iplon, k, j, 0] * (
-                        1.0 - aerosols[iplon, k, j, 1]
-                    )
+            tauaer[: , :]= (aerosols[iplon, :, :, 0] * (1.0 - aerosols[iplon, :, :, 1])).T
 
             if ilwcliq > 0:
-                for k in range(nlay):
-                    cldfrc[k + 1] = clouds[iplon, k, 0]
-                    clwp[k] = clouds[iplon, k, 1]
-                    relw[k] = clouds[iplon, k, 2]
-                    ciwp[k] = clouds[iplon, k, 3]
-                    reiw[k] = clouds[iplon, k, 4]
-                    cda1[k] = clouds[iplon, k, 5]
-                    cda2[k] = clouds[iplon, k, 6]
-                    cda3[k] = clouds[iplon, k, 7]
-                    cda4[k] = clouds[iplon, k, 8]
+                cldfrc[1:-1] = clouds[iplon, :, 0]
+                clwp[:] = clouds[iplon, :, 1]
+                relw[:] = clouds[iplon, :, 2]
+                ciwp[:] = clouds[iplon, :, 3]
+                reiw[:] = clouds[iplon, :, 4]
+                cda1[:] = clouds[iplon, :, 5]
+                cda2[:] = clouds[iplon, :, 6]
+                cda3[:] = clouds[iplon, :, 7]
+                cda4[:] = clouds[iplon, :, 8]
             else:
-                for k in range(nlay):
-                    cldfrc[k + 1] = clouds[iplon, k, 0]
-                    cda1[k] = clouds[iplon, k, 1]
+                cldfrc[1:-1] = clouds[iplon, :, 0]
+                cda1[:] = clouds[iplon, :, 1]
 
             cldfrc[0] = 1.0
             cldfrc[nlp1] = 0.0

--- a/external/radiation/python/radlw/radlw_main.py
+++ b/external/radiation/python/radlw/radlw_main.py
@@ -1772,25 +1772,22 @@ class RadLWClass:
             tem2 = 1.0e-20 * 1.0e3 * con_avgd
             tz[0] = tlvl[iplon, 0]
 
-            for k in range(nlay):
-                pavel[k] = plyr[iplon, k]
-                delp[k] = delpin[iplon, k]
-                tavel[k] = tlyr[iplon, k]
-                tz[k + 1] = tlvl[iplon, k + 1]
-                dz[k] = dzlyr[iplon, k]
+            
+            pavel[:] = plyr[iplon, :]
+            delp[:] = delpin[iplon, :]
+            tavel[:] = tlyr[iplon, :]
+            tz[1:] = tlvl[iplon, 1:]
+            dz[:] = dzlyr[iplon, :]
+            h2ovmr[:] = np.maximum(0.0, qlyr[iplon, :] * self.amdw / (1.0 - qlyr[iplon, :]))
+            o3vmr[:] = np.maximum(0.0, olyr[iplon, :] * self.amdo3)
 
-                h2ovmr[k] = max(
-                    0.0, qlyr[iplon, k] * self.amdw / (1.0 - qlyr[iplon, k])
-                )
-                o3vmr[k] = max(0.0, olyr[iplon, k] * self.amdo3)
+            tem0 = (1.0 - h2ovmr[:]) * con_amd + h2ovmr[:] * con_amw
+            coldry[:] = tem2 * delp[:] / (tem1 * tem0 * (1.0 + h2ovmr[:]))
+            temcol[:] = 1.0e-12 * coldry[:]
 
-                tem0 = (1.0 - h2ovmr[k]) * con_amd + h2ovmr[k] * con_amw
-                coldry[k] = tem2 * delp[k] / (tem1 * tem0 * (1.0 + h2ovmr[k]))
-                temcol[k] = 1.0e-12 * coldry[k]
-
-                colamt[k, 0] = max(0.0, coldry[k] * h2ovmr[k])  # h2o
-                colamt[k, 1] = max(temcol[k], coldry[k] * gasvmr[iplon, k, 0])  # co2
-                colamt[k, 2] = max(temcol[k], coldry[k] * o3vmr[k])  # o3
+            colamt[:, 0] = np.maximum(0.0, coldry[:] * h2ovmr[:])  # h2o
+            colamt[:, 1] = np.maximum(temcol[:], coldry[:] * gasvmr[iplon, :, 0])  # co2
+            colamt[:, 2] = np.maximum(temcol[:], coldry[:] * o3vmr[:])  # o3
 
             if ilwrgas > 0:
                 for k in range(nlay):

--- a/external/radiation/python/radlw/radlw_main.py
+++ b/external/radiation/python/radlw/radlw_main.py
@@ -2219,8 +2219,8 @@ class RadLWClass:
             for k in range(nlay):
                 hlw0[iplon, k] = htrcl[k]
 
-            if verbose:
-                print("Finished!")
+        if verbose:
+            print("Finished!")
 
         return (
             hlwc,
@@ -2322,12 +2322,6 @@ class RadLWClass:
         tem2 = totplnk[indlev, :] - totplnk[indlev - 1, :]
         pklay[:, 0] = delwave * (totplnk[indlay - 1, :] + tlyrfr * tem1)
         pklev[:, 0] = delwave * (totplnk[indlev - 1, :] + tlvlfr * tem2)
-
-        # for i in range(nbands):
-        #     tem1 = totplnk[indlay, i] - totplnk[indlay - 1, i]
-        #     tem2 = totplnk[indlev, i] - totplnk[indlev - 1, i]
-        #     pklay[i, 0] = delwave[i] * (totplnk[indlay - 1, i] + tlyrfr * tem1)
-        #     pklev[i, 0] = delwave[i] * (totplnk[indlev - 1, i] + tlvlfr * tem2)
 
         #  --- ...  begin layer loop
         #           calculate the integrated Planck functions for each band at the


### PR DESCRIPTION
The goal of this PR is to reduce  taumol() computing time by extracting the for iplon loop

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/7706d3ac-cd54-4f2a-8d02-10fce349bc0c\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)