### PR TITLE
Odds and ends for precpd-diff-only report

### DIFF
--- a/projects/microphysics/download_wandb/Makefile
+++ b/projects/microphysics/download_wandb/Makefile
@@ -1,6 +1,5 @@
 
-stats.csv: query_prog_run_location.sql example.db
-	python3 2_wandb_to_sqlite.py
+stats.csv: query.sql
 	sqlite3  example.db < $<
 
 example.db: build_db.sh

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -82,7 +82,12 @@ def _coarsen_cell_centered_to_target_resolution(
 
 def _load_3d(url: str, catalog: intake.catalog.Catalog) -> xr.Dataset:
     logger.info(f"Processing 3d data from run directory at {url}")
-    files_3d = ["diags_3d.zarr", "state_after_timestep.zarr", "nudging_tendencies.zarr"]
+    files_3d = [
+        "diags_3d.zarr",
+        "state_after_timestep.zarr",
+        "nudging_tendencies.zarr",
+        "piggy.zarr",
+    ]
     ds = xr.merge(
         [
             load_coarse_data(os.path.join(url, filename), catalog)


### PR DESCRIPTION
A couple small changes I added when working on the slides for the precpd only experiment.

* sql query for making table

* add piggy.zarr to list of files loaded in prognostic_run_diags shell

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/ea628f71-e649-4be8-8fd0-27e9633fa336\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)