### PR TITLE
Upload artifacts from model training

### DIFF
--- a/external/fv3fit/docs/configuration.rst
+++ b/external/fv3fit/docs/configuration.rst
@@ -5,6 +5,9 @@ Configuration
 
 Configuration is loaded from yaml files into the :py:class:`fv3fit.TrainingConfig` class for training options and a :py:class:`loaders.BatchesLoader` class for data. For example configuration files, check out the `vcm-workflow-control examples <https://github.com/ai2cm/vcm-workflow-control/tree/master/examples>`_, in particular this `training-config.yaml <https://github.com/ai2cm/vcm-workflow-control/blob/master/examples/train-evaluate-prognostic-run/training-config.yaml>`_
 
+Any artifacts created during training saved in the `artifacts` directory will be copied to the final output location along with the trained model.
+i.e. configuration entries that specify output locations for artifacts should be given as `artifacts/...`.
+
 For more information on loaders configuration, see the `loaders documentation <https://vulcanclimatemodeling.com/docs/loaders/loaders_api.html>`
 
 .. autoclass:: fv3fit.TrainingConfig

--- a/external/fv3fit/docs/usage.rst
+++ b/external/fv3fit/docs/usage.rst
@@ -17,6 +17,7 @@ It has several useful features:
 
 * Different architectures: RNN, dense, etc...also extensible.
 
+* Any artifacts created during training saved in the `artifacts` directory will be copied to the final output location along with the trained model.
 
 Here is an example:
 .. literalinclude:: transformed-config.yaml

--- a/external/fv3fit/docs/usage.rst
+++ b/external/fv3fit/docs/usage.rst
@@ -17,7 +17,6 @@ It has several useful features:
 
 * Different architectures: RNN, dense, etc...also extensible.
 
-* Any artifacts created during training saved in the `artifacts` directory will be copied to the final output location along with the trained model.
 
 Here is an example:
 .. literalinclude:: transformed-config.yaml

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     logger.setLevel(logging.INFO)
     parser = get_parser()
     args, unknown_args = parser.parse_known_args()
-    os.mkdir("artifacts")
+    os.makedirs("artifacts", exist_ok=True)
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
@@ -191,6 +191,4 @@ if __name__ == "__main__":
     main(args, unknown_args)
 
     with put_dir(args.output_path) as path:
-        shutil.copytree(
-            "artifacts", os.path.join(path, "artifacts"), dirs_exist_ok=True
-        )
+        shutil.move("artifacts", os.path.join(path, "artifacts"))

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -178,13 +178,19 @@ if __name__ == "__main__":
     logger.setLevel(logging.INFO)
     parser = get_parser()
     args, unknown_args = parser.parse_known_args()
+    os.mkdir("artifacts")
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler("training.log"), logging.StreamHandler()],
+        handlers=[
+            logging.FileHandler("artifacts/training.log"),
+            logging.StreamHandler(),
+        ],
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     main(args, unknown_args)
 
     with put_dir(args.output_path) as path:
-        shutil.copytree(".", path, dirs_exist_ok=True)
+        shutil.copytree(
+            "artifacts", os.path.join(path, "artifacts"), dirs_exist_ok=True
+        )

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -9,6 +9,8 @@ from fv3fit._shared.config import (
     to_flat_dict,
     to_nested_dict,
 )
+from fv3fit._shared import put_dir
+
 import yaml
 import fsspec
 
@@ -16,12 +18,11 @@ import fv3fit.keras
 import fv3fit.sklearn
 import fv3fit
 from .data import tfdataset_loader_from_dict, TFDatasetLoader
-import tempfile
 from fv3fit.dataclasses import asdict_with_enum
 import wandb
 import sys
+import shutil
 
-from vcm.cloud import copy
 from fv3net.artifacts.metadata import StepMetadata
 
 logger = logging.getLogger(__name__)
@@ -177,12 +178,13 @@ if __name__ == "__main__":
     logger.setLevel(logging.INFO)
     parser = get_parser()
     args, unknown_args = parser.parse_known_args()
-    with tempfile.NamedTemporaryFile() as temp_log:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s [%(levelname)s] %(message)s",
-            handlers=[logging.FileHandler(temp_log.name), logging.StreamHandler()],
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        main(args, unknown_args)
-        copy(temp_log.name, os.path.join(args.output_path, "training.log"))
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.FileHandler("training.log"), logging.StreamHandler()],
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    main(args, unknown_args)
+
+    with put_dir(args.output_path) as path:
+        shutil.copytree(".", path, dirs_exist_ok=True)


### PR DESCRIPTION
Sometimes there are outputs other than the trained model that we may want to save to the final model directory, such as model checkpoints and training logs. This PR adds a bit to the main training script to upload the contents of the `artifacts` directory to the final dump location. If you want to have additional artifacts saved with the model, configure them to be saved in the `artifacts/` dir during training.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/e53bcf78-c3e3-4445-a0ff-3d5cfe8db49e\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)