### PR TITLE
Fix bug where segment 2 is run repeatedly

### DIFF
--- a/workflows/prognostic_c48_run/runtime/segmented_run/append.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/append.py
@@ -17,6 +17,9 @@ from .run import run_segment
 def read_last_segment(run_url):
     fs = vcm.get_fs(run_url)
     artifacts_dir = os.path.join(run_url, "artifacts")
+    # fsspec caches the ls call locally so it needs to be manually invalidated
+    # to get up-to-date listings
+    fs.invalidate_cache()
     try:
         segments = sorted(fs.ls(artifacts_dir))
     except FileNotFoundError:

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+import subprocess
 from runtime.segmented_run.append import read_last_segment
+import uuid
 
 
 def test_read_last_segment(tmpdir):
@@ -9,3 +12,21 @@ def test_read_last_segment(tmpdir):
     arts.mkdir(date2)
     ans = read_last_segment(str(tmpdir))
     assert f"file:/{str(tmpdir)}/artifacts/20160102.000000" == ans
+
+
+def test_read_last_segment_gcs(tmp_path: Path):
+    # This test requires network access, but so do some others
+    # This tests the consistency of GCS in the sense of "reading our own writes"
+    # (https://cloud.google.com/storage/docs/consistency)
+    # and also any integrations with fsspec which has several layers of internal
+    # caching which can break this.
+    id_ = uuid.uuid4().hex
+    url = "gs://vcm-ml-scratch/test_data" + "/" + id_
+    last_segment = None
+    for i in range(3):
+        assert read_last_segment(url) == last_segment
+        last_segment = url + f"/artifacts/{i}"
+        dest = last_segment + "/hello.txt"
+        file = tmp_path / "hello.txt"
+        file.write_text("hello")
+        subprocess.check_call(["gsutil", "cp", file.as_posix(), dest])


### PR DESCRIPTION
When using the python segemented run api, prognostics runs of more than
two segements repeat the second segment indefinitely. This occurs due to
a bug in read_last_segment. fsspec file listings share a write-through
cache that is not updated when GCS is modified outside of fsspec. This
means that listing the artifacts directory will not show the
folders uploaded by the gsutil part of append.

The first call to read_last_segment returns None and doesn't call
fsspec.ls. The second call succeeds, and the third call returns the
cached contents of the second call.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/5b9627a9-de5d-4de2-8e4a-c3f191f6b92e\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)