### PR TITLE
fv3kube: fix v0.7 base yaml SST flag

### DIFF
--- a/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
+++ b/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
@@ -280,7 +280,7 @@ namelist:
     shal_cnv: true
     swhtr: true
     trans_trac: true
-    use_analysis_sst: true
+    use_analysis_sst: false
     use_ufo: true
   interpolator_nml:
     interp_method: conserve_great_circle

--- a/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
+++ b/external/fv3kube/fv3kube/base_yamls/v0.7/fv3config.yml
@@ -6,10 +6,6 @@ experiment_name: default_experiment
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 initial_conditions: ''  # no default provided
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
-gfs_analysis_data:
-  url: gs://vcm-ml-raw-flexible-retention/2019-12-02-year-2016-T85-nudging-data
-  filename_pattern: "%Y%m%d_%HZ_T85LR.nc"
-  copy_method: copy
 namelist:
   amip_interp_nml:
     data_set: reynolds_oi

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
@@ -7,10 +7,6 @@ diagnostics: []
 experiment_name: default_experiment
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 fortran_diagnostics: []
-gfs_analysis_data:
-  copy_method: copy
-  filename_pattern: '%Y%m%d_%HZ_T85LR.nc'
-  url: gs://vcm-ml-raw-flexible-retention/2019-12-02-year-2016-T85-nudging-data
 initial_conditions:
 - copy_method: copy
   source_location: gs://ic-bucket/20160805.000000

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
@@ -409,7 +409,7 @@ namelist:
     shal_cnv: true
     swhtr: true
     trans_trac: true
-    use_analysis_sst: true
+    use_analysis_sst: false
     use_ufo: true
   interpolator_nml:
     interp_method: conserve_great_circle

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
@@ -408,7 +408,7 @@ namelist:
     shal_cnv: true
     swhtr: true
     trans_trac: true
-    use_analysis_sst: true
+    use_analysis_sst: false
     use_ufo: true
   interpolator_nml:
     interp_method: conserve_great_circle

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
@@ -7,10 +7,6 @@ diagnostics: []
 experiment_name: default_experiment
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 fortran_diagnostics: []
-gfs_analysis_data:
-  copy_method: copy
-  filename_pattern: '%Y%m%d_%HZ_T85LR.nc'
-  url: gs://vcm-ml-raw-flexible-retention/2019-12-02-year-2016-T85-nudging-data
 initial_conditions:
 - copy_method: copy
   source_location: gs://ic-bucket/20160805.000000


### PR DESCRIPTION
Fixes a misconfiguration in the fv3kube v0.7 base yaml that resulted in SSTs being set to wrong values for non nudge-to-obs runs, unless they were overridden (but even then the wrong values remained in the diagnostics). 

Refactored public API:
- changes `gfs_physics_nml.use_analysis_sst` to false in v0.7 base yaml; also removes analysis data provisioning not used outside of nudge-to-obs

Resolves #1972 

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/859f6d17-28e6-492e-9887-84d04607ebf9/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)