### PR TITLE
Resource constraints for prepare-config step of prognostic runs

### DIFF
--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -95,6 +95,13 @@ spec:
           - {name: fv3config, path: /tmp/fv3config.yaml}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "1000m"
+          limits:
+            memory: "500Mi"
+            cpu: "1200m"
         command: ["bash", "-c", "-x", "-e"]
         workingDir: /fv3net/workflows/prognostic_c48_run
         volumeMounts:


### PR DESCRIPTION

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/8f11ef89-ccba-42a0-91ca-36f3dc4efb4a/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)