### PR TITLE
Use standardize_fv3_metadata in microphysics reports

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -317,7 +317,11 @@ def open_rundir(url):
     grid = vcm.catalog.catalog["grid/c48"].to_dask().load()
     piggy = open_zarr(url + "/piggy.zarr")
     state = open_zarr(url + "/state_after_timestep.zarr")
-    return vcm.fv3.metadata.gfdl_to_standard(piggy).merge(grid).merge(state)
+
+    piggy = vcm.fv3.standardize_fv3_diagnostics(piggy)
+    state = vcm.fv3.standardize_fv3_diagnostics(state)
+
+    return piggy.merge(grid).merge(state)
 
 
 def log_summary_wandb(summary):


### PR DESCRIPTION
This function handles some corner cases like duplicated coordinate values or
other malformed metadata.

I used this to make plots from a [run] which had appended the segment twice and
therefore had duplicate time values.

[run]: https://wandb.ai/ai2cm/microphysics-emulation/groups/precpd-diff-only-rnn-combined-cloudlimit-v4-online/workspace?workspace=user-nbrenowitz

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/e43ee0cc-386f-4f6f-b6f2-b606bff6a37b\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)