### PR TITLE
Allow prog diags to run if verification time range is non overlapping

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
@@ -157,10 +157,14 @@ def daily_mean(split: timedelta, arg: DiagArg) -> DiagArg:
         arg: input arguments to transform prior to the diagnostic calculation
     """
     prognostic, verification, grid = arg.prediction, arg.verification, arg.grid
-    split_time = prognostic.time.values[0] + split
-    prognostic = _resample_end(prognostic, split_time, "1D")
-    verification = _resample_end(verification, split_time, "1D")
-    return DiagArg(prognostic, verification, grid)
+
+    if "time" in prognostic and prognostic.time.size > 0:
+        split_time = prognostic.time.values[0] + split
+        prognostic = _resample_end(prognostic, split_time, "1D")
+        verification = _resample_end(verification, split_time, "1D")
+        return DiagArg(prognostic, verification, grid)
+    else:
+        return DiagArg(xr.Dataset(), xr.Dataset(), grid)
 
 
 def _resample_end(ds: xr.Dataset, split: datetime, freq_label: str) -> xr.Dataset:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -97,7 +97,6 @@ def _merge_diag_computes(
         merged_input_data += [
             (func_name, func, registry_key, diag_arg)
             for func_name, func in registries[registry_key].funcs.items()
-            # for func_name, func in registries["debug"].funcs.items()
         ]
 
     def _compute(func_name, func, key, diag_arg):
@@ -122,13 +121,11 @@ def merge_diags(diags: Sequence[Tuple[str, xr.Dataset]]) -> Mapping[str, xr.Data
 registries = {
     "2d": Registry(merge_diags),
     "3d": Registry(merge_diags),
-    "debug": Registry(merge_diags),
 }
 
 # expressions not allowed in decorator calls, so need explicit variables for each here
 registry_2d = registries["2d"]
 registry_3d = registries["3d"]
-registry_debug = registries["debug"]
 
 
 def _is_empty(data: Union[xr.Dataset, xr.DataArray]) -> bool:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -252,12 +252,11 @@ def zonal_bias_3d(diag_arg: DiagArg):
     common_vars = list(set(prognostic.data_vars).intersection(verification.data_vars))
     for var in common_vars:
         logger.info(f"Computing zonal+time mean biases (3d) for {var}")
-
         with xr.set_options(keep_attrs=True):
             zm_bias = vcm.zonal_average_approximate(
-                grid.lat, bias_[var], lat_name="latitude",
+                grid.lat, bias_[[var]], lat_name="latitude",
             )
-            zm_bias_time_mean = time_mean(zm_bias).load()
+            zm_bias_time_mean = time_mean(zm_bias)[var].load()
             zonal_means[var] = zm_bias_time_mean
     return zonal_means
 
@@ -280,11 +279,11 @@ def zonal_and_time_mean_biases_2d(diag_arg: DiagArg):
     common_vars = list(set(prognostic.data_vars).intersection(verification.data_vars))
     zonal_means = xr.Dataset()
     for var in common_vars:
-        logger.info("Computing zonal+time mean biases (2d)")
+        logger.info(f"Computing zonal+time mean biases (2d) for {var}")
         zonal_mean_bias = vcm.zonal_average_approximate(
-            grid.lat, bias_[var], lat_name="latitude"
+            grid.lat, bias_[[var]], lat_name="latitude"
         )
-        zonal_means[var] = time_mean(zonal_mean_bias).load()
+        zonal_means[var] = time_mean(zonal_mean_bias)[var].load()
     return zonal_means
 
 


### PR DESCRIPTION
If the verification time range doesn't overlap with the prognostic data, differencing the two datasets leads to a zero-length time dimension, which in turn leads to various errors in other functions that take in the bias data. The "DivisionByZero" error that pops up in the zonal mean bias is due to this issue. This PR adds some if/else statements in diagnostic functions that used to assume a nonzero time dimension.

Some of the repeated if/else checks could be avoided if the bias function used `with xr.set_options(arithmetic_join="outer")`. However, I think this would result in a lot of unnecessary reads of both the prognostic and verification data to just end up with a final diagnostic full of NaNs.



Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/69b02a68-3f87-4478-b774-dbdd403cc1b1\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)