### PR TITLE
Corrected CPU constraints for prepare-config

### DIFF
--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -98,10 +98,10 @@ spec:
         resources:
           requests:
             memory: "500Mi"
-            cpu: "1000m"
+            cpu: "700m"
           limits:
             memory: "500Mi"
-            cpu: "1200m"
+            cpu: "700m"
         command: ["bash", "-c", "-x", "-e"]
         workingDir: /fv3net/workflows/prognostic_c48_run
         volumeMounts:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -95,6 +95,13 @@ spec:
           - {name: fv3config, path: /tmp/fv3config.yaml}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "1000m"
+          limits:
+            memory: "500Mi"
+            cpu: "1200m"
         command: ["bash", "-c", "-x", "-e"]
         workingDir: /fv3net/workflows/prognostic_c48_run
         volumeMounts:


### PR DESCRIPTION
Reduces CPU constraints of [this PR](https://github.com/ai2cm/fv3net/pull/1973) to ensure that `prepare-config` jobs will actually be scheduled.

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/23f152a6-599d-42f6-bac8-8adf45be27f8/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)