### PR TITLE
prognostic_run_diags shell improvements

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -75,8 +75,9 @@ class State:
         self.data_3d = self.prognostic.data_3d.merge(grid)
         self.data_2d = grid.merge(self.prognostic.data_2d, compat="override")
 
-    def get_time(self) -> int:
-        return int(self.state.get("time", "0"))
+    def get_time(self):
+        i = int(self.state.get("time", "0"))
+        return self.data_2d.time[i]
 
     def set(self, key, val):
         self.state[key] = val
@@ -86,11 +87,11 @@ class State:
 
     def get_3d_snapshot(self):
         time = self.get_time()
-        return self.data_3d.isel(time=time).merge(grid)
+        return self.data_3d.sel(time=time, method="nearest").merge(grid)
 
     def get_2d_snapshot(self):
         time = self.get_time()
-        return self.data_2d.isel(time=time)
+        return self.data_2d.sel(time=time)
 
     def print(self):
         print("3D Variables:")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -139,6 +139,10 @@ def hovmoller(state: State, variable, vmin=None, vmax=None):
     state.tape.save_plot()
 
 
+def parse_pcolor_arg(arg):
+    return arg, {}
+
+
 class ProgShell(cmd.Cmd):
     intro = (
         "Welcome to the ProgRunDiag shell.   Type help or ? to list commands.\n"  # noqa
@@ -178,15 +182,15 @@ class ProgShell(cmd.Cmd):
         self.state.print()
 
     def do_meridional(self, arg):
-        variable = arg
+        variable, kwargs = parse_pcolor_arg(arg)
         lon = int(self.state.get("lon", "0"))
         transect = meridional_transect(self.get_3d_snapshot())
         transect = transect.assign_coords(lon=lon)
-        transect[variable].plot(yincrease=False, y="pressure")
+        transect[variable].plot(yincrease=False, y="pressure", **kwargs)
         self.state.tape.save_plot()
 
     def do_zonal(self, arg):
-        variable = arg
+        variable, kwargs = parse_pcolor_arg(arg)
         lat = float(self.state.get("lat", 0))
 
         ds = self.state.get_3d_snapshot()
@@ -197,25 +201,25 @@ class ProgShell(cmd.Cmd):
         transect = transect.assign_coords(lat=lat)
 
         plt.figure(figsize=(10, 3))
-        transect[variable].plot(yincrease=False, y="pressure")
+        transect[variable].plot(yincrease=False, y="pressure", **kwargs)
         self.state.tape.save_plot()
 
     def do_zonalavg(self, arg):
-        variable = arg
+        variable, kwargs = parse_pcolor_arg(arg)
         ds = self.state.get_3d_snapshot()
         transect = vcm.zonal_average_approximate(ds.lat, ds[variable])
-        transect.plot(yincrease=False, y="pressure")
+        transect.plot(yincrease=False, y="pressure", **kwargs)
         self.state.tape.save_plot()
 
     def do_column(self, arg):
-        variable = arg
+        variable, kwargs = parse_pcolor_arg(arg)
         lon = float(self.state.get("lon", 0))
         lat = float(self.state.get("lat", 0))
 
         ds = self.state.get_3d_snapshot()
         transect_coords = vcm.select.latlon(lat, lon)
         transect = vcm.interpolate_unstructured(ds, transect_coords).squeeze()
-        transect[variable].plot(yincrease=False, y="pressure")
+        transect[variable].plot(yincrease=False, y="pressure", **kwargs)
         self.state.tape.save_plot()
 
     def onecmd(self, line):
@@ -225,9 +229,9 @@ class ProgShell(cmd.Cmd):
             print(e)
 
     def do_map2d(self, arg):
-        variable = arg
+        variable, kwargs = parse_pcolor_arg(arg)
         data = self.state.get_2d_snapshot()
-        fv3viz.plot_cube(data, variable)
+        fv3viz.plot_cube(data, variable, **kwargs)
         time_name = data.time.item().isoformat()
         plt.title(f"{time_name} {variable}")
         plt.tight_layout()

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -140,7 +140,16 @@ def hovmoller(state: State, variable, vmin=None, vmax=None):
 
 
 def parse_pcolor_arg(arg):
-    return arg, {}
+    tokens = arg.split()
+    kwargs = {}
+    if len(tokens) >= 3:
+        kwargs["vmin"] = float(tokens[1])
+        kwargs["vmax"] = float(tokens[2])
+
+    if len(tokens) >= 4:
+        kwargs["cmap"] = tokens[3]
+
+    return tokens[0], kwargs
 
 
 class ProgShell(cmd.Cmd):

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/shell.py
@@ -7,6 +7,7 @@ import xarray as xr
 import fv3viz
 import pathlib
 import matplotlib.pyplot as plt
+import cartopy.crs
 import sys
 import io
 import warnings
@@ -160,9 +161,16 @@ class ProgShell(cmd.Cmd):
     def __init__(self, state: State):
         super().__init__()
         self.state = state
+        self.crs = None
 
     def do_avg2d(self, arg):
         avg2d(self.state, arg)
+
+    def do_crs(self, arg):
+        if arg == "antarctic":
+            self.crs = cartopy.crs.Orthographic(central_latitude=-90)
+        else:
+            raise NotImplementedError(arg)
 
     def do_avg3d(self, arg):
         avg3d(self.state, arg)
@@ -240,7 +248,7 @@ class ProgShell(cmd.Cmd):
     def do_map2d(self, arg):
         variable, kwargs = parse_pcolor_arg(arg)
         data = self.state.get_2d_snapshot()
-        fv3viz.plot_cube(data, variable, **kwargs)
+        fv3viz.plot_cube(data, variable, projection=self.crs, **kwargs)
         time_name = data.time.item().isoformat()
         plt.title(f"{time_name} {variable}")
         plt.tight_layout()


### PR DESCRIPTION
Some internal refactors, consistent time slicing of the 2d and 3d data, change the projection, and colorbar options.

Example of use:

https://colab.research.google.com/drive/1sfN9RFv9nRbuK_H29boTmOOJqqm30Izk#scrollTo=sapphire-stake

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/4e741e67-065a-42b7-a44e-d295c6add1f1\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)