### PR TITLE
Train models with high antarctic points only

### DIFF
--- a/external/fv3fit/fv3fit/emulation/trainer.py
+++ b/external/fv3fit/fv3fit/emulation/trainer.py
@@ -103,12 +103,14 @@ class ModelCheckpointCallback(tf.keras.callbacks.Callback):
     """the built in one doesn't work with ``Trainer`` since it saves the full
     trainer object rather than the inner model"""
 
-    def __init__(self, filepath: str):
+    def __init__(self, filepath: str, interval: int = 1):
         super().__init__()
         self.filepath = filepath
+        self.interval = interval
 
     def set_model(self, model: _ModelWrapper):
         self.model = model.model
 
     def on_epoch_end(self, epoch, logs=None):
-        self.model.save(self.filepath.format(epoch=epoch), save_format="tf")
+        if epoch % self.interval == 0:
+            self.model.save(self.filepath.format(epoch=epoch), save_format="tf")

--- a/external/fv3fit/fv3fit/emulation/zhao_carr/filters.py
+++ b/external/fv3fit/fv3fit/emulation/zhao_carr/filters.py
@@ -1,4 +1,10 @@
+"""Filters to be used with unbatched tensorflow datasets
+
+These should be callables of a single column of data (i.e. no batch dimension)
+it must return a scalar boolean.
+"""
 from typing import Set
+import tensorflow as tf
 from fv3fit.emulation.types import TensorDict
 import dataclasses
 import numpy as np
@@ -12,7 +18,7 @@ class HighAntarctic:
     def input_variables(self) -> Set[str]:
         return {"latitude", "surface_air_pressure"}
 
-    def __call__(self, elm: TensorDict):
-        lat = elm["latitude"] < np.deg2rad(-60)
-        ps = elm["surface_air_pressure"] < 700e2
+    def __call__(self, element: TensorDict) -> tf.Tensor:
+        lat = element["latitude"] < np.deg2rad(-60)
+        ps = element["surface_air_pressure"] < 700e2
         return (ps & lat)[0]

--- a/external/fv3fit/fv3fit/emulation/zhao_carr/filters.py
+++ b/external/fv3fit/fv3fit/emulation/zhao_carr/filters.py
@@ -1,0 +1,18 @@
+from typing import Set
+from fv3fit.emulation.types import TensorDict
+import dataclasses
+import numpy as np
+
+
+@dataclasses.dataclass
+class HighAntarctic:
+    high_antarctic_only: bool = True
+
+    @property
+    def input_variables(self) -> Set[str]:
+        return {"latitude", "surface_air_pressure"}
+
+    def __call__(self, elm: TensorDict):
+        lat = elm["latitude"] < np.deg2rad(-60)
+        ps = elm["surface_air_pressure"] < 700e2
+        return (ps & lat)[0]

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -170,6 +170,7 @@ class TransformedParameters(Hyperparameters):
     # only model checkpoints are saved at out_url, but need to keep these name
     # for backwards compatibility
     checkpoint_model: bool = True
+    checkpoint_interval: int = 1
     out_url: str = ""
     # ideally will refactor these out, but need to insert the callback somehow
     use_wandb: bool = True
@@ -447,7 +448,8 @@ def _train_function_unbatched(
             ModelCheckpointCallback(
                 filepath=os.path.join(
                     config.out_url, "checkpoints", "epoch.{epoch:03d}.tf"
-                )
+                ),
+                interval=config.checkpoint_interval,
             )
         )
 

--- a/external/fv3fit/tests/emulation/test_train_microphysics.py
+++ b/external/fv3fit/tests/emulation/test_train_microphysics.py
@@ -12,6 +12,7 @@ from fv3fit.emulation.layers.architecture import ArchitectureConfig
 from fv3fit.emulation.losses import CustomLoss
 from fv3fit.emulation.models import MicrophysicsConfig
 from fv3fit.emulation.zhao_carr_fields import Field
+from fv3fit.emulation.zhao_carr.filters import HighAntarctic
 from fv3fit.emulation.transforms import GscondRoute
 from fv3fit.train_microphysics import (
     TrainConfig,
@@ -216,3 +217,8 @@ def test_TrainConfig_inputs_routed():
     assert "air_temperature_after_gscond" not in config.input_variables
     assert "specific_humidity_after_gscond" not in config.input_variables
     assert "cloud_water_mixing_ratio_after_gscond" not in config.input_variables
+
+
+def test_TrainConfig_filters():
+    config = TrainConfig(filters=[HighAntarctic()], model=MicrophysicsConfig())
+    assert {"latitude", "surface_air_pressure"} <= config.model_variables


### PR DESCRIPTION
Changes to allow training emulators for just the antarctic high plateau. Hopefully we have enough training data there.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/5f62559b-e145-4aeb-a51d-47bd20970262\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)