### PR TITLE
Remove inout-like parameters to GFS_radiation_driver

### DIFF
--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -344,7 +344,6 @@ class RadiationDriver:
             Coupling,
             Grid,
             Tbd,
-            Radtend,
             randomdict,
             lwdict,
             swdict,
@@ -358,7 +357,6 @@ class RadiationDriver:
         Coupling,
         Grid,
         Tbd,
-        Radtend,
         randomdict,
         lwdict,
         swdict,
@@ -423,6 +421,18 @@ class RadiationDriver:
 
         scmpsw = dict()
         Diag = dict()
+        Radtend = dict()
+        Radtend["coszen"] = np.zeros(IM)
+        Radtend["coszdg"] = np.zeros(IM)
+        Radtend["sfalb"] = np.zeros(IM)
+        Radtend["htrsw"] = np.zeros((IM,Model["levs"]))
+        Radtend["swhc"] = np.zeros((IM,Model["levs"]))
+        Radtend["lwhc"] = np.zeros((IM,Model["levs"]))
+        Radtend["semis"] = np.zeros(IM)
+        Radtend["tsflw"] = np.zeros(IM)
+        Radtend["sfcfsw"] = dict()
+        Radtend["sfcflw"] = dict()
+
         Diag["fluxr"]  = np.zeros((IM,45))
         Diag["topflw"] = dict()
         Diag["topfsw"] = dict()

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -345,7 +345,6 @@ class RadiationDriver:
             Grid,
             Tbd,
             Radtend,
-            Diag,
             randomdict,
             lwdict,
             swdict,
@@ -360,7 +359,6 @@ class RadiationDriver:
         Grid,
         Tbd,
         Radtend,
-        Diag,
         randomdict,
         lwdict,
         swdict,
@@ -424,7 +422,10 @@ class RadiationDriver:
         cldtausw = np.zeros((IM, Model["levr"] + self.LTP))
 
         scmpsw = dict()
-
+        Diag = dict()
+        Diag["fluxr"]  = np.zeros((IM,45))
+        Diag["topflw"] = dict()
+        Diag["topfsw"] = dict()
         Diag["topfsw"]["upfxc"] = np.zeros(IM)
         Diag["topfsw"]["dnfxc"] = np.zeros(IM)
         Diag["topfsw"]["upfx0"] = np.zeros(IM)

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -338,28 +338,11 @@ class RadiationDriver:
     ):
 
         return self._GFS_radiation_driver(
-            Model,
-            Statein,
-            Sfcprop,
-            Coupling,
-            Grid,
-            Tbd,
-            randomdict,
-            lwdict,
-            swdict,
+            Model, Statein, Sfcprop, Grid, Tbd, randomdict, lwdict, swdict,
         )
 
     def _GFS_radiation_driver(
-        self,
-        Model,
-        Statein,
-        Sfcprop,
-        Coupling,
-        Grid,
-        Tbd,
-        randomdict,
-        lwdict,
-        swdict,
+        self, Model, Statein, Sfcprop, Grid, Tbd, randomdict, lwdict, swdict,
     ):
         if not (Model["lsswr"] or Model["lslwr"]):
             return
@@ -419,21 +402,31 @@ class RadiationDriver:
 
         cldtausw = np.zeros((IM, Model["levr"] + self.LTP))
 
+        Coupling = dict()
+        Coupling["nirbmdi"] = np.zeros(IM)
+        Coupling["nirdfdi"] = np.zeros(IM)
+        Coupling["visbmdi"] = np.zeros(IM)
+        Coupling["visdfdi"] = np.zeros(IM)
+        Coupling["nirbmui"] = np.zeros(IM)
+        Coupling["nirdfui"] = np.zeros(IM)
+        Coupling["visbmui"] = np.zeros(IM)
+        Coupling["visdfui"] = np.zeros(IM)
+
         scmpsw = dict()
         Diag = dict()
         Radtend = dict()
         Radtend["coszen"] = np.zeros(IM)
         Radtend["coszdg"] = np.zeros(IM)
         Radtend["sfalb"] = np.zeros(IM)
-        Radtend["htrsw"] = np.zeros((IM,Model["levs"]))
-        Radtend["swhc"] = np.zeros((IM,Model["levs"]))
-        Radtend["lwhc"] = np.zeros((IM,Model["levs"]))
+        Radtend["htrsw"] = np.zeros((IM, Model["levs"]))
+        Radtend["swhc"] = np.zeros((IM, Model["levs"]))
+        Radtend["lwhc"] = np.zeros((IM, Model["levs"]))
         Radtend["semis"] = np.zeros(IM)
         Radtend["tsflw"] = np.zeros(IM)
         Radtend["sfcfsw"] = dict()
         Radtend["sfcflw"] = dict()
 
-        Diag["fluxr"]  = np.zeros((IM,45))
+        Diag["fluxr"] = np.zeros((IM, 45))
         Diag["topflw"] = dict()
         Diag["topfsw"] = dict()
         Diag["topfsw"]["upfxc"] = np.zeros(IM)
@@ -1045,41 +1038,35 @@ class RadiationDriver:
                 #  - Save two spectral bands' surface downward and upward fluxes for
                 #    output.
 
-                for i in range(IM):
-                    Coupling["nirbmdi"][i] = scmpsw["nirbm"][i]
-                    Coupling["nirdfdi"][i] = scmpsw["nirdf"][i]
-                    Coupling["visbmdi"][i] = scmpsw["visbm"][i]
-                    Coupling["visdfdi"][i] = scmpsw["visdf"][i]
+                Coupling["nirbmdi"] = scmpsw["nirbm"]
+                Coupling["nirdfdi"] = scmpsw["nirdf"]
+                Coupling["visbmdi"] = scmpsw["visbm"]
+                Coupling["visdfdi"] = scmpsw["visdf"]
 
-                    Coupling["nirbmui"][i] = scmpsw["nirbm"][i] * sfcalb[i, 0]
-                    Coupling["nirdfui"][i] = scmpsw["nirdf"][i] * sfcalb[i, 1]
-                    Coupling["visbmui"][i] = scmpsw["visbm"][i] * sfcalb[i, 2]
-                    Coupling["visdfui"][i] = scmpsw["visdf"][i] * sfcalb[i, 3]
+                Coupling["nirbmui"] = scmpsw["nirbm"] * sfcalb[:, 0]
+                Coupling["nirdfui"] = scmpsw["nirdf"] * sfcalb[:, 1]
+                Coupling["visbmui"] = scmpsw["visbm"] * sfcalb[:, 2]
+                Coupling["visdfui"] = scmpsw["visdf"] * sfcalb[:, 3]
 
             else:
 
                 Radtend["htrsw"][:, :] = 0.0
-
-                for i in range(IM):
-                    Coupling["nirbmdi"][i] = 0.0
-                    Coupling["nirdfdi"][i] = 0.0
-                    Coupling["visbmdi"][i] = 0.0
-                    Coupling["visdfdi"][i] = 0.0
-                    Coupling["nirbmui"][i] = 0.0
-                    Coupling["nirdfui"][i] = 0.0
-                    Coupling["visbmui"][i] = 0.0
-                    Coupling["visdfui"][i] = 0.0
+                Coupling["nirbmdi"] = np.zeros(IM)
+                Coupling["nirdfdi"] = np.zeros(IM)
+                Coupling["visbmdi"] = np.zeros(IM)
+                Coupling["visdfdi"] = np.zeros(IM)
+                Coupling["nirbmui"] = np.zeros(IM)
+                Coupling["nirdfui"] = np.zeros(IM)
+                Coupling["visbmui"] = np.zeros(IM)
+                Coupling["visdfui"] = np.zeros(IM)
 
                 if Model["swhtr"]:
                     Radtend["swhc"][:, :] = 0
                     cldtausw[:, :] = 0.0
 
             # --- radiation fluxes for other physics processes
-            for i in range(IM):
-                Coupling["sfcnsw"][i] = (
-                    Radtend["sfcfsw"]["dnfxc"][i] - Radtend["sfcfsw"]["upfxc"][i]
-                )
-                Coupling["sfcdsw"][i] = Radtend["sfcfsw"]["dnfxc"][i]
+            Coupling["sfcnsw"] = Radtend["sfcfsw"]["dnfxc"] - Radtend["sfcfsw"]["upfxc"]
+            Coupling["sfcdsw"] = Radtend["sfcfsw"]["dnfxc"]
 
         # Start LW radiation calculations
         if Model["lslwr"]:
@@ -1201,7 +1188,7 @@ class RadiationDriver:
                         Radtend["lwhc"][:IM, k] = Radtend["lwhc"][:IM, LM - 1]
 
             # --- radiation fluxes for other physics processes
-            Coupling["sfcdlw"][:] = Radtend["sfcflw"]["dnfxc"]
+            Coupling["sfcdlw"] = Radtend["sfcflw"]["dnfxc"]
 
         #  - For time averaged output quantities (including total-sky and
         #    clear-sky SW and LW fluxes at TOA and surface; conventional

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -337,6 +337,34 @@ class RadiationDriver:
         swdict,
     ):
 
+        return self._GFS_radiation_driver(
+            Model,
+            Statein,
+            Sfcprop,
+            Coupling,
+            Grid,
+            Tbd,
+            Radtend,
+            Diag,
+            randomdict,
+            lwdict,
+            swdict,
+        )
+
+    def _GFS_radiation_driver(
+        self,
+        Model,
+        Statein,
+        Sfcprop,
+        Coupling,
+        Grid,
+        Tbd,
+        Radtend,
+        Diag,
+        randomdict,
+        lwdict,
+        swdict,
+    ):
         if not (Model["lsswr"] or Model["lslwr"]):
             return
 

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -403,21 +403,11 @@ class RadiationDriver:
         cldtausw = np.zeros((IM, Model["levr"] + self.LTP))
 
         Coupling = dict()
-        Coupling["nirbmdi"] = np.zeros(IM)
-        Coupling["nirdfdi"] = np.zeros(IM)
-        Coupling["visbmdi"] = np.zeros(IM)
-        Coupling["visdfdi"] = np.zeros(IM)
-        Coupling["nirbmui"] = np.zeros(IM)
-        Coupling["nirdfui"] = np.zeros(IM)
-        Coupling["visbmui"] = np.zeros(IM)
-        Coupling["visdfui"] = np.zeros(IM)
-
         scmpsw = dict()
         Diag = dict()
         Radtend = dict()
         Radtend["coszen"] = np.zeros(IM)
         Radtend["coszdg"] = np.zeros(IM)
-        Radtend["sfalb"] = np.zeros(IM)
         Radtend["htrsw"] = np.zeros((IM, Model["levs"]))
         Radtend["swhc"] = np.zeros((IM, Model["levs"]))
         Radtend["lwhc"] = np.zeros((IM, Model["levs"]))
@@ -906,7 +896,7 @@ class RadiationDriver:
             )
 
             # Approximate mean surface albedo from vis- and nir-  diffuse values.
-            Radtend["sfalb"][:] = np.maximum(0.01, 0.5 * (sfcalb[:, 1] + sfcalb[:, 3]))
+            Radtend["sfalb"] = np.maximum(0.01, 0.5 * (sfcalb[:, 1] + sfcalb[:, 3]))
 
             lhswb = False
             lhsw0 = True

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -1354,4 +1354,4 @@ class RadiationDriver:
                             1.0 - np.exp(-tem2)
                         )
 
-        return Radtend, Diag
+        return Radtend, Diag, Coupling

--- a/external/radiation/python/radiation_driver.py
+++ b/external/radiation/python/radiation_driver.py
@@ -402,10 +402,10 @@ class RadiationDriver:
 
         cldtausw = np.zeros((IM, Model["levr"] + self.LTP))
 
-        Coupling = dict()
-        scmpsw = dict()
-        Diag = dict()
-        Radtend = dict()
+        Coupling = {}
+        scmpsw = {}
+        Diag = {}
+        Radtend = {}
         Radtend["coszen"] = np.zeros(IM)
         Radtend["coszdg"] = np.zeros(IM)
         Radtend["htrsw"] = np.zeros((IM, Model["levs"]))

--- a/external/radiation/python/test_driver.py
+++ b/external/radiation/python/test_driver.py
@@ -179,7 +179,7 @@ for rank in range(6):
     lwdict = getdata.lw(LOOKUP_DIR)
     swdict = getdata.sw(LOOKUP_DIR)
 
-    Radtendout, Diagout = driver.GFS_radiation_driver(
+    Radtendout, Diagout, Couplingout = driver.GFS_radiation_driver(
         Model,
         Statein,
         Sfcprop,


### PR DESCRIPTION
This PR defined a method called _GFS_radiation_driver() that does not take zero array inputs. 

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/3fc45540-4060-4207-a6ea-85734af1895f\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)