### PR TITLE
Add longitudinal Hovmoller plots to prognostic run report

### DIFF
--- a/external/vcm/tests/test_select.py
+++ b/external/vcm/tests/test_select.py
@@ -18,13 +18,16 @@ from vcm.select import (
 def test_approximate_averages(function, group_name):
     group = xr.DataArray(np.linspace(0, 9, 10), dims=["x"])
     data = xr.DataArray(
-        [[i * j for i in range(10)] for j in [0, 1]], dims=["z", "x"]
+        [[i * j for i in range(10)] for j in [0, 1]],
+        dims=["z", "x"],
+        attrs={"units": "test_units"},
     ).rename("data")
     average = function(group, data, bins=np.arange(0, 10, 2),)
     # bins are (low, high]
     np.testing.assert_allclose(average.isel(z=0), np.zeros(4))
     np.testing.assert_allclose(average.isel(z=1), [1.5, 3.5, 5.5, 7.5])
     assert group_name in average.dims
+    assert average.attrs["units"] == "test_units"
 
 
 @pytest.mark.parametrize(
@@ -35,13 +38,16 @@ def test_weighted_approximate_averages(function, group_name):
     group = xr.DataArray(np.arange(10), dims=["x"])
     weights = (group % 2) == 1
     data = xr.DataArray(
-        [[i * j for i in range(10)] for j in [0, 1]], dims=["z", "x"]
+        [[i * j for i in range(10)] for j in [0, 1]],
+        dims=["z", "x"],
+        attrs={"units": "test_units"},
     ).rename("data")
     average = function(group, data, bins=np.arange(0, 11, 2), weights=weights,)
     # bins are (low, high]
     np.testing.assert_allclose(average.isel(z=0), np.zeros(5))
     np.testing.assert_allclose(average.isel(z=1), np.arange(1, 11, 2))
     assert group_name in average.dims
+    assert average.attrs["units"] == "test_units"
 
 
 @pytest.fixture()

--- a/external/vcm/tests/test_xarray_utils.py
+++ b/external/vcm/tests/test_xarray_utils.py
@@ -154,7 +154,7 @@ def test_weighted_mean_via_groupby_bins_dataset():
     # means and ignoring NaNs is tested at the DataArray level above.
     a = xr.DataArray(np.arange(10), dims=["x"], name="foo", attrs={"units": "mm/day"})
     b = xr.DataArray(np.arange(10), dims=["y"], name="bar", attrs={"units": "K"})
-    ds = xr.merge([a, b])
+    ds = xr.Dataset({a.name: a, b.name: b})
 
     group = xr.DataArray(np.arange(10), dims=["x"], name="baz")
     bins = np.array(np.arange(0, 11, 2))
@@ -163,9 +163,4 @@ def test_weighted_mean_via_groupby_bins_dataset():
     result = weighted_mean_via_groupby_bins(ds, group, weights, bins)
     with xr.set_options(keep_attrs=True):
         expected = ds.groupby_bins(group, bins).mean()
-
-    # Due to an xarray bug in groupby_bins, units are added to the Dataset
-    # attributes in addition to being maintained on the data variables.  We
-    # remove the Dataset attributes here.
-    expected.attrs = {}
     assert_identical_including_dtype(result, expected)

--- a/external/vcm/tests/test_xarray_utils.py
+++ b/external/vcm/tests/test_xarray_utils.py
@@ -1,5 +1,6 @@
 import dask
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
@@ -8,6 +9,7 @@ from vcm.xarray_utils import (
     assert_identical_including_dtype,
     isclose,
     repeat,
+    weighted_mean_via_groupby_bins,
 )
 
 
@@ -109,3 +111,55 @@ def test_assert_identical_including_dtype(object_type):
 
     with pytest.raises(AssertionError):
         assert_identical_including_dtype(d, b)
+
+
+def test_weighted_mean_via_groupby_bins():
+    a = xr.DataArray(np.arange(10), dims=["x"], name="foo")
+    group = xr.DataArray(np.arange(10), dims=["x"], name="bar")
+    bins = np.array(np.arange(0, 11, 2))
+    weights = (group % 2) == 1
+
+    result = weighted_mean_via_groupby_bins(a, group, weights, bins)
+    expected_coordinate = pd.interval_range(start=0, end=10, freq=2)
+    expected = xr.DataArray(
+        np.arange(1, 11, 2, dtype=float),
+        dims=["bar_bins"],
+        coords=[expected_coordinate],
+        name="foo",
+    )
+    assert_identical_including_dtype(result, expected)
+
+
+def test_weighted_mean_via_groupby_bins_with_nans():
+    a = xr.DataArray(np.arange(10), dims=["x"], name="foo")
+    a = a.where((a % 5) > 2)  # Introduce some NaNs
+    group = xr.DataArray(np.arange(10), dims=["x"], name="bar")
+    bins = np.array(np.arange(0, 11, 5))
+
+    # This is just testing that NaNs are properly zeroed out in the weights,
+    # so we can use an array of ones to keep things simple.
+    weights = xr.ones_like(group)
+
+    result = weighted_mean_via_groupby_bins(a, group, weights, bins)
+    expected_coordinate = pd.interval_range(start=0, end=10, freq=5)
+    expected = xr.DataArray(
+        [3.5, 8.5], dims=["bar_bins"], coords=[expected_coordinate], name="foo"
+    )
+    assert_identical_including_dtype(result, expected)
+
+
+def test_weighted_mean_via_groupby_bins_dataset():
+    # This test just ensures the broadcasting behavior matches that
+    # of xarray's built-in groupby_bins.  The logic for computing weighted
+    # means and ignoring NaNs is tested at the DataArray level above.
+    a = xr.DataArray(np.arange(10), dims=["x"], name="foo")
+    b = xr.DataArray(np.arange(10), dims=["y"], name="bar")
+    ds = xr.merge([a, b])
+
+    group = xr.DataArray(np.arange(10), dims=["x"], name="baz")
+    bins = np.array(np.arange(0, 11, 2))
+    weights = xr.ones_like(a)
+
+    result = weighted_mean_via_groupby_bins(ds, group, weights, bins)
+    expected = ds.groupby_bins(group, bins).mean()
+    assert_identical_including_dtype(result, expected)

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -68,7 +68,12 @@ from .interpolate import (
 )
 
 from ._zarr_mapping import ZarrMapping
-from .select import mask_to_surface_type, RegionOfInterest, zonal_average_approximate
+from .select import (
+    mask_to_surface_type,
+    RegionOfInterest,
+    zonal_average_approximate,
+    meridional_average_approximate,
+)
 from .xarray_loaders import open_tiles, open_delayed, open_remote_nc, dump_nc
 from .sampling import train_test_split_sample
 from .derived_mapping import DerivedMapping

--- a/external/vcm/vcm/select.py
+++ b/external/vcm/vcm/select.py
@@ -41,6 +41,33 @@ def zonal_average_approximate(
     return output.assign_coords({lat_name: lats_mid})
 
 
+def meridional_average_approximate(
+    lon: xr.DataArray,
+    data: Union[xr.DataArray, xr.Dataset],
+    bins: Optional[Sequence[float]] = None,
+    lon_name: str = "lon",
+):
+    """Compute meridional mean of a dataset or dataarray using groupby_bins.
+
+    Args:
+        lon: longitude values on same grid as data.
+        data: dataset of variables to averaged or dataarray to be averaged.
+        bins: bins to use for zonal mean. Output will have a coordinate
+            using the midpoints of given bins. Defaults to np.arange(0, 361, 2).
+        lon_name: name to use for latitude coordinate in output.
+
+    Returns:
+        meridional mean of dataset or dataarray.
+    """
+    if bins is None:
+        bins = np.arange(0, 361, 2)
+    with xr.set_options(keep_attrs=True):
+        output = data.groupby_bins(lon.rename("lon"), bins=bins).mean()
+        output = output.rename({"lon_bins": lon_name})
+    lons_mid = [lon.item().mid for lon in output[lon_name]]
+    return output.assign_coords({lon_name: lons_mid})
+
+
 def meridional_ring(lon=0, n=180):
     attrs = {"description": f"Lon = {lon}"}
     lat = np.linspace(-90, 90, n)

--- a/external/vcm/vcm/select.py
+++ b/external/vcm/vcm/select.py
@@ -12,6 +12,18 @@ from vcm.cubedsphere.constants import (
     VAR_LAT_CENTER,
     VAR_LON_CENTER,
 )
+from vcm.xarray_utils import weighted_mean_via_groupby_bins
+
+
+def _groupby_bins(data, group, group_name, bins, weights=None):
+    renamed_group = group.rename(group_name)
+    if weights is None:
+        output = data.groupby_bins(renamed_group, bins=bins).mean()
+    else:
+        output = weighted_mean_via_groupby_bins(data, renamed_group, weights, bins=bins)
+    output = output.rename({f"{group_name}_bins": group_name})
+    midpoints = [v.item().mid for v in output[group_name]]
+    return output.assign_coords({group_name: midpoints})
 
 
 def zonal_average_approximate(
@@ -19,6 +31,7 @@ def zonal_average_approximate(
     data: Union[xr.DataArray, xr.Dataset],
     bins: Optional[Sequence[float]] = None,
     lat_name: str = "lat",
+    weights: Optional[xr.DataArray] = None,
 ):
     """Compute zonal mean of a dataset or dataarray using groupby_bins.
 
@@ -28,17 +41,14 @@ def zonal_average_approximate(
         bins: bins to use for zonal mean. Output will have a coordinate
             using the midpoints of given bins. Defaults to np.arange(-90, 91, 2).
         lat_name: name to use for latitude coordinate in output.
+        weights: weights to use when computing the zonal mean
 
     Returns:
         zonal mean of dataset or dataarray.
     """
     if bins is None:
         bins = np.arange(-90, 91, 2)
-    with xr.set_options(keep_attrs=True):
-        output = data.groupby_bins(lat.rename("lat"), bins=bins).mean()
-        output = output.rename({"lat_bins": lat_name})
-    lats_mid = [lat.item().mid for lat in output[lat_name]]
-    return output.assign_coords({lat_name: lats_mid})
+    return _groupby_bins(data, lat, lat_name, bins, weights)
 
 
 def meridional_average_approximate(
@@ -46,26 +56,24 @@ def meridional_average_approximate(
     data: Union[xr.DataArray, xr.Dataset],
     bins: Optional[Sequence[float]] = None,
     lon_name: str = "lon",
+    weights: Optional[xr.DataArray] = None,
 ):
     """Compute meridional mean of a dataset or dataarray using groupby_bins.
 
     Args:
         lon: longitude values on same grid as data.
         data: dataset of variables to averaged or dataarray to be averaged.
-        bins: bins to use for zonal mean. Output will have a coordinate
+        bins: bins to use for meridional mean. Output will have a coordinate
             using the midpoints of given bins. Defaults to np.arange(0, 361, 2).
         lon_name: name to use for latitude coordinate in output.
+        weights: weights to use when computing the meridional mean
 
     Returns:
         meridional mean of dataset or dataarray.
     """
     if bins is None:
         bins = np.arange(0, 361, 2)
-    with xr.set_options(keep_attrs=True):
-        output = data.groupby_bins(lon.rename("lon"), bins=bins).mean()
-        output = output.rename({"lon_bins": lon_name})
-    lons_mid = [lon.item().mid for lon in output[lon_name]]
-    return output.assign_coords({lon_name: lons_mid})
+    return _groupby_bins(data, lon, lon_name, bins, weights)
 
 
 def meridional_ring(lon=0, n=180):

--- a/external/vcm/vcm/select.py
+++ b/external/vcm/vcm/select.py
@@ -18,7 +18,8 @@ from vcm.xarray_utils import weighted_mean_via_groupby_bins
 def _groupby_bins(data, group, group_name, bins, weights=None):
     renamed_group = group.rename(group_name)
     if weights is None:
-        output = data.groupby_bins(renamed_group, bins=bins).mean()
+        with xr.set_options(keep_attrs=True):
+            output = data.groupby_bins(renamed_group, bins=bins).mean()
     else:
         output = weighted_mean_via_groupby_bins(data, renamed_group, weights, bins=bins)
     output = output.rename({f"{group_name}_bins": group_name})

--- a/external/vcm/vcm/xarray_utils.py
+++ b/external/vcm/vcm/xarray_utils.py
@@ -136,7 +136,5 @@ def weighted_mean_via_groupby_bins(
     else:
         result = numerator / denominator
         for v in obj.data_vars:
-            # print(obj[v])
             result[v] = result[v].assign_attrs(obj[v].attrs)
-            # print(result[v])
         return result

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/transform.py
@@ -295,6 +295,8 @@ def _mask_array(
         net_precipitation = xr.full_like(arr, fill_value=np.nan)
     if region == "tropics":
         masked_arr = arr.where(abs(latitude) <= 10.0)
+    elif region == "tropics15":
+        masked_arr = arr.where(abs(latitude) <= 15.0)
     elif region == "tropics20":
         masked_arr = arr.where(abs(latitude) <= 20.0)
     elif region == "global":

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -347,17 +347,16 @@ def _compute_deep_tropical_meridional_mean(
 
 @registry_2d.register("deep_tropical_meridional_mean_value")
 @transform.apply(transform.resample_time, "3H", inner_join=True)
-@transform.apply(transform.daily_mean, datetime.timedelta(days=10))
 @transform.apply(transform.subset_variables, ["total_precip_to_surface", "ULWRFtoa"])
 @transform.apply(transform.mask_to_sfc_type, "tropics20")
 def deep_tropical_mean_hovmoller_value(diag_arg: DiagArg):
     logger.info(f"Preparing deep tropical meridional mean values (2d)")
-    return _compute_deep_tropical_meridional_mean(diag_arg.prediction, diag_arg.grid)
+    result = _compute_deep_tropical_meridional_mean(diag_arg.prediction, diag_arg.grid)
+    return result.rename({"time": "high_frequency_time"})
 
 
 @registry_2d.register("deep_tropical_meridional_mean_bias")
 @transform.apply(transform.resample_time, "3H", inner_join=True)
-@transform.apply(transform.daily_mean, datetime.timedelta(days=10))
 @transform.apply(transform.subset_variables, ["total_precip_to_surface", "ULWRFtoa"])
 @transform.apply(transform.mask_to_sfc_type, "tropics20")
 def deep_tropical_mean_hovmoller_bias(diag_arg: DiagArg):
@@ -365,7 +364,7 @@ def deep_tropical_mean_hovmoller_bias(diag_arg: DiagArg):
     grid = diag_arg.grid
     prediction = _compute_deep_tropical_meridional_mean(diag_arg.prediction, grid)
     verification = _compute_deep_tropical_meridional_mean(diag_arg.verification, grid)
-    return bias(verification, prediction)
+    return bias(verification, prediction).rename({"time": "high_frequency_time"})
 
 
 for mask_type in ["global", "land", "sea", "tropics"]:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -347,6 +347,7 @@ def deep_tropical_mean_hovmoller(diag_arg: DiagArg):
                 grid.lon,
                 prognostic[[var]].where(np.abs(grid.lat) <= 15),
                 lon_name="longitude",
+                weights=grid.area,
             )[var].load()
     return deep_tropical_means
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -336,6 +336,7 @@ def zonal_mean_bias_hovmoller(diag_arg: DiagArg):
 @transform.apply(transform.resample_time, "3H", inner_join=True)
 @transform.apply(transform.daily_mean, datetime.timedelta(days=10))
 @transform.apply(transform.subset_variables, ["total_precip_to_surface", "ULWRFtoa"])
+@transform.apply(transform.mask_to_sfc_type, "tropics20")
 def deep_tropical_mean_hovmoller(diag_arg: DiagArg):
     logger.info(f"Preparing deep tropical meridional mean values (2d)")
     prognostic, grid = diag_arg.prediction, diag_arg.grid
@@ -344,10 +345,7 @@ def deep_tropical_mean_hovmoller(diag_arg: DiagArg):
         logger.info(f"Computing deep tropical meridional mean (2d) over time for {var}")
         with xr.set_options(keep_attrs=True):
             deep_tropical_means[var] = vcm.meridional_average_approximate(
-                grid.lon,
-                prognostic[[var]].where(np.abs(grid.lat) <= 15),
-                lon_name="longitude",
-                weights=grid.area,
+                grid.lon, prognostic[[var]], lon_name="longitude", weights=grid.area,
             )[var].load()
     return deep_tropical_means
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -332,22 +332,40 @@ def zonal_mean_bias_hovmoller(diag_arg: DiagArg):
     return zonal_means
 
 
+def _compute_deep_tropical_meridional_mean(
+    ds: xr.Dataset, grid: xr.Dataset
+) -> xr.Dataset:
+    deep_tropical_means = xr.Dataset()
+    for var in ds.data_vars:
+        logger.info(f"Computing deep tropical meridional mean (2d) over time for {var}")
+        with xr.set_options(keep_attrs=True):
+            deep_tropical_means[var] = vcm.meridional_average_approximate(
+                grid.lon, ds[[var]], lon_name="longitude", weights=grid.area,
+            )[var].load()
+    return deep_tropical_means
+
+
 @registry_2d.register("deep_tropical_meridional_mean_value")
 @transform.apply(transform.resample_time, "3H", inner_join=True)
 @transform.apply(transform.daily_mean, datetime.timedelta(days=10))
 @transform.apply(transform.subset_variables, ["total_precip_to_surface", "ULWRFtoa"])
 @transform.apply(transform.mask_to_sfc_type, "tropics20")
-def deep_tropical_mean_hovmoller(diag_arg: DiagArg):
+def deep_tropical_mean_hovmoller_value(diag_arg: DiagArg):
     logger.info(f"Preparing deep tropical meridional mean values (2d)")
-    prognostic, grid = diag_arg.prediction, diag_arg.grid
-    deep_tropical_means = xr.Dataset()
-    for var in prognostic.data_vars:
-        logger.info(f"Computing deep tropical meridional mean (2d) over time for {var}")
-        with xr.set_options(keep_attrs=True):
-            deep_tropical_means[var] = vcm.meridional_average_approximate(
-                grid.lon, prognostic[[var]], lon_name="longitude", weights=grid.area,
-            )[var].load()
-    return deep_tropical_means
+    return _compute_deep_tropical_meridional_mean(diag_arg.prediction, diag_arg.grid)
+
+
+@registry_2d.register("deep_tropical_meridional_mean_bias")
+@transform.apply(transform.resample_time, "3H", inner_join=True)
+@transform.apply(transform.daily_mean, datetime.timedelta(days=10))
+@transform.apply(transform.subset_variables, ["total_precip_to_surface", "ULWRFtoa"])
+@transform.apply(transform.mask_to_sfc_type, "tropics20")
+def deep_tropical_mean_hovmoller_bias(diag_arg: DiagArg):
+    logger.info(f"Preparing deep tropical meridional mean biases (2d)")
+    grid = diag_arg.grid
+    prediction = _compute_deep_tropical_meridional_mean(diag_arg.prediction, grid)
+    verification = _compute_deep_tropical_meridional_mean(diag_arg.verification, grid)
+    return bias(verification, prediction)
 
 
 for mask_type in ["global", "land", "sea", "tropics"]:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -103,9 +103,7 @@ class RunDiagnostics:
     def __post_init__(self):
         # indexes for faster lookup
         self._attrs = {ds.run: ds.attrs for ds in self.diagnostics}
-        self._varnames = {
-            ds.run: set(ds).union(set(ds.coords)) for ds in self.diagnostics
-        }
+        self._varnames = {ds.run: set(ds.variables) for ds in self.diagnostics}
         self._run_index = {ds.run: k for k, ds in enumerate(self.diagnostics)}
 
     @property
@@ -116,7 +114,7 @@ class RunDiagnostics:
     @property
     def variables(self) -> Set[str]:
         """The available variables"""
-        return set.union(*[set(d).union(set(d.coords)) for d in self.diagnostics])
+        return set.union(*[set(d.variables) for d in self.diagnostics])
 
     @property
     def long_names(self) -> Mapping[str, str]:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -103,7 +103,9 @@ class RunDiagnostics:
     def __post_init__(self):
         # indexes for faster lookup
         self._attrs = {ds.run: ds.attrs for ds in self.diagnostics}
-        self._varnames = {ds.run: set(ds) for ds in self.diagnostics}
+        self._varnames = {
+            ds.run: set(ds).union(set(ds.coords)) for ds in self.diagnostics
+        }
         self._run_index = {ds.run: k for k, ds in enumerate(self.diagnostics)}
 
     @property

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -370,6 +370,7 @@ def _get_verification_diagnostics(ds: xr.Dataset) -> xr.Dataset:
         "histogram": "hist_bias",
         "hist_2d": "hist2d_bias",
         "pressure_level_zonal_time_mean": "pressure_level_zonal_bias",
+        "deep_tropical_meridional_mean_value": "deep_tropical_meridional_mean_bias",
     }
     for mean_filter, bias_filter in mean_bias_pairs.items():
         mean_vars = [var for var in ds if mean_filter in var]

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -116,7 +116,7 @@ class RunDiagnostics:
     @property
     def variables(self) -> Set[str]:
         """The available variables"""
-        return set.union(*[set(d) for d in self.diagnostics])
+        return set.union(*[set(d).union(set(d.coords)) for d in self.diagnostics])
 
     @property
     def long_names(self) -> Mapping[str, str]:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -177,3 +177,10 @@ TOP_LEVEL_METRICS = {
 
 GRID_VARS = ("lat", "latb", "lon", "lonb")
 GRID_INTERFACE_COORDS = ("x_interface", "y_interface")
+
+# https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html
+DEFAULT_FIGURE_WIDTH = 6.4
+DEFAULT_FIGURE_HEIGHT = 4.8
+
+# For inferring a readable aspect ratio for tropical Hovmoller plots
+REFERENCE_HOVMOLLER_DURATION_SECONDS = 40 * 86400

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -67,6 +67,7 @@ def plot_2d_matplotlib(
     varfilter: str,
     dims: Tuple[str, str],
     contour=False,
+    figsize=None,
     **opts,
 ) -> RawHTML:
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
@@ -88,7 +89,7 @@ def plot_2d_matplotlib(
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)
             long_name_and_units = f"{v.long_name} [{v.units}]"
-            fig, ax = plt.subplots()
+            fig, ax = plt.subplots(figsize=figsize)
             if contour:
                 levels = CONTOUR_LEVELS.get(varname)
                 xr.plot.contourf(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -27,6 +27,9 @@ from fv3net.diagnostics.prognostic_run.constants import (
     PERCENTILES,
     PRECIP_RATE,
     TOP_LEVEL_METRICS,
+    DEFAULT_FIGURE_WIDTH,
+    DEFAULT_FIGURE_HEIGHT,
+    REFERENCE_HOVMOLLER_DURATION_SECONDS,
     MovieUrls,
 )
 from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
@@ -274,12 +277,31 @@ def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTM
     return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
+def infer_duration_seconds(diagnostics: Iterable[xr.Dataset]) -> float:
+    sample_diagnostics, *_ = diagnostics
+    sample_time = sample_diagnostics.time
+    return (sample_time.isel(time=-1) - sample_time.isel(time=0)).item().total_seconds()
+
+
+def infer_tropical_hovmoller_figsize(
+    diagnostics: Iterable[xr.Dataset],
+) -> Tuple[int, int]:
+    duration_seconds = infer_duration_seconds(diagnostics)
+    ratio = duration_seconds / REFERENCE_HOVMOLLER_DURATION_SECONDS
+    height = DEFAULT_FIGURE_HEIGHT * ratio
+    return (DEFAULT_FIGURE_WIDTH, 3 * height)
+
+
 @tropical_hovmoller_plot_manager.register
 def deep_tropical_meridional_mean_hovmoller_plots(
     diagnostics: Iterable[xr.Dataset],
 ) -> RawHTML:
+    figsize = infer_tropical_hovmoller_figsize(diagnostics)
     return plot_2d_matplotlib(
-        diagnostics, "deep_tropical_meridional_mean_value", ["longitude", "time"]
+        diagnostics,
+        "deep_tropical_meridional_mean_value",
+        ["longitude", "time"],
+        figsize=figsize,
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -280,8 +280,8 @@ def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTM
 
 def infer_duration_seconds(diagnostics: RunDiagnostics) -> float:
     run, *_ = diagnostics.runs
-    sample_time = diagnostics.get_variable(run, "time")
-    delta = sample_time.isel(time=-1) - sample_time.isel(time=0)
+    time = diagnostics.get_variable(run, "high_frequency_time")
+    delta = time.isel(high_frequency_time=-1) - time.isel(high_frequency_time=0)
     return (delta / np.timedelta64(1, "s")).item()
 
 
@@ -303,7 +303,7 @@ def deep_tropical_meridional_mean_hovmoller_plots(
     return plot_2d_matplotlib(
         diagnostics,
         "deep_tropical_meridional_mean_value",
-        ["longitude", "time"],
+        ["longitude", "high_frequency_time"],
         figsize=figsize,
     )
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 import os
 import xarray as xr
 import fsspec
+import numpy as np
 import pandas as pd
 import holoviews as hv
 
@@ -277,24 +278,26 @@ def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTM
     return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
-def infer_duration_seconds(diagnostics: Iterable[xr.Dataset]) -> float:
-    sample_diagnostics, *_ = diagnostics
-    sample_time = sample_diagnostics.time
-    return (sample_time.isel(time=-1) - sample_time.isel(time=0)).item().total_seconds()
+def infer_duration_seconds(diagnostics: RunDiagnostics) -> float:
+    run, *_ = diagnostics.runs
+    sample_time = diagnostics.get_variable(run, "time")
+    delta = sample_time.isel(time=-1) - sample_time.isel(time=0)
+    return (delta / np.timedelta64(1, "s")).item()
 
 
-def infer_tropical_hovmoller_figsize(
-    diagnostics: Iterable[xr.Dataset],
-) -> Tuple[int, int]:
+def infer_tropical_hovmoller_figsize(diagnostics: RunDiagnostics,) -> Tuple[int, int]:
+    """A heuristic to infer a reasonable size and aspect ratio for Hovmoller plots"""
     duration_seconds = infer_duration_seconds(diagnostics)
-    ratio = duration_seconds / REFERENCE_HOVMOLLER_DURATION_SECONDS
-    height = DEFAULT_FIGURE_HEIGHT * ratio
-    return (DEFAULT_FIGURE_WIDTH, 3 * height)
+    height_ratio = duration_seconds / REFERENCE_HOVMOLLER_DURATION_SECONDS
+    reference_width = DEFAULT_FIGURE_WIDTH
+    reference_height = DEFAULT_FIGURE_HEIGHT
+    height = min(reference_height * height_ratio, 10 * reference_height)
+    return (reference_width, height)
 
 
 @tropical_hovmoller_plot_manager.register
 def deep_tropical_meridional_mean_hovmoller_plots(
-    diagnostics: Iterable[xr.Dataset],
+    diagnostics: RunDiagnostics,
 ) -> RawHTML:
     figsize = infer_tropical_hovmoller_figsize(diagnostics)
     return plot_2d_matplotlib(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -235,6 +235,7 @@ hovmoller_plot_manager = PlotManager()
 zonal_pressure_plot_manager = PlotManager()
 diurnal_plot_manager = PlotManager()
 histogram_plot_manager = PlotManager()
+tropical_hovmoller_plot_manager = PlotManager()
 
 # this will be passed the data from the metrics.json files
 metrics_plot_manager = PlotManager()
@@ -271,6 +272,15 @@ def zonal_mean_hovmoller_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
     return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
+
+
+@tropical_hovmoller_plot_manager.register
+def deep_tropical_meridional_mean_hovmoller_plots(
+    diagnostics: Iterable[xr.Dataset],
+) -> RawHTML:
+    return plot_2d_matplotlib(
+        diagnostics, "deep_tropical_meridional_mean_value", ["longitude", "time"]
+    )
 
 
 def time_mean_cubed_sphere_maps(
@@ -526,6 +536,9 @@ def render_process_diagnostics(metadata, diagnostics, metrics):
         "Diurnal cycle": list(diurnal_plot_manager.make_plots(diagnostics)),
         "Precipitation and water vapor path": list(
             histogram_plot_manager.make_plots(diagnostics)
+        ),
+        "Tropical Hovmoller plots": list(
+            tropical_hovmoller_plot_manager.make_plots(diagnostics)
         ),
     }
     return create_html(

--- a/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
+++ b/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
@@ -138,10 +138,10 @@ def test_RunDiagnostics_list_variables():
         [
             ds.assign(a=1, b=1).assign_attrs(run="1"),
             ds.assign(b=1).assign_attrs(run="2"),
-            ds.assign(c=1).assign_attrs(run="3"),
+            ds.assign(c=1).assign_coords(d=1).assign_attrs(run="3"),
         ]
     )
-    assert diagnostics.variables == {"a", "b", "c"}
+    assert diagnostics.variables == {"a", "b", "c", "d"}
 
 
 def test_RunDiagnostics_long_names():


### PR DESCRIPTION
This PR adds longitudinal Hovmoller diagrams to the prognostic run report so that we can get a sense for tropical wave behavior.  It adds an option to set the figure size of 2D plots, which I use to increase the height of the Hovmoller diagrams for longer runs.  An example of what this looks like for a 40-day run can be found [here](https://storage.googleapis.com/vcm-ml-public/argo/tropical-hovmoller-with-verification-no-daily-mean/process_diagnostics.html).

Per Noah's request I also added the option to include area weights when computing zonal or meridional means.

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/35544e30-1b37-4904-bf24-c43f07f35130/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)