### PR TITLE
Improve high-antarctic training performance.

### DIFF
--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -406,9 +406,7 @@ class TrainConfig(TransformedParameters):
         self, url: str, nfiles: Optional[int], required_variables: Set[str],
     ) -> tf.data.Dataset:
         if self.data_format == "nc":
-            self._open_dataset(
-                url, nfiles, required_variables,
-            )
+            return self._open_dataset(url, nfiles, required_variables,)
         elif self.data_format == "tf":
             # needs to be batched
             return tf.data.experimental.load(url).batch(1)

--- a/external/fv3fit/fv3fit/train_microphysics.py
+++ b/external/fv3fit/fv3fit/train_microphysics.py
@@ -276,15 +276,16 @@ class TrainConfig(TransformedParameters):
 
     Attributes:
 
-        train_url: Path to training netcdfs (already in [sample x feature] format)
-        test_url: Path to validation netcdfs (already in [sample x feature] format)
+        train_url: Path to training data (already in [sample x feature] format)
+        test_url: Path to validation data (already in [sample x feature] format)
         transform: Data preprocessing TransformConfig
         nfiles: Number of files to use from train_url
         nfiles_valid: Number of files to use from test_url
         log_level: what logging level to use
         save_only: If true, don't train, but save the train and test data with
             tf.data.experimental.save to ``out_url``
-        data_format: one of ['nc', 'tf']
+        data_format: one of ['nc', 'tf']. The data format of datasets at
+            ``train_url`` and ``test_url``.
     """
 
     train_url: str = ""


### PR DESCRIPTION
The high-antarctic filter was far too slow to use for training it took 1944 seconds per epoch (even though each epoch is only 1.5 of the data). This was dominated by I/O from the local filesystem.

Pre-saving a filtered dataset reduces the per-epoch time to 16 seconds.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/acf81c7b-144b-4c09-b289-91edfe0bdfeb\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)