### PR TITLE
Add --url flag to prognostic_run_diags piggy

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -297,6 +297,12 @@ def register_parser(subparsers) -> None:
     )
     parser.add_argument("tag", help="The unique tag used for the prognostic run.")
     parser.add_argument(
+        "--url",
+        help="The path to the run-directory...in cases when tag alone is not enough "
+        "like a crashed run.",
+        type=str,
+    )
+    parser.add_argument(
         "-s", "--summary-only", help="Only run summaries.", action="store_true"
     )
     parser.add_argument(
@@ -375,7 +381,9 @@ def get_summary_functions() -> Iterable[
         yield func
 
 
-def upload_diagnostics_for_tag(tag: str, summary_only: bool, summary_name: str):
+def upload_diagnostics_for_tag(
+    tag: str, summary_only: bool, summary_name: str, url: str = ""
+):
     run = wandb.init(
         job_type=WANDB_JOB_TYPE,
         project=WANDB_PROJECT,
@@ -384,12 +392,14 @@ def upload_diagnostics_for_tag(tag: str, summary_only: bool, summary_name: str):
         tags=[tag],
         reinit=True,
     )
-    api = wandb.Api()
-    prognostic_run = query.PrognosticRunClient(
-        tag, entity=run.entity, project=run.project, api=api
-    )
-    prognostic_run.use_artifact_in(run)
-    url = prognostic_run.get_rundir_url()
+
+    if not url:
+        api = wandb.Api()
+        prognostic_run = query.PrognosticRunClient(
+            tag, entity=run.entity, project=run.project, api=api
+        )
+        prognostic_run.use_artifact_in(run)
+        url = prognostic_run.get_rundir_url()
 
     wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
     StepMetadata(
@@ -405,5 +415,8 @@ def upload_diagnostics_for_tag(tag: str, summary_only: bool, summary_name: str):
 
 def main(args):
     return upload_diagnostics_for_tag(
-        args.tag, summary_only=args.summary_only, summary_name=args.summary_filter
+        args.tag,
+        summary_only=args.summary_only,
+        summary_name=args.summary_filter,
+        url=args.url,
     )

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/emulation/single_run.py
@@ -301,6 +301,7 @@ def register_parser(subparsers) -> None:
         help="The path to the run-directory...in cases when tag alone is not enough "
         "like a crashed run.",
         type=str,
+        default="",
     )
     parser.add_argument(
         "-s", "--summary-only", help="Only run summaries.", action="store_true"


### PR DESCRIPTION
This allows making a report even if the wandb artifact is not
suceesfully uploaded.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/52b95172-13b5-4d4d-baa7-7ab53846b1e0\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)