### PR TITLE
Change e2e timeout from 30min to 35min

### DIFF
--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -26,7 +26,7 @@ function waitForComplete {
     # Sleep while job is active
     jobName=$1
     NAMESPACE=$2
-    timeout=$(date -ud "30 minutes" +%s)
+    timeout=$(date -ud "35 minutes" +%s)
     job_phase=$(getPhase $jobName $NAMESPACE)
     continue_phases="Running Pending null"  # job phase may be Pending or null initially
     while [[ $(date +%s) -le $timeout && "$(grep $job_phase <<< $continue_phases )" ]]


### PR DESCRIPTION
The e2e integration test is often reaching its timeout limit of 30min. This PR extends the limit to 35min so more of the jobs will be able to pass.

The timeout seems to be often happening during the last step of the test, so hopefully this slight increase will be enough for most to complete successfully:

Example recent e2e test:

```
STEP                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            TEMPLATE                                PODNAME                                   DURATION  MESSAGE
 ✖ integration-test-41a6c24-ebd4                                                                                                                                                                                                                                                                                                                                                                                                                                                                main                                                                                                                                                 
 ├─✔ nudge-to-fine-run                                                                                                                                                                                                                                                                                                                                                                                                                                                                          prognostic-run/prognostic-run                                                                                                                        
 │ ├───✔ resolve-output-url                                                                                                                                                                                                                                                                                                                                                                                                                                                                     resolve-output-url/resolve-output-url   integration-test-41a6c24-ebd4-2437568168  5s                                                                 
 │ ├───✔ prepare-config                                                                                                                                                                                                                                                                                                                                                                                                                                                                         prepare-config                          integration-test-41a6c24-ebd4-321393353   3m                                                                 
 │ ├───✔ run-model                                                                                                                                                                                                                                                                                                                                                                                                                                                                              run-fv3gfs/run-fv3gfs                                                                                                                                
 │ │   ├─┬─✔ choose-node-pool                                                                                                                                                                                                                                                                                                                                                                                                                                                                   choose-node-pool                        integration-test-41a6c24-ebd4-700785064   4s                                                                 
 │ │   │ └─✔ create-run                                                                                                                                                                                                                                                                                                                                                                                                                                                                         create-run                              integration-test-41a6c24-ebd4-582375769   27s                                                                
 │ │   └───✔ run-first-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                                  run-all-segments                                                                                                                                     
 │ │       ├───✔ append-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                                 append-segment                          integration-test-41a6c24-ebd4-504981332   4m                                                                 
 │ │       ├───✔ increment-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                              increment-count                         integration-test-41a6c24-ebd4-750440456   7s                                                                 
 │ │       └───✔ run-next-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                               run-all-segments                                                                                                                                     
 │ │           ├───✔ append-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                             append-segment                          integration-test-41a6c24-ebd4-3522671123  1m                                                                 
 │ │           ├───✔ increment-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                          increment-count                         integration-test-41a6c24-ebd4-1154996445  4s                                                                 
 │ │           └───○ run-next-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                           run-all-segments                                                                            when '2 < 2' evaluated false                             
 │ ├───○ online-diags                                                                                                                                                                                                                                                                                                                                                                                                                                                                           prognostic-run-diags/diagnostics                                                            when 'false == true' evaluated false                     
 │ ├───○ online-diags-report                                                                                                                                                                                                                                                                                                                                                                                                                                                                    prognostic-run-diags/report-single-run                                                      when 'false == true' evaluated false                     
 │ └───○ exit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   exit                                                                                        when 'Succeeded == Failed' evaluated false               
 ├─✔ resolve-output-url                                                                                                                                                                                                                                                                                                                                                                                                                                                                         resolve-output-url/resolve-output-url   integration-test-41a6c24-ebd4-448149582   5s                                                                 
 └─✖ train-offline-diags-prognostic                                                                                                                                                                                                                                                                                                                                                                                                                                                             train-diags-prog/train-diags-prog                                                                                                                    
   ├─✔ resolve-output-url                                                                                                                                                                                                                                                                                                                                                                                                                                                                       resolve-output-url/resolve-output-url   integration-test-41a6c24-ebd4-2822659780  15s                                                                
   ├─✔ insert-model-urls                                                                                                                                                                                                                                                                                                                                                                                                                                                                        insert-model-urls                       integration-test-41a6c24-ebd4-2249233660  8s                                                                 
   ├─✔ train-model(0:config:{"model_type":"sklearn_random_forest","hyperparameters":{"max_depth":13,"n_estimators":1},"input_variables":["air_temperature","specific_humidity","cos_zenith_angle"],"output_variables":["dQ1"]},name:sklearn_dQ1_model)                                                                                                                                                                                                                                          training/training                       integration-test-41a6c24-ebd4-1033260262  3m                                                                 
   ├─✔ train-model(1:config:{"model_type":"dense","hyperparameters":{"input_variables":["air_temperature","specific_humidity","cos_zenith_angle"],"output_variables":["dQ2"],"normalize_loss":true,"optimizer_config":{"name":"Adam","kwargs":{"learning_rate":0.002}},"dense_network":{"depth":2,"width":12,"kernel_regularizer":{"name":"l2","kwargs":{"l":0.0001}}},"training_loop":{"batch_size":512,"epochs":2},"loss":{"loss_type":"mae","scaling":"standard"}}},name:keras_dQ2_model)    training/training                       integration-test-41a6c24-ebd4-4170004940  3m                                                                 
   ├─✔ offline-diags(0:config:{"model_type":"sklearn_random_forest","hyperparameters":{"max_depth":13,"n_estimators":1},"input_variables":["air_temperature","specific_humidity","cos_zenith_angle"],"output_variables":["dQ1"]},name:sklearn_dQ1_model)                                                                                                                                                                                                                                        offline-diags/offline-diags             integration-test-41a6c24-ebd4-82131630    4m                                                                 
   ├─✔ offline-diags(1:config:{"model_type":"dense","hyperparameters":{"input_variables":["air_temperature","specific_humidity","cos_zenith_angle"],"output_variables":["dQ2"],"normalize_loss":true,"optimizer_config":{"name":"Adam","kwargs":{"learning_rate":0.002}},"dense_network":{"depth":2,"width":12,"kernel_regularizer":{"name":"l2","kwargs":{"l":0.0001}}},"training_loop":{"batch_size":512,"epochs":2},"loss":{"loss_type":"mae","scaling":"standard"}}},name:keras_dQ2_model)  offline-diags/offline-diags             integration-test-41a6c24-ebd4-3461527188  5m                                                                 
   └─✖ prognostic-run                                                                                                                                                                                                                                                                                                                                                                                                                                                                           prognostic-run/prognostic-run                                                               child 'integration-test-41a6c24-ebd4-1102867353' failed  
     ├───✔ resolve-output-url                                                                                                                                                                                                                                                                                                                                                                                                                                                                   resolve-output-url/resolve-output-url   integration-test-41a6c24-ebd4-2668236192  4s                                                                 
     ├───✔ prepare-config                                                                                                                                                                                                                                                                                                                                                                                                                                                                       prepare-config                          integration-test-41a6c24-ebd4-4100023745  16s                                                                
     ├───✔ run-model                                                                                                                                                                                                                                                                                                                                                                                                                                                                            run-fv3gfs/run-fv3gfs                                                                                                                                
     │   ├─┬─✔ create-run                                                                                                                                                                                                                                                                                                                                                                                                                                                                       create-run                              integration-test-41a6c24-ebd4-640429121   20s                                                                
     │   │ └─✔ choose-node-pool                                                                                                                                                                                                                                                                                                                                                                                                                                                                 choose-node-pool                        integration-test-41a6c24-ebd4-1250449968  2s                                                                 
     │   └───✔ run-first-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                                run-all-segments                                                                                                                                     
     │       ├───✔ append-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                               append-segment                          integration-test-41a6c24-ebd4-3343241980  2m                                                                 
     │       ├───✔ increment-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                            increment-count                         integration-test-41a6c24-ebd4-1371254576  3s                                                                 
     │       └───○ run-next-segment                                                                                                                                                                                                                                                                                                                                                                                                                                                             run-all-segments                                                                            when '1 < 1' evaluated false                             
     ├───✔ online-diags                                                                                                                                                                                                                                                                                                                                                                                                                                                                         prognostic-run-diags/diagnostics                                                                                                                     
     │   ├─✔ compute-reduced-diagnostics                                                                                                                                                                                                                                                                                                                                                                                                                                                        compute-reduced-diagnostics             integration-test-41a6c24-ebd4-2402442848  5m                                                                 
     │   ├─✔ movies                                                                                                                                                                                                                                                                                                                                                                                                                                                                             movie                                   integration-test-41a6c24-ebd4-1470791668  3m                                                                 
     │   └─✔ regrid-reduced-diagnostics-to-latlon                                                                                                                                                                                                                                                                                                                                                                                                                                               cubed-to-latlon/regrid-single-input     integration-test-41a6c24-ebd4-156453897   1m                                                                 
     └───✖ online-diags-report                                                                                                                                                                                                                                                                                                                                                                                                                                                                  prognostic-run-diags/report-single-run  integration-test-41a6c24-ebd4-1102867353  2m        workflow shutdown with strategy:  Terminate 
```

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/9e184b92-b022-4e5e-9c32-0949b8f874e7/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)
