### PR TITLE
Mask extrapolated areas in PIRE pressure level diagnostics

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -753,6 +753,8 @@ sources:
 
   2020_1yr_pire_dyn_plev:
     description: 2D dycore variables interpolated to pressure levels from 1 year PIRE simulation post-spinup, coarsened to C48 resolution.
+      Areas where the value is extrapolated (i.e. surface pressure is less than the variable pressure level) are masked using the notebook
+      https://github.com/ai2cm/explore/blob/master/annak/2021-07-30-PIRE-nudging-data/2022-08-22-fill-extrapolated-pressure-to-nan.ipynb
     driver: zarr
     metadata:
       grid: c48

--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -777,7 +777,7 @@ sources:
         - TMP200
         - UGRD850
     args:
-      urlpath: "gs://vcm-ml-intermediate/2021-10-12-PIRE-c48-post-spinup-verification/pire_atmos_dyn_plev_coarse_3h.zarr"
+      urlpath: "gs://vcm-ml-intermediate/2021-10-12-PIRE-c48-post-spinup-verification/pire_atmos_dyn_plev_coarse_3h_mask_extroplated.zarr"
       consolidated: True
 
   2020_1yr_pire_dyn:


### PR DESCRIPTION
Areas in higher elevation (e.g. Psfc < 850 hPa) are extrapolated in the fortran diagnostics. The extrapolation is very different for the case where the model is run at coarse resolution versus if run at fine res and then coarsened. This update masks out extrapolated areas in the verification so that this issue does not affect the calculated biases.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/b6b557dc-242d-4f10-885f-a83c512cb7dc\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)