### PR TITLE
Use ubuntu-20.04 tag for fv3net base image

### DIFF
--- a/docker/fv3net/Dockerfile
+++ b/docker/fv3net/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook as build
+FROM jupyter/base-notebook:ubuntu-20.04 as build
 
 # Manually increment this string to invalidate the cache
 ENV MANUAL_CACHE_STRING 2

--- a/docker/fv3net/Dockerfile
+++ b/docker/fv3net/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 RUN apt-get update && apt-get install -y google-cloud-sdk jq python3-dev python3-pip kubectl gfortran
 
 # install Argo CLI
-RUN curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v2.7.0/argo-linux-amd64
+RUN curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v3.3.7/argo-linux-amd64
 RUN chmod +x /usr/local/bin/argo
 
 # install gcloud sdk


### PR DESCRIPTION
There was a change in the jupyter/base-notebook image that is leading to the fv3net image failing to build. Pinning the base image tag resolves this issue.

Resolves #2018 

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/4730927c-0cc0-4329-94d6-c26c4f161917/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)