### PR TITLE
Add synthetic data loaders to fv3fit

### DIFF
--- a/external/fv3fit/fv3fit/data/synthetic.py
+++ b/external/fv3fit/fv3fit/data/synthetic.py
@@ -15,8 +15,8 @@ class SyntheticNoise(TFDatasetLoader):
     ntime: int
     nx: int
     nz: int
+    noise_amplitude: float
     scalar_names: List[str] = dataclasses.field(default_factory=list)
-    noise_amplitude: float = 1.0
 
     def open_tfdataset(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -69,7 +69,7 @@ class SyntheticWaves(TFDatasetLoader):
         period_max: maximum period of waves
         phase_range: fraction of 2*pi to use for possible range of
             random phase, should be a value between 0 and 1.
-        type: one of "sinusoidal" or "square"
+        wave_type: one of "sinusoidal" or "square"
     """
 
     nsamples: int
@@ -77,13 +77,13 @@ class SyntheticWaves(TFDatasetLoader):
     ntime: int
     nx: int
     nz: int
+    wave_type: str
     scalar_names: List[str] = dataclasses.field(default_factory=list)
     scale_min: float = 0.0
     scale_max: float = 1.0
     period_min: float = 8.0
     period_max: float = 16.0
     phase_range: float = 1.0
-    type: str = "sinusoidal"
 
     def open_tfdataset(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -97,12 +97,15 @@ class SyntheticWaves(TFDatasetLoader):
                 variable name to variable value, and each value is a tensor whose
                 first dimension is the batch dimension
         """
-        if self.type == "sinusoidal":
+        if self.wave_type == "sinusoidal":
             func = np.sin
-        elif self.type == "square":
+        elif self.wave_type == "square":
 
             def func(x):
                 return np.sign(np.sin(x))
+
+        else:
+            raise ValueError(f"Invalid wave_type {self.wave_type}")
 
         dataset = get_waves_tfdataset(
             variable_names,

--- a/external/fv3fit/fv3fit/data/synthetic.py
+++ b/external/fv3fit/fv3fit/data/synthetic.py
@@ -1,0 +1,235 @@
+from .base import TFDatasetLoader, register_tfdataset_loader
+import dataclasses
+from typing import Optional, Sequence, List
+import tensorflow as tf
+import numpy as np
+from ..tfdataset import generator_to_tfdataset
+import dacite
+
+
+@register_tfdataset_loader
+@dataclasses.dataclass
+class SyntheticNoise(TFDatasetLoader):
+    nsamples: int
+    nbatch: int
+    ntime: int
+    nx: int
+    nz: int
+    scalar_names: List[str] = dataclasses.field(default_factory=list)
+    noise_amplitude: float = 1.0
+
+    def open_tfdataset(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        """
+        Args:
+            local_download_path: if provided, cache data locally at this path
+            variable_names: names of variables to include when loading data
+        Returns:
+            dataset containing requested variables, each record is a mapping from
+                variable name to variable value, and each value is a tensor whose
+                first dimension is the batch dimension
+        """
+        dataset = get_noise_tfdataset(
+            variable_names,
+            scalar_names=self.scalar_names,
+            nsamples=self.nsamples,
+            nbatch=self.nbatch,
+            ntime=self.ntime,
+            nx=self.nx,
+            ny=self.nx,
+            nz=self.nz,
+            noise_amplitude=self.noise_amplitude,
+        )
+        if local_download_path is not None:
+            dataset = dataset.cache(local_download_path)
+        return dataset
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TFDatasetLoader":
+        return dacite.from_dict(
+            data_class=cls, data=d, config=dacite.Config(strict=True)
+        )
+
+
+@register_tfdataset_loader
+@dataclasses.dataclass
+class SyntheticWaves(TFDatasetLoader):
+    """
+    Attributes:
+        nsamples: number of samples to generate per batch
+        nbatch: number of batches to generate
+        nx: length of x- and y-dimensions to generate
+        nz: length of z-dimension to generate
+        scalar_names: names to generate as scalars instead of
+            vertically-resolved variables
+        scale_min: minimum amplitude of waves
+        scale_max: maximum amplitude of waves
+        period_min: minimum period of waves
+        period_max: maximum period of waves
+        phase_range: fraction of 2*pi to use for possible range of
+            random phase, should be a value between 0 and 1.
+        type: one of "sinusoidal" or "square"
+    """
+
+    nsamples: int
+    nbatch: int
+    ntime: int
+    nx: int
+    nz: int
+    scalar_names: List[str] = dataclasses.field(default_factory=list)
+    scale_min: float = 0.0
+    scale_max: float = 1.0
+    period_min: float = 8.0
+    period_max: float = 16.0
+    phase_range: float = 1.0
+    type: str = "sinusoidal"
+
+    def open_tfdataset(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        """
+        Args:
+            local_download_path: if provided, cache data locally at this path
+            variable_names: names of variables to include when loading data
+        Returns:
+            dataset containing requested variables, each record is a mapping from
+                variable name to variable value, and each value is a tensor whose
+                first dimension is the batch dimension
+        """
+        if self.type == "sinusoidal":
+            func = np.sin
+        elif self.type == "square":
+
+            def func(x):
+                return np.sign(np.sin(x))
+
+        dataset = get_waves_tfdataset(
+            variable_names,
+            scalar_names=self.scalar_names,
+            nsamples=self.nsamples,
+            nbatch=self.nbatch,
+            ntime=self.ntime,
+            nx=self.nx,
+            ny=self.nx,
+            nz=self.nz,
+            scale_min=self.scale_min,
+            scale_max=self.scale_max,
+            period_min=self.period_min,
+            period_max=self.period_max,
+            phase_range=self.phase_range,
+            func=func,
+        )
+        if local_download_path is not None:
+            dataset = dataset.cache(local_download_path)
+        return dataset
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TFDatasetLoader":
+        return dacite.from_dict(
+            data_class=cls, data=d, config=dacite.Config(strict=True)
+        )
+
+
+def get_waves_tfdataset(
+    variable_names,
+    *,
+    scalar_names,
+    nsamples: int,
+    nbatch: int,
+    ntime: int,
+    nx: int,
+    ny: int,
+    nz: int,
+    scale_min: float,
+    scale_max: float,
+    period_min: float,
+    period_max: float,
+    phase_range: float,
+    func=np.sin,
+):
+    ntile = 6
+
+    grid_x = np.arange(0, nx, dtype=np.float32)
+    grid_y = np.arange(0, ny, dtype=np.float32)
+    grid_x, grid_y = np.broadcast_arrays(grid_x[:, None], grid_y[None, :])
+    grid_x = grid_x[None, None, None, :, :, None]
+    grid_y = grid_y[None, None, None, :, :, None]
+
+    def sample_generator():
+        # creates a timeseries where each time is the negation of time before it
+        for _ in range(nsamples):
+            ax = np.random.uniform(scale_min, scale_max, size=(nbatch, 1, ntile, nz))[
+                :, :, :, None, None, :
+            ]
+            bx = np.random.uniform(period_min, period_max, size=(nbatch, 1, ntile, nz))[
+                :, :, :, None, None, :
+            ]
+            cx = np.random.uniform(
+                0.0, 2 * np.pi * phase_range, size=(nbatch, 1, ntile, nz)
+            )[:, :, :, None, None, :]
+            ay = np.random.uniform(scale_min, scale_max, size=(nbatch, 1, ntile, nz))[
+                :, :, :, None, None, :
+            ]
+            by = np.random.uniform(period_min, period_max, size=(nbatch, 1, ntile, nz))[
+                :, :, :, None, None, :
+            ]
+            cy = np.random.uniform(
+                0.0, 2 * np.pi * phase_range, size=(nbatch, 1, ntile, nz)
+            )[:, :, :, None, None, :]
+            data = (
+                ax
+                * func(2 * np.pi * grid_x / bx + cx)
+                * ay
+                * func(2 * np.pi * grid_y / by + cy)
+            )
+            start = {}
+            for varname in variable_names:
+                if varname in scalar_names:
+                    start[varname] = data[..., 0].astype(np.float32)
+                else:
+                    start[varname] = data.astype(np.float32)
+            out = {key: [value] for key, value in start.items()}
+            for _ in range(ntime - 1):
+                for varname in start.keys():
+                    out[varname].append(out[varname][-1] * -1.0)
+            for varname in out:
+                out[varname] = np.concatenate(out[varname], axis=1)
+            yield out
+
+    return generator_to_tfdataset(sample_generator)
+
+
+def get_noise_tfdataset(
+    variable_names,
+    *,
+    scalar_names,
+    nsamples: int,
+    nbatch: int,
+    ntime: int,
+    nx: int,
+    ny: int,
+    nz: int,
+    noise_amplitude: float,
+):
+    ntile = 6
+
+    def sample_generator():
+        # creates a timeseries where each time is the negation of time before it
+        for _ in range(nsamples):
+            data = noise_amplitude * np.random.randn(nbatch, 1, ntile, nx, ny, nz)
+            start = {}
+            for varname in variable_names:
+                if varname in scalar_names:
+                    start[varname] = data[..., 0].astype(np.float32)
+                else:
+                    start[varname] = data.astype(np.float32)
+            out = {key: [value] for key, value in start.items()}
+            for _ in range(ntime - 1):
+                for varname in start.keys():
+                    out[varname].append(out[varname][-1] * -1.0)
+            for varname in out:
+                out[varname] = np.concatenate(out[varname], axis=1)
+            yield out
+
+    return generator_to_tfdataset(sample_generator)

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -82,7 +82,9 @@ class CycleGANLoader(TFDatasetLoader):
             tfdataset_loader_from_dict(domain_config)
             for domain_config in d["domain_configs"]
         ]
-        return CycleGANLoader(domain_configs=domain_configs)
+        kwargs = d.copy()
+        kwargs["domain_configs"] = domain_configs
+        return CycleGANLoader(**kwargs)
 
 
 @register_tfdataset_loader

--- a/external/fv3fit/tests/training/test_autoencoder.py
+++ b/external/fv3fit/tests/training/test_autoencoder.py
@@ -3,71 +3,29 @@ import xarray as xr
 from typing import Sequence
 from fv3fit.pytorch.cyclegan import AutoencoderHyperparameters, train_autoencoder
 from fv3fit.pytorch.cyclegan.train import TrainingConfig
-from fv3fit.tfdataset import iterable_to_tfdataset
+import pytest
+from fv3fit.data.synthetic import SyntheticWaves
 import collections
 import os
 import fv3fit.pytorch
 import fv3fit
-import tensorflow as tf
-import pytest
 
 
-def get_tfdataset(nsamples, nbatch, ntime, nx, ny, nz) -> tf.data.Dataset:
-    """
-    Returns at tf.data.Dataset of shape [nsamples, nbatch, ntime, nx, ny, nz]
-    whose samples are sin waves in the horizontal with random phases and amplitudes.
-    Contains the variables "a", which is vertically-resolved, and "b",
-    which is a scalar.
-    """
-
-    ntile = 6
-
-    grid_x = np.arange(0, nx, dtype=np.float32)
-    grid_y = np.arange(0, ny, dtype=np.float32)
-    grid_x, grid_y = np.broadcast_arrays(grid_x[:, None], grid_y[None, :])
-    grid_x = grid_x[None, None, None, :, :, None]
-    grid_y = grid_y[None, None, None, :, :, None]
-
-    def sample_iterator():
-        # creates a timeseries where each time is the negation of time before it
-        for _ in range(nsamples):
-            ax = np.random.uniform(0.1, 1.5, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            bx = np.random.uniform(8, 16, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            cx = np.random.uniform(0.0, 2 * np.pi, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            ay = np.random.uniform(0.1, 1.5, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            by = np.random.uniform(8, 16, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            cy = np.random.uniform(0.0, 2 * np.pi, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            a = (
-                ax
-                * np.sin(2 * np.pi * grid_x / bx + cx)
-                * ay
-                * np.sin(2 * np.pi * grid_y / by + cy)
-            )
-            start = {
-                "a": a.astype(np.float32),
-                "b": -a[..., 0].astype(np.float32),
-            }
-            out = {key: [value] for key, value in start.items()}
-            for _ in range(ntime - 1):
-                for varname in start.keys():
-                    out[varname].append(out[varname][-1] * -1.0)
-            for varname in out:
-                out[varname] = np.concatenate(out[varname], axis=1)
-            yield out
-
-    return iterable_to_tfdataset(list(sample_iterator()))
+def get_tfdataset(nsamples, nbatch, ntime, nx, nz):
+    config = SyntheticWaves(
+        nsamples=nsamples,
+        nbatch=nbatch,
+        ntime=ntime,
+        nx=nx,
+        nz=nz,
+        scalar_names=["b"],
+        scale_min=0.5,
+        scale_max=1.5,
+        period_min=8,
+        period_max=16,
+    )
+    dataset = config.open_tfdataset(local_download_path=None, variable_names=["a", "b"])
+    return dataset
 
 
 def tfdataset_to_xr_dataset(tfdataset, dims: Sequence[str]):
@@ -99,8 +57,8 @@ def test_autoencoder(tmpdir):
     os.chdir(tmpdir)
     # need a larger nx, ny for the sample data here since we're training
     # on whether we can autoencode sin waves, and need to resolve full cycles
-    nx, ny = 32, 32
-    sizes = {"nbatch": 2, "ntime": 2, "nx": nx, "ny": ny, "nz": 2}
+    nx = 32
+    sizes = {"nbatch": 2, "ntime": 2, "nx": nx, "nz": 2}
     state_variables = ["a", "b"]
     train_tfdataset = get_tfdataset(nsamples=20, **sizes)
     val_tfdataset = get_tfdataset(nsamples=3, **sizes)
@@ -109,19 +67,20 @@ def test_autoencoder(tmpdir):
         generator=fv3fit.pytorch.GeneratorConfig(
             n_convolutions=2, n_resnet=3, max_filters=32
         ),
-        training_loop=TrainingConfig(n_epoch=5, samples_per_batch=2),
+        training_loop=TrainingConfig(n_epoch=10, samples_per_batch=2),
         optimizer_config=fv3fit.pytorch.OptimizerConfig(name="Adam",),
         noise_amount=0.5,
     )
     predictor = train_autoencoder(hyperparameters, train_tfdataset, val_tfdataset)
     # for test, need one continuous series so we consistently flip sign
-    test_sizes = {"nbatch": 1, "ntime": 100, "nx": nx, "ny": ny, "nz": 2}
+    test_sizes = {"nbatch": 1, "ntime": 100, "nx": nx, "nz": 2}
     test_xrdataset = tfdataset_to_xr_dataset(
         get_tfdataset(nsamples=1, **test_sizes), dims=["time", "tile", "x", "y", "z"]
     )
     predicted = predictor.predict(test_xrdataset)
     reference = test_xrdataset
     # plotting code to uncomment if you'd like to manually check the results:
+    # import matplotlib.pyplot as plt
     # for i in range(6):
     #     fig, ax = plt.subplots(1, 2)
     #     vmin = reference["a"][0, i, :, :, 0].values.min()
@@ -151,8 +110,8 @@ def test_autoencoder_overfit(tmpdir):
     os.chdir(tmpdir)
     # need a larger nx, ny for the sample data here since we're training
     # on whether we can autoencode sin waves, and need to resolve full cycles
-    nx, ny = 32, 32
-    sizes = {"nbatch": 1, "ntime": 1, "nx": nx, "ny": ny, "nz": 2}
+    nx = 32
+    sizes = {"nbatch": 1, "ntime": 1, "nx": nx, "nz": 2}
     state_variables = ["a", "b"]
     train_tfdataset = get_tfdataset(nsamples=1, **sizes)
     train_tfdataset = train_tfdataset.cache()  # needed to keep sample identical
@@ -175,12 +134,13 @@ def test_autoencoder_overfit(tmpdir):
     predicted = predictor.predict(test_xrdataset)
     reference = test_xrdataset
     # plotting code to uncomment if you'd like to manually check the results:
+    # import matplotlib.pyplot as plt
     # for i in range(6):
     #     fig, ax = plt.subplots(1, 2)
     #     vmin = reference["a"][0, i, :, :, 0].values.min()
     #     vmax = reference["a"][0, i, :, :, 0].values.max()
-    #     ax[0].imshow(reference["a"][0, i, :, :, 0].values)  # , vmin=vmin, vmax=vmax)
-    #     ax[1].imshow(predicted["a"][0, i, :, :, 0].values)  # , vmin=vmin, vmax=vmax)
+    #     ax[0].imshow(reference["a"][0, i, :, :, 0].values, vmin=vmin, vmax=vmax)
+    #     ax[1].imshow(predicted["a"][0, i, :, :, 0].values, vmin=vmin, vmax=vmax)
     #     plt.tight_layout()
     #     plt.show()
     bias = predicted - reference

--- a/external/fv3fit/tests/training/test_autoencoder.py
+++ b/external/fv3fit/tests/training/test_autoencoder.py
@@ -18,6 +18,7 @@ def get_tfdataset(nsamples, nbatch, ntime, nx, nz):
         ntime=ntime,
         nx=nx,
         nz=nz,
+        wave_type="sinusoidal",
         scalar_names=["b"],
         scale_min=0.5,
         scale_max=1.5,


### PR DESCRIPTION
This PR adds synthetic data loader configurations for sin waves, square waves, and gaussian noise to fv3fit.

Refactored public API:
- fv3fit data loader configurations can now match new SyntheticWaves or SyntheticNoise APIs.

Significant internal changes:
- Fixed a bug in CycleGANLoader's `from_dict` initializer where it would ignore non-domain configuration (e.g. batch size)

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/c1152fe0-2239-453d-967b-2cc49ce89b79/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)