### PR TITLE
Rename LossConfig.loss to LossConfig.instance in fv3fit

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/loss.py
+++ b/external/fv3fit/fv3fit/pytorch/loss.py
@@ -18,7 +18,7 @@ class LossConfig:
             )
 
     @property
-    def loss(self) -> torch.nn.Module:
+    def instance(self) -> torch.nn.Module:
         """
         Returns the loss function described by the configuration.
 

--- a/external/fv3fit/fv3fit/pytorch/training_loop.py
+++ b/external/fv3fit/fv3fit/pytorch/training_loop.py
@@ -56,7 +56,7 @@ class TrainingConfig:
         def evaluate_on_batch(batch_state, model):
             batch_input = torch.as_tensor(batch_state[0]).float().to(DEVICE)
             batch_output = torch.as_tensor(batch_state[1]).float().to(DEVICE)
-            loss: torch.Tensor = loss_config.loss(model(batch_input), batch_output)
+            loss: torch.Tensor = loss_config.instance(model(batch_input), batch_output)
             return loss
 
         return _train_loop(
@@ -116,7 +116,7 @@ class AutoregressiveTrainingConfig:
                 batch_state=batch_state,
                 model=train_model,
                 multistep=self.multistep,
-                loss=loss_config.loss,
+                loss=loss_config.instance,
             )
             return loss
 

--- a/external/fv3fit/fv3fit/tfdataset.py
+++ b/external/fv3fit/fv3fit/tfdataset.py
@@ -11,22 +11,26 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
 )
 from toolz.functoolz import curry
 import loaders.typing
 
+T_in = TypeVar("T_in")
+T_out = TypeVar("T_out")
+
 
 @curry
 def apply_to_mapping(
-    tensor_func: Callable[[tf.Tensor], tf.Tensor], data: Mapping[str, tf.Tensor]
-) -> Dict[str, tf.Tensor]:
+    tensor_func: Callable[[T_in], T_out], data: Mapping[str, T_in]
+) -> Dict[str, T_out]:
     return {name: tensor_func(tensor) for name, tensor in data.items()}
 
 
 @curry
 def apply_to_tuple(
-    tensor_func: Callable[[tf.Tensor], tf.Tensor], data: Tuple[tf.Tensor, ...]
-) -> Tuple[tf.Tensor, ...]:
+    tensor_func: Callable[[T_in], T_out], data: Tuple[T_in, ...]
+) -> Tuple[T_out, ...]:
     return tuple(tensor_func(tensor) for tensor in data)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,5 @@ markers =
 
 filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
+    ignore:Call to deprecated create function:DeprecationWarning
+    ignore:.*is deprecated and will be removed in Pillow 10:DeprecationWarning


### PR DESCRIPTION
This PR makes small fixes to fv3fit.

Refactored public API:
- fv3fit.pytorch's LossConfig.loss is renamed to LossConfig.instance
- pytest configuration now ignores certain deprecation warnings internal to tensorflow/pytorch

Significant internal changes:
- Adjusted type hinting on `fv3fit.tfdataset.apply_to_mapping` and `fv3fit.tfdataset.apply_to_tuple` so they can be used for arbitrary structures of tensors

No new tests needed.

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/f1b32e89-32f6-43b7-921b-81306b412dce/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)