### PR TITLE
Remove iteration over batches from offline diagnostics compute step

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -225,17 +225,3 @@ def insert_column_integrated_vars(
         ds = ds.assign({column_integrated_name: da})
 
     return ds
-
-
-def batches_mean(
-    ds: xr.Dataset, res: int, dim: str = "batch", maximum_3d_resolution: int = 48
-) -> xr.Dataset:
-    """Average over batches, but not for 3D variables if at greater than
-    C48 resolution"""
-
-    with xr.set_options(keep_attrs=True):
-        if res > maximum_3d_resolution:
-            excluded_vars = [var for var in ds.data_vars if is_3d(ds[var])]
-            return ds.drop_vars(excluded_vars).mean(dim=dim)
-        else:
-            return ds.mean(dim=dim)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -1,7 +1,10 @@
+import atexit
 import json
+import logging
 import numpy as np
 import os
 import shutil
+from tempfile import TemporaryDirectory
 from typing import Hashable, Mapping, Sequence, Dict, Tuple, Union
 import vcm
 import xarray as xr
@@ -51,6 +54,8 @@ GRID_INFO_VARS = [
     "area",
 ]
 ScalarMetrics = Dict[str, Mapping[str, float]]
+
+logger = logging.getLogger(__name__)
 
 
 def is_3d(da: xr.DataArray, vertical_dim: str = "z"):
@@ -225,3 +230,15 @@ def insert_column_integrated_vars(
         ds = ds.assign({column_integrated_name: da})
 
     return ds
+
+
+def _cleanup_temp_dir(temp_dir):
+    logger.info(f"Cleaning up temp dir {temp_dir.name}")
+    temp_dir.cleanup()
+
+
+def temporary_directory():
+    # useful for when the temp dir is used throughout the script
+    temp_data_dir = TemporaryDirectory()
+    atexit.register(_cleanup_temp_dir, temp_data_dir)
+    return temp_data_dir

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_select.py
@@ -1,5 +1,3 @@
-import numpy as np
-from typing import Sequence
 import xarray as xr
 import cftime
 
@@ -7,20 +5,8 @@ from vcm.select import meridional_ring
 import vcm
 
 
-def nearest_time_batch_index(
-    time: cftime.DatetimeJulian, time_batches: Sequence[Sequence[cftime.DatetimeJulian]]
-):
-    min_index = 0
-    min_distance = min(abs(np.array(time_batches[0]) - time))
-    for index, time_batch in enumerate(time_batches):
-        distance = min(abs(np.array(time_batch) - time))
-        if distance < min_distance:
-            min_index = index
-    return min_index
-
-
-def select_snapshot(batch: xr.Dataset, time: cftime.DatetimeJulian) -> xr.Dataset:
-    return batch.sortby("time").sel(time=time, method="nearest")
+def select_snapshot(ds: xr.Dataset, time: cftime.DatetimeJulian) -> xr.Dataset:
+    return ds.sortby("time").sel(time=time, method="nearest")
 
 
 def meridional_transect(ds: xr.Dataset):

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -260,6 +260,7 @@ def get_prediction(
 ) -> xr.Dataset:
 
     model_variables = _variables_to_load(model)
+    config.timesteps = sorted(config.timesteps)
     batches = config.load_batches(model_variables)
 
     transforms = [_get_predict_function(model, model_variables)]
@@ -277,11 +278,10 @@ def get_prediction(
     mapping_function = compose_left(*transforms)
     batches = loaders.Map(mapping_function, batches)
     loaded_batches = []
-    # for each batch...
     for i, ds in enumerate(batches):
         logger.info(f"Processing batch {i+1}/{len(batches)}")
         loaded_batches.append(ds.load())
-    return xr.merge(loaded_batches)
+    return xr.concat(loaded_batches, dim="time")
 
 
 def main(args):

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -28,11 +28,10 @@ from ._helpers import (
     insert_rmse,
     is_3d,
     load_grid_info,
-    batches_mean,
 )
 from ._coarsening import coarsen_cell_centered, res_from_string
 from ._input_sensitivity import plot_input_sensitivity
-from ._select import meridional_transect, nearest_time_batch_index, select_snapshot
+from ._select import meridional_transect, select_snapshot
 from .compute_diagnostics import compute_diagnostics
 from .derived_diagnostics import derived_registry
 
@@ -140,42 +139,27 @@ def _coord_to_var(coord: xr.DataArray, new_var_name: str) -> xr.DataArray:
 
 
 def _compute_diagnostics(
-    batches: Sequence[xr.Dataset],
-    grid: xr.Dataset,
-    predicted_vars: List[str],
-    res: int,
-    n_jobs: int,
+    ds: xr.Dataset, grid: xr.Dataset, predicted_vars: List[str], n_jobs: int,
 ) -> Tuple[xr.Dataset, xr.Dataset]:
-    batches_summary, timesteps = [], []
+    timesteps = []
 
-    # for each batch...
-    for i, ds in enumerate(batches):
-        logger.info(f"Processing batch {i+1}/{len(batches)}")
+    # ...insert additional variables
+    diagnostic_vars_3d = [var for var in predicted_vars if is_3d(ds[var])]
+    ds = ds.pipe(insert_column_integrated_vars, diagnostic_vars_3d).load()
 
-        # ...insert additional variables
-        diagnostic_vars_3d = [var for var in predicted_vars if is_3d(ds[var])]
-        ds = ds.pipe(insert_column_integrated_vars, diagnostic_vars_3d).load()
+    full_predicted_vars = [var for var in ds if DERIVATION_DIM_NAME in ds[var].dims]
+    if "dQ2" in full_predicted_vars or "Q2" in full_predicted_vars:
+        full_predicted_vars.append("water_vapor_path")
+    prediction = safe.get_variables(
+        ds.sel({DERIVATION_DIM_NAME: PREDICT_COORD}), full_predicted_vars
+    )
+    target = safe.get_variables(
+        ds.sel({DERIVATION_DIM_NAME: TARGET_COORD}), full_predicted_vars
+    )
+    ds_summary = compute_diagnostics(prediction, target, grid, ds[DELP], n_jobs=n_jobs)
 
-        full_predicted_vars = [var for var in ds if DERIVATION_DIM_NAME in ds[var].dims]
-        if "dQ2" in full_predicted_vars or "Q2" in full_predicted_vars:
-            full_predicted_vars.append("water_vapor_path")
-        prediction = safe.get_variables(
-            ds.sel({DERIVATION_DIM_NAME: PREDICT_COORD}), full_predicted_vars
-        )
-        target = safe.get_variables(
-            ds.sel({DERIVATION_DIM_NAME: TARGET_COORD}), full_predicted_vars
-        )
-        ds_summary = compute_diagnostics(
-            prediction, target, grid, ds[DELP], n_jobs=n_jobs
-        )
+    timesteps.append(ds["time"])
 
-        timesteps.append(ds["time"])
-
-        batches_summary.append(ds_summary.load())
-        del ds
-
-    # then average over the batches for each output
-    ds_summary = xr.concat(batches_summary, dim="batch")
     ds_summary = ds_summary.merge(compute_r2(ds_summary))
     if DATASET_DIM_NAME in ds_summary.dims:
         ds_summary = insert_aggregate_r2(ds_summary)
@@ -187,12 +171,12 @@ def _compute_diagnostics(
     )
     timesteps_all = _coord_to_var(xr.concat(timesteps, dim="time").time, "timesteps")
     ds_diagnostics["timesteps"] = timesteps_all
-    return batches_mean(ds_diagnostics, res), ds_scalar_metrics
+    return ds_diagnostics, ds_scalar_metrics
 
 
 def _consolidate_dimensioned_data(ds):
     # moves dimensioned quantities into final diags dataset so they're saved as netcdf
-    scalar_metrics = [var for var in ds if ds[var].size == len(ds.batch)]
+    scalar_metrics = [var for var in ds if ds[var].size == 1]
     ds_scalar_metrics = safe.get_variables(ds, scalar_metrics)
     ds_metrics_arrays = ds.drop(scalar_metrics)
     ds_diagnostics = ds.merge(ds_metrics_arrays)
@@ -250,14 +234,65 @@ def _get_data_mapper_if_exists(config):
 
 
 def _variables_to_load(model):
-    return list(
+    vars = list(
         set(list(model.input_variables) + list(model.output_variables) + [DELP])
     )
+    if "Q2" in model.output_variables:
+        vars.append("water_vapor_path")
+    return vars
 
 
 def _add_derived_diagnostics(ds):
     merged = xr.merge([ds, derived_registry.compute(ds, n_jobs=1)])
     return merged.assign_attrs(ds.attrs)
+
+
+def _coarsen_transform(evaluation_resolution: int, prediction_resolution: int):
+    coarsening_factor = prediction_resolution // evaluation_resolution
+    logger.info(
+        f"Making predictions at validation data's c{prediction_resolution} resolution."
+    )
+    logger.info(f"Evaluating diagnostics at c{evaluation_resolution} resolution.")
+    if prediction_resolution % evaluation_resolution != 0:
+        raise ValueError(
+            "Evaluation grid resolution does not match or evenly divide prediction "
+            "resolution."
+        )
+    if coarsening_factor > 1:
+        prediction_grid = load_grid_info(f"c{prediction_resolution}")
+        logger.info(f"Coarsening predictions by factor of {coarsening_factor}.")
+        return coarsen_cell_centered(
+            weights=prediction_grid.area, coarsening_factor=coarsening_factor
+        )
+
+
+def get_prediction(
+    config: loaders.BatchesConfig, model: fv3fit.Predictor, evaluation_grid: xr.Dataset
+) -> xr.Dataset:
+
+    model_variables = _variables_to_load(model)
+    batches = config.load_batches(model_variables)
+
+    transforms = [_get_predict_function(model, model_variables)]
+
+    prediction_resolution = res_from_string(config.res)
+    evaluation_resolution = evaluation_grid.sizes["x"]
+    if prediction_resolution != evaluation_resolution:
+        transforms.append(
+            _coarsen_transform(
+                evaluation_resolution=evaluation_resolution,
+                prediction_resolution=prediction_resolution,
+            )
+        )
+
+    mapping_function = compose_left(*transforms)
+    batches = loaders.Map(mapping_function, batches)
+    loaded_batches = []
+    # for each batch...
+    for i, ds in enumerate(batches):
+        logger.info(f"Processing batch {i+1}/{len(batches)}")
+        loaded_batches.append(ds.load())
+    return xr.merge(loaded_batches)
 
 
 def main(args):
@@ -279,57 +314,29 @@ def main(args):
     # add Q2 and total water path for PW-Q2 scatterplots and net precip domain averages
     if any(["Q2" in v for v in model.output_variables]):
         model = fv3fit.DerivedModel(model, derived_output_variables=["Q2"])
-        model_variables = _variables_to_load(model) + ["water_vapor_path"]
-    else:
-        model_variables = _variables_to_load(model)
+
+    ds_predicted = get_prediction(
+        config=config, model=model, evaluation_grid=evaluation_grid
+    )
 
     output_data_yaml = os.path.join(args.output_path, "data_config.yaml")
     with fsspec.open(args.data_yaml, "r") as f_in, fsspec.open(
         output_data_yaml, "w"
     ) as f_out:
         f_out.write(f_in.read())
-    batches = config.load_batches(model_variables)
-
-    transforms = [_get_predict_function(model, model_variables)]
-
-    prediction_resolution = res_from_string(config.res)
-    logger.info(
-        f"Making predictions at validation data's c{prediction_resolution} resolution."
-    )
-    evaluation_resolution = evaluation_grid.sizes["x"]
-    logger.info(f"Evaluating diagnostics at c{evaluation_resolution} resolution.")
-    if prediction_resolution % evaluation_resolution != 0:
-        raise ValueError(
-            "Evaluation grid resolution does not match or evenly divide prediction "
-            "resolution."
-        )
-    coarsening_factor = prediction_resolution // evaluation_resolution
-    if coarsening_factor > 1:
-        prediction_grid = load_grid_info(config.res)
-        logger.info(f"Coarsening predictions by factor of {coarsening_factor}.")
-        transforms.append(
-            coarsen_cell_centered(
-                weights=prediction_grid.area, coarsening_factor=coarsening_factor
-            )
-        )
-
-    mapping_function = compose_left(*transforms)
-
-    batches = loaders.Map(mapping_function, batches)
 
     # compute diags
     ds_diagnostics, ds_scalar_metrics = _compute_diagnostics(
-        batches,
+        ds_predicted,
         evaluation_grid,
         predicted_vars=model.output_variables,
-        res=evaluation_resolution,
         n_jobs=args.n_jobs,
     )
 
     ds_diagnostics = ds_diagnostics.update(evaluation_grid)
 
     # save model senstivity figures- these exclude derived variables
-    fig_input_sensitivity = plot_input_sensitivity(model, batches[0])
+    fig_input_sensitivity = plot_input_sensitivity(model, ds_predicted)
     if fig_input_sensitivity is not None:
         with fsspec.open(
             os.path.join(
@@ -346,10 +353,8 @@ def main(args):
             or sorted(getattr(config, "timesteps", list(mapper.keys())))[0]
         )
         snapshot_time = vcm.parse_datetime_from_str(snapshot_timestamp)
-        snapshot_index = nearest_time_batch_index(
-            snapshot_time, [batch.time.values for batch in batches]
-        )
-        ds_snapshot = select_snapshot(batches[snapshot_index], snapshot_time)
+
+        ds_snapshot = select_snapshot(ds_predicted, snapshot_time)
 
         vertical_vars = [
             var for var in model.output_variables if is_3d(ds_snapshot[var])
@@ -378,7 +383,9 @@ def main(args):
     )
 
     # convert and output metrics json
-    metrics = _average_metrics_dict(ds_scalar_metrics)
+    metrics = {
+        var: ds_scalar_metrics[var].values.item() for var in ds_scalar_metrics.data_vars
+    }
     with fsspec.open(os.path.join(args.output_path, METRICS_JSON_NAME), "w") as f:
         json.dump(metrics, f, indent=4)
 

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from tempfile import NamedTemporaryFile
-from typing import List, Mapping, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 import yaml
 
@@ -12,7 +12,6 @@ import dataclasses
 import fsspec
 import fv3fit
 import loaders
-import numpy as np
 import vcm
 import xarray as xr
 from toolz import compose_left
@@ -113,18 +112,6 @@ def _write_nc(ds: xr.Dataset, output_dir: str, output_file: str):
         ds.to_netcdf(tmpfile.name)
         vcm.get_fs(output_dir).put(tmpfile.name, output_file)
     logger.info(f"Writing netcdf to {output_file}")
-
-
-def _average_metrics_dict(ds_metrics: xr.Dataset) -> Mapping:
-    logger.info("Calculating metrics mean and stddev over batches...")
-    metrics = {
-        var: {
-            "mean": float(np.mean(ds_metrics[var].values)),
-            "std": float(np.std(ds_metrics[var].values)),
-        }
-        for var in ds_metrics.data_vars
-    }
-    return metrics
 
 
 def _standardize_names(*args: xr.Dataset):
@@ -267,7 +254,9 @@ def _coarsen_transform(evaluation_resolution: int, prediction_resolution: int):
 
 
 def get_prediction(
-    config: loaders.BatchesConfig, model: fv3fit.Predictor, evaluation_grid: xr.Dataset
+    config: loaders.BatchesFromMapperConfig,
+    model: fv3fit.Predictor,
+    evaluation_grid: xr.Dataset,
 ) -> xr.Dataset:
 
     model_variables = _variables_to_load(model)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -286,6 +286,7 @@ def get_prediction(
 def _daskify_sequence(batches):
     temp_data_dir = temporary_directory()
     for i, batch in enumerate(batches):
+        logger.info(f"Locally caching batch {i+1}/{len(batches)+1}")
         batch.to_netcdf(os.path.join(temp_data_dir.name, f"{i}.nc"))
     dask_ds = xr.open_mfdataset(os.path.join(temp_data_dir.name, "*.nc"))
     return dask_ds
@@ -381,7 +382,7 @@ def main(args):
 
     # convert and output metrics json
     metrics = {
-        var: ds_scalar_metrics[var].values.item() for var in ds_scalar_metrics.data_vars
+        var: ds_scalar_metrics[var].item() for var in ds_scalar_metrics.data_vars
     }
     with fsspec.open(os.path.join(args.output_path, METRICS_JSON_NAME), "w") as f:
         json.dump(metrics, f, indent=4)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -21,6 +21,7 @@ from fv3net.diagnostics.offline._helpers import (
     tidy_title,
     is_3d,
     temporary_directory,
+    units_from_name,
 )
 from fv3net.diagnostics.offline._select import plot_transect
 from fv3net.diagnostics.offline.compute import (
@@ -318,7 +319,9 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
     for var_r2, var_bias in zip(scalar_vars_r2, scalar_vars_bias):
         values = {
             "r2": "{:.2e}".format(metrics[var_r2]),
-            "bias": "{:.2e}".format(metrics[var_bias]),
+            "bias": (
+                "{:.2e} ".format(metrics[var_bias]) + f" {units_from_name(var_bias)}"
+            ),
         }
         metrics_formatted.append((var_r2.replace("_r2", ""), values))
 

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -18,11 +18,9 @@ from vcm.cloud import get_fs
 from fv3net.artifacts.metadata import StepMetadata
 import yaml
 from fv3net.diagnostics.offline._helpers import (
-    get_metric_string,
     open_diagnostics_outputs,
     copy_outputs,
     tidy_title,
-    units_from_name,
     is_3d,
 )
 from fv3net.diagnostics.offline._select import plot_transect
@@ -320,10 +318,8 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
 
     for var_r2, var_bias in zip(scalar_vars_r2, scalar_vars_bias):
         values = {
-            "r2": get_metric_string(metrics[var_r2]),
-            "bias": " ".join(
-                [get_metric_string(metrics[var_bias]), units_from_name(var_bias)]
-            ),
+            "r2": "{:.2e}".format(metrics[var_r2]),
+            "bias": "{:.2e}".format(metrics[var_bias]),
         }
         metrics_formatted.append((var_r2.replace("_r2", ""), values))
 
@@ -393,8 +389,8 @@ def create_report(args):
             metadata["training_data_config"] = yaml.safe_load(f)
     if args.no_wandb is False:
         wandb_config = {
-            "training_data": metadata.pop("training_data_config"),
-            "model_training_config": metadata.pop("training_config"),
+            "training_data": metadata.pop("training_data_config", None),
+            "model_training_config": metadata.pop("training_config", None),
             "metadata": metadata,
         }
         wandb.init(config=wandb_config)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -1,9 +1,7 @@
 import argparse
 import os
-import atexit
 import logging
 import sys
-import tempfile
 from typing import MutableMapping, Sequence, List
 import fsspec
 import wandb
@@ -22,6 +20,7 @@ from fv3net.diagnostics.offline._helpers import (
     copy_outputs,
     tidy_title,
     is_3d,
+    temporary_directory,
 )
 from fv3net.diagnostics.offline._select import plot_transect
 from fv3net.diagnostics.offline.compute import (
@@ -365,8 +364,7 @@ def render_index(config, metrics, ds_diags, ds_transect, output_dir) -> str:
 
 
 def create_report(args):
-    temp_output_dir = tempfile.TemporaryDirectory()
-    atexit.register(_cleanup_temp_dir, temp_output_dir)
+    temp_output_dir = temporary_directory()
 
     ds_diags, ds_transect, metrics, metadata = open_diagnostics_outputs(
         args.input_path,

--- a/workflows/diagnostics/tests/offline/test__select.py
+++ b/workflows/diagnostics/tests/offline/test__select.py
@@ -1,7 +1,7 @@
 import pytest
 import cftime
 import xarray as xr
-from fv3net.diagnostics.offline._select import nearest_time_batch_index, select_snapshot
+from fv3net.diagnostics.offline._select import select_snapshot
 
 
 BATCH_ONE = [
@@ -16,19 +16,6 @@ BATCH_THREE = [
     cftime.DatetimeJulian(2016, 8, 1, 11, 30),
     cftime.DatetimeJulian(2016, 8, 1, 20),
 ]
-
-
-@pytest.mark.parametrize(
-    "time, time_batches, expected_index",
-    [
-        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE], 0,),
-        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE, BATCH_TWO], 0,),
-        (cftime.DatetimeJulian(2016, 8, 1, 12), [BATCH_ONE, BATCH_THREE], 1,),
-    ],
-)
-def test_nearest_time(time, time_batches, expected_index):
-    index = nearest_time_batch_index(time, time_batches)
-    assert index == expected_index
 
 
 ORDERED_TIMES = [

--- a/workflows/diagnostics/tests/offline/test_compute.py
+++ b/workflows/diagnostics/tests/offline/test_compute.py
@@ -48,7 +48,7 @@ def test_offline_diags_integration(data_path, grid_dataset_path):  # noqa: F811
         "needs_grid": False,
         "res": "c8",
         "timesteps_per_batch": 1,
-        "timesteps": ["20160801.001500"],
+        "timesteps": ["20160801.001500", "20160801.003000"],
     }
     trained_model = fv3fit.testing.ConstantOutputPredictor(
         input_variables=["air_temperature", "specific_humidity"],

--- a/workflows/diagnostics/tests/offline/test_helpers.py
+++ b/workflows/diagnostics/tests/offline/test_helpers.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-import pytest
 import vcm
 from fv3net.diagnostics.offline._helpers import (
     DATASET_DIM_NAME,
@@ -10,7 +9,6 @@ from fv3net.diagnostics.offline._helpers import (
     insert_aggregate_r2,
     insert_column_integrated_vars,
     rename_via_replace,
-    batches_mean,
 )
 from fv3net.diagnostics.offline.compute_diagnostics import DERIVATION_DIM
 
@@ -110,18 +108,3 @@ def test_insert_column_integrated_vars():
     expected = ds.assign({"column_integrated_Q1": heating})
 
     xr.testing.assert_allclose(insert_column_integrated_vars(ds, ["Q1"]), expected)
-
-
-@pytest.mark.parametrize(
-    ["resolution", "expected_vars"],
-    [
-        pytest.param(48, ["a", "b"], id="c48_all_variables"),
-        pytest.param(384, ["b"], id="c384_only_2d_variables"),
-    ],
-)
-def test_batches_mean(resolution, expected_vars):
-    da_3d = xr.DataArray(np.arange(12.0).reshape(2, 3, 2), dims=["x", "z", "batch"])
-    da_2d = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=["x", "batch"])
-    ds = xr.Dataset({"a": da_3d, "b": da_2d})
-    result = batches_mean(ds, resolution)
-    assert set(result.data_vars) == set(expected_vars)


### PR DESCRIPTION
Iterating over batches adds complication to the computation of time mean metrics and also required extra helper functions to deal with averaging over batches. Model prediction is done over batches, which are saved locally to a temporary directory and read in as a single merged dataset of dask arrays, which is then used in the rest of the computations.

The main change is the addition of the `get_prediction` function, which takes the batches sequence, applies the prediction and optional coarsening transforms, and returns the data as a single dataset of dask arrays.

Significant internal changes:
- Removed loop over batches in diagnostics computation



Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/bf973bc1-0372-4578-8dbb-2fd575788394\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)