### PR TITLE
Small updates in the course of CycleGAN work

### DIFF
--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -1,3 +1,4 @@
 from .base import TFDatasetLoader, tfdataset_loader_from_dict, register_tfdataset_loader
 from .batches import FromBatches
-from .tfdataset import WindowedZarrLoader, VariableConfig
+from .tfdataset import WindowedZarrLoader, VariableConfig, CycleGANLoader
+from .synthetic import SyntheticNoise, SyntheticWaves

--- a/external/fv3fit/fv3fit/data/synthetic.py
+++ b/external/fv3fit/fv3fit/data/synthetic.py
@@ -94,8 +94,8 @@ class SyntheticWaves(TFDatasetLoader):
             variable_names: names of variables to include when loading data
         Returns:
             dataset containing requested variables, each record is a mapping from
-                variable name to variable value, and each value is a tensor whose
-                first dimension is the batch dimension
+                variable name to variable value, and each value is a tensor
+                of shape [nbatch, nsamples, ntime, nx, ny(, nz)]
         """
         if self.wave_type == "sinusoidal":
             func = np.sin

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -73,8 +73,10 @@ class CycleGANLoader(TFDatasetLoader):
     ) -> tf.data.Dataset:
         datasets = []
         for config in self.domain_configs:
-            datasets.append(config.open_tfdataset(local_download_path, variable_names))
-        return tf.data.Dataset.zip(tuple(datasets))
+            datasets.append(
+                config.open_tfdataset(local_download_path, variable_names).unbatch()
+            )
+        return tf.data.Dataset.zip(tuple(datasets)).batch(batch_size=self.batch_size)
 
     @classmethod
     def from_dict(cls, d: dict) -> "CycleGANLoader":

--- a/external/fv3fit/fv3fit/keras/_models/convolutional.py
+++ b/external/fv3fit/fv3fit/keras/_models/convolutional.py
@@ -17,7 +17,7 @@ from fv3fit.keras._models.shared.utils import (
     full_standard_normalized_input,
 )
 from fv3fit import tfdataset
-from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping, apply_to_tuple
+from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping
 
 logger = logging.getLogger(__file__)
 
@@ -88,8 +88,8 @@ def get_Xy_dataset(
         # clipping of inputs happens within the keras model, we don't clip at the
         # data layer so that the model still takes full-sized inputs when used
         # in production
-        x = apply_to_tuple(append_halos_tensor(n_halo))(
-            select_keys(input_variables, data)
+        x = select_keys(
+            input_variables, apply_to_mapping(append_halos_tensor(n_halo))(data)
         )
         y = select_keys(output_variables, clip_function(data))
         return x, y

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/train.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/train.py
@@ -16,7 +16,7 @@ from typing import (
     cast,
 )
 from .network import Generator
-from fv3fit.pytorch.graph.train import get_Xy_dataset
+from fv3fit.pytorch.graph.train import get_Xy_map_fn
 from fv3fit._shared.scaler import (
     get_standard_scaler_mapping,
     get_mapping_standard_scale_func,
@@ -94,18 +94,18 @@ def train_autoencoder(
     scalers = get_standard_scaler_mapping(sample_batch)
     mapping_scale_func = get_mapping_standard_scale_func(scalers)
 
-    get_state = curry(get_Xy_dataset)(
+    get_state = get_Xy_map_fn(
         state_variables=hyperparameters.state_variables,
         n_dims=6,  # [batch, time, tile, x, y, z]
         mapping_scale_func=mapping_scale_func,
     )
 
     if validation_batches is not None:
-        val_state = get_state(data=validation_batches)
+        val_state = validation_batches.map(get_state)
     else:
         val_state = None
 
-    train_state = get_state(data=train_batches)
+    train_state = train_batches.map(get_state)
 
     train_model = build_model(
         hyperparameters.generator, n_state=next(iter(train_state)).shape[-1]

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/train.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/train.py
@@ -8,19 +8,15 @@ from fv3fit.pytorch.training_loop import TrainingConfig
 
 from fv3fit._shared import register_training_function
 from typing import (
-    Hashable,
     List,
-    Mapping,
     Optional,
     Tuple,
-    cast,
 )
 from .network import Generator
 from fv3fit.pytorch.graph.train import get_Xy_map_fn
 from fv3fit._shared.scaler import (
     get_standard_scaler_mapping,
     get_mapping_standard_scale_func,
-    StandardScaler,
 )
 from toolz import curry
 import logging
@@ -135,7 +131,7 @@ def train_autoencoder(
         input_variables=hyperparameters.state_variables,
         output_variables=hyperparameters.state_variables,
         model=train_model,
-        scalers=cast(Mapping[Hashable, StandardScaler], scalers),
+        scalers=scalers,
     )
     return predictor
 

--- a/external/fv3fit/fv3fit/pytorch/graph/train.py
+++ b/external/fv3fit/fv3fit/pytorch/graph/train.py
@@ -2,7 +2,6 @@ import tensorflow as tf
 import numpy as np
 import dataclasses
 from fv3fit._shared.training_config import Hyperparameters
-from toolz.functoolz import curry
 from fv3fit.pytorch.predict import PytorchAutoregressor
 from fv3fit.pytorch.graph.mpg_unet import MPGraphUNetConfig
 from fv3fit.pytorch.graph.unet import GraphUNetConfig
@@ -89,18 +88,19 @@ def train_graph_model(
     scalers = get_standard_scaler_mapping(sample)
     mapping_scale_func = get_mapping_standard_scale_func(scalers)
 
-    get_state = curry(get_Xy_dataset)(
+    get_Xy = get_Xy_map_fn(
         state_variables=hyperparameters.state_variables,
         n_dims=6,  # [batch, time, tile, x, y, z]
         mapping_scale_func=mapping_scale_func,
     )
 
     if validation_batches is not None:
-        val_state = get_state(data=validation_batches).unbatch()
+        val_state = validation_batches.map(get_Xy).unbatch()
     else:
         val_state = None
 
-    train_state = get_state(data=train_batches).unbatch()
+    train_state = train_batches.map(get_Xy).unbatch()
+
     sample = next(iter(train_state))
     train_model = build_model(
         hyperparameters.graph_network, n_state=sample.shape[-1], nx=sample.shape[3],
@@ -133,11 +133,10 @@ def build_model(graph_network, n_state: int, nx: int):
     )
 
 
-def get_Xy_dataset(
+def get_Xy_map_fn(
     state_variables: Sequence[str],
     n_dims: int,
     mapping_scale_func: Callable[[Mapping[str, np.ndarray]], Mapping[str, np.ndarray]],
-    data: tf.data.Dataset,
 ):
     """
     Given a tf.data.Dataset with mappings from variable name to samples
@@ -165,4 +164,4 @@ def get_Xy_dataset(
         data = tf.concat(data, axis=-1)
         return data
 
-    return data.map(map_fn)
+    return map_fn

--- a/external/fv3fit/fv3fit/pytorch/graph/train.py
+++ b/external/fv3fit/fv3fit/pytorch/graph/train.py
@@ -11,20 +11,17 @@ from fv3fit.pytorch.training_loop import AutoregressiveTrainingConfig
 from fv3fit._shared.scaler import (
     get_standard_scaler_mapping,
     get_mapping_standard_scale_func,
-    StandardScaler,
 )
 from ..system import DEVICE
 
 from fv3fit._shared import register_training_function
 from typing import (
     Callable,
-    Hashable,
     List,
     Optional,
     Sequence,
     Set,
     Mapping,
-    cast,
     Union,
 )
 from fv3fit.tfdataset import select_keys, ensure_nd, apply_to_mapping
@@ -117,7 +114,7 @@ def train_graph_model(
     predictor = PytorchAutoregressor(
         state_variables=hyperparameters.state_variables,
         model=train_model,
-        scalers=cast(Mapping[Hashable, StandardScaler], scalers),
+        scalers=scalers,
     )
     return predictor
 

--- a/external/fv3fit/fv3fit/pytorch/system.py
+++ b/external/fv3fit/fv3fit/pytorch/system.py
@@ -1,3 +1,14 @@
+import torch.backends
 import torch
+import os
 
-DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+if os.environ.get("TORCH_CPU_ONLY", False):
+    DEVICE = torch.device("cpu")
+else:
+    DEVICE = torch.device(
+        "cuda:0"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.backends.mps.is_available()
+        else "cpu"
+    )

--- a/external/fv3fit/fv3fit/tfdataset.py
+++ b/external/fv3fit/fv3fit/tfdataset.py
@@ -27,11 +27,13 @@ def apply_to_mapping(
     return {name: tensor_func(tensor) for name, tensor in data.items()}
 
 
-@curry
 def apply_to_tuple(
-    tensor_func: Callable[[T_in], T_out], data: Tuple[T_in, ...]
-) -> Tuple[T_out, ...]:
-    return tuple(tensor_func(tensor) for tensor in data)
+    tensor_func: Callable[[T_in], T_out],
+) -> Callable[[Tuple[T_in, ...]], Tuple[T_out, ...]]:
+    def wrapped(*data):
+        return tuple(tensor_func(tensor) for tensor in data)
+
+    return wrapped
 
 
 def sequence_size(seq):

--- a/external/fv3fit/tests/test_tfdataset_ops.py
+++ b/external/fv3fit/tests/test_tfdataset_ops.py
@@ -224,3 +224,26 @@ def test__seq_to_tfdataset():
     result = next(tf_ds.as_numpy_iterator())
     assert isinstance(result, dict)
     np.testing.assert_equal(result["a"], batches[0]["a"] * 2)
+
+
+def test_tuple_map():
+    """
+    External package test demonstrating that for map operations on tuples
+    of functions, tuple entries are passed as independent arguments
+    and must be collected with *args.
+    """
+
+    def generator():
+        for entry in [(1, 1), (2, 2), (3, 3)]:
+            yield entry
+
+    dataset = tf.data.Dataset.from_generator(
+        generator, output_types=(tf.int32, tf.int32)
+    )
+
+    def map_fn(x, y):
+        return x * 2, y * 3
+
+    mapped = dataset.map(map_fn)
+    out = list(mapped)
+    assert out == [(2, 3), (4, 6), (6, 9)]


### PR DESCRIPTION
This PR contains small fixes and changes needed to support adding the CycleGAN model.

Added public API:
- Added missing symbols `CycleGANLoader`, `SyntheticNoise`, and `SyntheticWaves` to fv3fit.data
- updated typing on PytorchAutoregressor to use str keys for scalers
- added MPS support to fv3fit.pytorch.system.DEVICE for mac M1s
- fixed bug in apply_to_tuple where it did not follow the *args convention used by tensorflow

Refactored public API:
- fixed bug in CycleGanLoader where batch_size option is ignored

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/b42cca04-75bb-4b97-b34f-4a49981a017c/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)