### PR TITLE
emulation: Add configuration for batch size

### DIFF
--- a/external/emulation/emulation/config.py
+++ b/external/emulation/emulation/config.py
@@ -98,6 +98,8 @@ class ModelConfig:
             transformations to apply before and after data is passed to models.
             Currently only works with transforms that do not require to be
             built.
+        batch_size: number of columns to batch the ml prediction by. May reduce
+            memory use.
     """
 
     path: Optional[str] = None
@@ -116,6 +118,7 @@ class ModelConfig:
     mask_gscond_zero_cloud_classifier: bool = False
     mask_gscond_no_tend_classifier: bool = False
     mask_precpd_zero_cloud_classifier: bool = False
+    batch_size: int = 512
 
     @property
     def _transform_factory(self) -> ComposedTransformFactory:
@@ -133,7 +136,7 @@ class ModelConfig:
                 else None
             )
             adapter = emulation.models.combine_classifier_and_regressor(
-                classifier, regressor
+                classifier, regressor, self.batch_size
             )
         else:
 

--- a/external/emulation/emulation/models.py
+++ b/external/emulation/emulation/models.py
@@ -65,7 +65,7 @@ def _as_numpy(state):
 
 
 def combine_classifier_and_regressor(
-    classifier, regressor
+    classifier, regressor, batch_size: int
 ) -> Callable[[FortranState], FortranState]:
     # These following two adapters are for backwards compatibility
     dict_output_model = adapters.ensure_dict_output(regressor)
@@ -77,4 +77,4 @@ def combine_classifier_and_regressor(
             "cloud_water_mixing_ratio_output": "cloud_water_mixing_ratio_after_precpd",  # noqa: E501
         },
     )
-    return ModelWithClassifier(model, classifier)
+    return ModelWithClassifier(model, classifier, batch_size=batch_size)

--- a/external/emulation/tests/test_microphysics.py
+++ b/external/emulation/tests/test_microphysics.py
@@ -22,7 +22,7 @@ def test_Hook_integration(saved_model_path):
 
     model = _load_tf_model(saved_model_path)
     model = emulation.models.combine_classifier_and_regressor(
-        regressor=model, classifier=None
+        regressor=model, classifier=None, batch_size=None
     )
     hook = MicrophysicsHook(model=model, mask=always_emulator)
 

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -441,6 +441,7 @@ tendency_prescriber: null
 zhao_carr_emulation:
   gscond: null
   model:
+    batch_size: 512
     classifier_path: null
     cloud_squash: null
     enforce_conservative: false


### PR DESCRIPTION
I need to further reduce this to improve memory performance...though the effect is pretty small 1% smaller use of system memory with the reduced batch size, but this seems to be just enough to allow the run to eke by.

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/44f11c6a-07a6-4f06-aff8-444dc82273d9\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)