### PR TITLE
Use existing column dQv diagnostic when available

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
@@ -183,6 +183,8 @@ def _column_dqv(ds: xr.Dataset) -> xr.DataArray:
         )
         # convert from m/s/s to Pa by multiplying by surface pressure divided by gravity
         column_dqv = 100000 / 9.8065 * ds.column_integrated_dQv
+    elif "column_integrated_dQv_stress" in ds:
+        column_dqv = ds.column_integrated_dQv_stress
     else:
         # assume given dataset has no ML prediction of momentum tendencies
         column_dqv = xr.zeros_like(ds.PRATEsfc)


### PR DESCRIPTION
Fixes issue of dQv being set to 0 in reduced prognostic run diagnostics, even when variable is saved out with proper name.

Resolves #1861 

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/55d63587-6864-4963-88a9-fb6bf12f8279\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)