### PR TITLE
Add artifacts offline-report search CLI

### DIFF
--- a/external/artifacts/fv3net/artifacts/cli.py
+++ b/external/artifacts/fv3net/artifacts/cli.py
@@ -1,7 +1,5 @@
 import argparse
-from fv3net.artifacts import query
-from fv3net.artifacts import report_search
-from fv3net.artifacts import resolve_url
+from fv3net.artifacts import query, resolve_url, report_search, offline_report_search
 
 
 def get_parser():
@@ -11,6 +9,7 @@ def get_parser():
     subparsers = parser.add_subparsers(required=True, dest="command")
     query.register_parser(subparsers)
     report_search.register_parser(subparsers)
+    offline_report_search.register_parser(subparsers)
     resolve_url.register_parser(subparsers)
     return parser
 

--- a/external/artifacts/fv3net/artifacts/offline_report_search.py
+++ b/external/artifacts/fv3net/artifacts/offline_report_search.py
@@ -1,0 +1,42 @@
+import os
+from typing import Optional
+
+from .report_search import ReportIndex
+
+REPORT_URL_DEFAULT = "gs://vcm-ml-public/ml_offline_diags"
+
+def _get_model_url(line: str) -> Optional[str]:
+    if '"model_path": "gs://' in line:
+        return line.split('"model_path": ')[1].strip('",')
+    else:
+        return None
+
+def main(args):
+    if args.write:
+        index = ReportIndex(_search_function=_get_model_url)
+        index.compute(args.reports_url, recurse_once=True)
+        index.dump(os.path.join(args.reports_url, "index.json"))
+    index = ReportIndex.from_json(os.path.join(args.reports_url, "index.json"))
+    for link in index.public_links(args.url):
+        print(link)
+
+
+def register_parser(subparsers):
+    parser = subparsers.add_parser("offline-report", help="Search for offline ML reports.")
+    parser.add_argument("url", help="An fv3fit model URL.")
+    parser.add_argument(
+        "-r",
+        "--reports-url",
+        help=(
+            f"Location of offline reports. Defaults to {REPORT_URL_DEFAULT}. "
+            "Search uses index at REPORTS_URL/index.json"
+        ),
+        default=REPORT_URL_DEFAULT,
+    )
+    parser.add_argument(
+        "-w",
+        "--write",
+        help="Recompute index and write to REPORTS_URL/index.json before searching.",
+        action="store_true",
+    )
+    parser.set_defaults(func=main)

--- a/external/artifacts/fv3net/artifacts/offline_report_search.py
+++ b/external/artifacts/fv3net/artifacts/offline_report_search.py
@@ -5,11 +5,13 @@ from .report_search import ReportIndex
 
 REPORT_URL_DEFAULT = "gs://vcm-ml-public/offline_ml_diags"
 
+
 def _get_model_url(line: str) -> Optional[str]:
     if '"model_path": "gs://' in line:
         return line.split('"model_path": ')[1].strip('",')
     else:
         return None
+
 
 def main(args):
     if args.write:
@@ -22,7 +24,9 @@ def main(args):
 
 
 def register_parser(subparsers):
-    parser = subparsers.add_parser("offline-report", help="Search for offline ML reports.")
+    parser = subparsers.add_parser(
+        "offline-report", help="Search for offline ML reports."
+    )
     parser.add_argument("url", help="An fv3fit model URL.")
     parser.add_argument(
         "-r",

--- a/external/artifacts/fv3net/artifacts/offline_report_search.py
+++ b/external/artifacts/fv3net/artifacts/offline_report_search.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from .report_search import ReportIndex
 
-REPORT_URL_DEFAULT = "gs://vcm-ml-public/ml_offline_diags"
+REPORT_URL_DEFAULT = "gs://vcm-ml-public/offline_ml_diags"
 
 def _get_model_url(line: str) -> Optional[str]:
     if '"model_path": "gs://' in line:

--- a/external/artifacts/fv3net/artifacts/report_search.py
+++ b/external/artifacts/fv3net/artifacts/report_search.py
@@ -87,7 +87,7 @@ class ReportIndex:
         {url}/*/{filename}."""
         out = {}
         for path in await _list(fs, url):
-            report_dirs = fs.ls(path) if recurse_once else [path]
+            report_dirs = await _list(fs, path) if recurse_once else [path]
             for report_dir in report_dirs:
                 report_url = self._url_prefix(fs) + os.path.join(report_dir, filename)
 

--- a/external/artifacts/fv3net/artifacts/tests/test_report_search.py
+++ b/external/artifacts/fv3net/artifacts/tests/test_report_search.py
@@ -151,6 +151,23 @@ def test_ReportIndex_compute(report_sample, tmpdir):
     }
 
 
+def test_ReportIndex_compute_with_recurse_once(tmpdir):
+    expected_run = (
+        "gs://vcm-ml-experiments/spencerc/2021-05-28/"
+        "n2f-25km-all-climate-tapered-fixed-ml-unperturbed-seed-0/fv3gfs_run"
+    )
+    os.makedirs(tmpdir.join("topdir/report1"))
+    os.makedirs(tmpdir.join("topdir/report2"))
+    with open(tmpdir.join("topdir/report1/index.html"), "w") as f:
+        f.write(NEW_REPORT_SAMPLE)
+    with open(tmpdir.join("topdir/report2/index.html"), "w") as f:
+        f.write(NEW_REPORT_SAMPLE)
+
+    index = ReportIndex()
+    index.compute(str(tmpdir), recurse_once=True)
+    assert expected_run in index.reports_by_id
+
+
 def test_ReportIndex_public_links():
     index = ReportIndex(
         {

--- a/external/artifacts/fv3net/artifacts/tests/test_report_search.py
+++ b/external/artifacts/fv3net/artifacts/tests/test_report_search.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from fv3net.artifacts.report_search import ReportIndex
+from fv3net.artifacts.offline_report_search import _get_model_url
 
 # flake8: noqa E501
 REPORT_SAMPLE = """<html>
@@ -127,6 +128,52 @@ NEW_REPORT_SAMPLE = """<html>
         <h2>Top-level metrics</h2>
 """
 
+OFFLINE_REPORT_SAMPLE = """
+    <html>
+    <head>
+        <title>ML offline diagnostics</title>
+
+    </head>
+
+    <body>
+    <h1>ML offline diagnostics</h1>
+    Report created 2021-11-07 01:02:49 PDT
+
+        <h2>Metadata</h2>
+<pre id="json">
+{
+    "model_path": "gs://vcm-ml-experiments/default/2021-11-07/hybrid-fluxes-input-3hrly-rf/trained_models/sklearn_model",
+    "data_config": {
+        "mapper_config": {
+            "function": "open_3hrly_fine_resolution_nudging_hybrid",
+            "kwargs": {
+                "fine_url": "gs://vcm-ml-intermediate/2021-10-08-fine-res-3hrly-averaged-Q1-Q2-from-40-day-X-SHiELD-simulation-2020-05-27.zarr",
+                "nudge_url": "gs://vcm-ml-experiments/default/2021-09-26/n2f-3km-nudging/fv3gfs_run"
+            }
+        },
+        "function": "batches_from_mapper",
+        "kwargs": {
+            "timesteps_per_batch": 10,
+            "timesteps": [
+                "20160902.203000",
+                "20160908.203000",
+                "20160906.083000",
+                "20160904.023000",
+                "20160904.233000",
+                "20160901.083000",
+                "20160905.083000",
+                "20160909.233000",
+                "20160904.143000",
+                "20160903.233000",
+                "20160907.083000",
+                "20160902.083000",
+                "20160903.173000",
+                "20160904.113000",
+                "20160907.143000",
+                "20160901.113000",
+                "20160901.203000",
+"""
+
 
 @pytest.mark.parametrize("report_sample", (REPORT_SAMPLE, NEW_REPORT_SAMPLE))
 def test_ReportIndex_compute(report_sample, tmpdir):
@@ -194,3 +241,17 @@ def test_ReportIndex_reports():
     )
     expected_reports = {"/report1/index.html", "/report2/index.html"}
     assert index.reports == expected_reports
+
+
+def test_offline_report_search(tmpdir):
+    expected_model_path = (
+        "gs://vcm-ml-experiments/default/2021-11-07/"
+        "hybrid-fluxes-input-3hrly-rf/trained_models/sklearn_model"
+    )
+    os.makedirs(tmpdir.join("topdir/report1"))
+    with open(tmpdir.join("topdir/report1/index.html"), "w") as f:
+        f.write(OFFLINE_REPORT_SAMPLE)
+
+    index = ReportIndex(_search_function=_get_model_url)
+    index.compute(str(tmpdir), recurse_once=True)
+    assert expected_model_path in index.reports_by_id

--- a/external/artifacts/fv3net/artifacts/tests/test_report_search.py
+++ b/external/artifacts/fv3net/artifacts/tests/test_report_search.py
@@ -144,8 +144,8 @@ def test_ReportIndex_compute(report_sample, tmpdir):
     index = ReportIndex()
     index.compute(str(tmpdir))
 
-    assert expected_run in index.reports_by_run
-    assert set(index.reports_by_run[expected_run]) == {
+    assert expected_run in index.reports_by_id
+    assert set(index.reports_by_id[expected_run]) == {
         str(tmpdir.join("report1/index.html")),
         str(tmpdir.join("report2/index.html")),
     }


### PR DESCRIPTION
It is difficult to find offline ML reports corresponding to particular models. This adds a search feature for offline reports very similar to the prognostic report searching functionality.

Added public API:
- `artifacts offline-report` CLI

Significant internal changes:
- Generalized the `ReportIndex` class to allow it to work as an index for either offline or prognostic run reports

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/5b3202af-4366-4c71-9e1c-8f6bca0bea24/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)