### PR TITLE
Ignore NaN predictions in fv3fit step transformer

### DIFF
--- a/workflows/prognostic_c48_run/runtime/transformers/core.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/core.py
@@ -68,7 +68,9 @@ class StepTransformer:
         return set(strip_prefix(self.prefix, self.diagnostic_variables))
 
     def transform(self, func: Step) -> Diagnostics:
-        inputs: State = {key: self.state[key] for key in self.model.input_variables}
+        inputs: State = {
+            key: self.state[key].copy(deep=True) for key in self.model.input_variables
+        }
         inputs_to_save: Diagnostics = {
             self.prefix + key: self.state[key] for key in self.inputs_to_save
         }

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -88,8 +88,6 @@ class Adapter:
                 k: v.where(v.notnull(), state[k]) for k, v in prediction.items()
             }
             state.update(prediction_masked)
-            # print(prediction)
-            # state.update(prediction)
 
     def partial_fit(self, inputs: State, state: State):
         pass

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -84,7 +84,12 @@ class Adapter:
 
     def apply(self, prediction: State, state: State):
         if self.config.online:
-            state.update(prediction)
+            prediction_masked = {
+                k: v.where(v.notnull(), state[k]) for k, v in prediction.items()
+            }
+            state.update(prediction_masked)
+            # print(prediction)
+            # state.update(prediction)
 
     def partial_fit(self, inputs: State, state: State):
         pass


### PR DESCRIPTION
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/2056c251-2a37-4dc8-a80c-70b1ecd7538c/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)