### PR TITLE
Prognostic run: factory method for radiation stepper inputs

### DIFF
--- a/workflows/prognostic_c48_run/runtime/factories.py
+++ b/workflows/prognostic_c48_run/runtime/factories.py
@@ -111,17 +111,22 @@ def get_tendency_prescriber(
 
 def _get_time_lookup_function(
     mapper: Mapping[str, xr.Dataset],
-    variables: Sequence[str],
+    variables: Union[Sequence[str], Mapping[str, str]],
     initial_time: Optional[str] = None,
     frequency_seconds: float = 900.0,
     limiter: Optional[DatasetQuantileLimiter] = None,
 ) -> Callable[[cftime.DatetimeJulian], State]:
+    if isinstance(variables, list):
+        _variables: Mapping[str, str] = {var: var for var in variables}
+    elif isinstance(variables, dict):
+        _variables = variables
+
     def time_lookup_function(time: cftime.DatetimeJulian) -> State:
         timestamp = vcm.encode_time(time)
         ds = mapper[timestamp]
         if limiter is not None:
             ds = limiter.transform(ds)
-        return {var: ds[var].load() for var in variables}
+        return {var_out: ds[var_in].load() for var_in, var_out in _variables.items()}
 
     if initial_time is not None:
         initial_time = label_to_time(initial_time)

--- a/workflows/prognostic_c48_run/runtime/factories.py
+++ b/workflows/prognostic_c48_run/runtime/factories.py
@@ -16,12 +16,8 @@ from runtime.config import UserConfig
 from runtime.transformers.core import StepTransformer
 from runtime.transformers.tendency_prescriber import TendencyPrescriber
 from runtime.steppers.prescriber import PrescriberConfig, Prescriber
-from runtime.steppers.radiation import RadiationStepperConfig, RadiationStepper
-from runtime.steppers.machine_learning import (
-    MachineLearningConfig,
-    PureMLStepper,
-    open_model,
-)
+from runtime.steppers.radiation import RadiationStepper
+from runtime.steppers.machine_learning import PureMLStepper
 from runtime.interpolate import time_interpolate_func, label_to_time
 from runtime.derived_state import DerivedFV3State
 import runtime.transformers.emulator
@@ -172,21 +168,13 @@ def get_prescriber(
 
 
 def get_radiation_stepper(
-    stepper_config: RadiationStepperConfig,
-    comm,
     physics_namelist: Mapping[Hashable, Any],
     timestep: float,
+    comm,
     tracer_metadata: Mapping[Hashable, Mapping[Hashable, int]],
+    input_generator: Optional[Union[PureMLStepper, Prescriber]],
 ) -> RadiationStepper:
     radiation_config = radiation.RadiationConfig.from_physics_namelist(physics_namelist)
-    if isinstance(stepper_config.input_generator, MachineLearningConfig):
-        input_generator: Optional[Union[PureMLStepper, Prescriber]] = PureMLStepper(
-            open_model(stepper_config.input_generator), timestep, hydrostatic=False
-        )
-    elif isinstance(stepper_config.input_generator, PrescriberConfig):
-        input_generator = get_prescriber(stepper_config.input_generator, comm)
-    else:
-        input_generator = None
     tracer_inds: Mapping[str, int] = {
         str(name): metadata["i_tracer"] for name, metadata in tracer_metadata.items()
     }

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple, Optional, Callable
+from typing import Sequence, Tuple, Optional, Callable, Union, Mapping
 import dataclasses
 import logging
 import cftime
@@ -18,7 +18,9 @@ class PrescriberConfig:
 
     Attributes:
         dataset_key: path of zarr dataset
-        variables: sequence of variable names in the dataset to prescribe
+        variables: sequence of variable names in the dataset to prescribe, or a
+            mapping from the non-standard names in the dataset to the standard names
+            to be prescribed
         consolidated: whether desired dataset has consolidated metadata;
             defaults to True
         reference_initial_time: if time interpolating, time of first point in dataset
@@ -38,7 +40,7 @@ class PrescriberConfig:
     """  # noqa
 
     dataset_key: str
-    variables: Sequence[str]
+    variables: Union[Sequence[str], Mapping[str, str]]
     consolidated: bool = True
     reference_initial_time: Optional[str] = None
     reference_frequency_seconds: float = 900

--- a/workflows/prognostic_c48_run/runtime/steppers/radiation.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/radiation.py
@@ -31,8 +31,7 @@ class RadiationStepper:
     def __call__(
         self, time: cftime.DatetimeJulian, state: State,
     ):
-        if self._input_generator is not None:
-            state = self._generate_inputs(state, time)
+        state = self._generate_inputs(state, time)
         diagnostics = self._radiation(time, state)
         return {}, diagnostics, {}
 

--- a/workflows/prognostic_c48_run/tests/test_adapters.py
+++ b/workflows/prognostic_c48_run/tests/test_adapters.py
@@ -62,6 +62,11 @@ def test_RenamingAdapter_input_vars_():
     assert model.input_variables == {"x"}
 
 
+def test_RenamingAdapter_output_vars_():
+    model = RenamingAdapter(MockPredictor(), {}, {"y": "rename_output"})
+    assert model.output_variables == {"y"}
+
+
 def test_MultiModelAdapter_combines_predictions():
     ds = xr.Dataset({"x": (["dim_0", "dim_1"], np.ones((5, 10)))})
     model0 = MockPredictor(output_variables=["y0"], input_variables=["x"])
@@ -91,3 +96,11 @@ def test_MultiModelAdapter_scales_predictions():
     assert "y0" in out.data_vars and "y1" in out.data_vars
     np.testing.assert_array_equal(out["y0"], 2.0)
     np.testing.assert_array_equal(out["y1"], 1.0)
+
+
+def test_MultiModelAdapter_input_output_vars_():
+    model0 = MockPredictor(output_variables=["y0"], input_variables=["x0"])
+    model1 = MockPredictor(output_variables=["y1"], input_variables=["x1"])
+    combined_model = MultiModelAdapter([model0, model1])
+    assert {"x0", "x1"} == combined_model.input_variables
+    assert {"y0", "y1"} == combined_model.output_variables


### PR DESCRIPTION
Adds a cleaner factory method for the radiation stepper, separating out the construction of the prescriber/ML stepper that generates inputs to the radiation stepper, from the construction of the stepper itself. This new prescriber/ML stepper constructor is then shared across the radiation and prephysics stepper construction. Previously running the radiation stepper with prescribed inputs was blocked due to a bug about its factory method's MPI comm input arg, but that was hard to see because the factory method was doing several things.

Significant internal changes:
- in the prognostic run loop, the prephysics and radiation input steppers are now generated by a common method, `_get_prescriber_or_ml_stepper`
- Adds an `.output_variables` property to the `Renaming` and `MultiModel` adapters in `runtime.steppers.machine_learning` to aid in logging what steppers are doing. 
- Also moves some of the model opening helpers out of `loop` and into `runtime.steppers.machine_learning`

[X] Tests added

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/c12f77b2-7134-4b9e-a097-d35ef3044b69/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)