### PR TITLE
Use xarray weighting feature in vcm.weighted_average

### DIFF
--- a/external/vcm/tests/test_calc.py
+++ b/external/vcm/tests/test_calc.py
@@ -209,7 +209,7 @@ weights_nans = xr.DataArray(np.full((4,), np.nan), dims=["z"])
     [
         (da, weights, "z", xr.DataArray(17.0 / 6.0)),
         (ds, weights, "z", xr.Dataset({"a": xr.DataArray(17.0 / 6.0)})),
-        (da_nans, weights, "z", xr.DataArray(0.0)),
+        (da_nans, weights, "z", xr.DataArray(np.nan)),
         (da, weights_nans, "z", xr.DataArray(np.nan)),
         (da, weights_some_nans, "z", xr.DataArray((0.5 + 1 + 4) / (0.5 + 0.5 + 1))),
         (da_some_nans, weights, "z", xr.DataArray((0.5 + 1 + 3) / (0.5 + 0.5 + 1))),

--- a/external/vcm/tests/test_calc.py
+++ b/external/vcm/tests/test_calc.py
@@ -197,8 +197,10 @@ def test_relative_humidity_from_pressure():
 
 da = xr.DataArray(np.arange(1.0, 5.0), dims=["z"])
 da_nans = xr.DataArray(np.full((4,), np.nan), dims=["z"])
+da_some_nans = xr.DataArray([1, 2, 3, np.nan], dims=["z"])
 ds = xr.Dataset({"a": da})
 weights = xr.DataArray([0.5, 0.5, 1, 1], dims=["z"])
+weights_some_nans = xr.DataArray([0.5, 0.5, np.nan, 1], dims=["z"])
 weights_nans = xr.DataArray(np.full((4,), np.nan), dims=["z"])
 
 
@@ -209,6 +211,8 @@ weights_nans = xr.DataArray(np.full((4,), np.nan), dims=["z"])
         (ds, weights, "z", xr.Dataset({"a": xr.DataArray(17.0 / 6.0)})),
         (da_nans, weights, "z", xr.DataArray(0.0)),
         (da, weights_nans, "z", xr.DataArray(np.nan)),
+        (da, weights_some_nans, "z", xr.DataArray((0.5 + 1 + 4) / (0.5 + 0.5 + 1))),
+        (da_some_nans, weights, "z", xr.DataArray((0.5 + 1 + 3) / (0.5 + 0.5 + 1))),
     ],
 )
 def test_weighted_average(da, weights, dims, expected):

--- a/external/vcm/vcm/calc/calc.py
+++ b/external/vcm/vcm/calc/calc.py
@@ -23,11 +23,6 @@ def local_time(ds, time=INIT_TIME_DIM, lon_var=VAR_LON_CENTER):
     return local_time
 
 
-def _weighted_average(array, weights, axis=None):
-
-    return np.nansum(array * weights, axis=axis) / np.nansum(weights, axis=axis)
-
-
 def weighted_average(
     array: Union[xr.Dataset, xr.DataArray],
     weights: xr.DataArray,
@@ -43,19 +38,8 @@ def weighted_average(
     Returns:
         xr dataarray or dataset of weighted averaged variables
     """
-    if dims is not None:
-        kwargs = {"axis": tuple(range(-len(dims), 0))}
-    else:
-        kwargs = {}
     with xr.set_options(keep_attrs=True):
-        return xr.apply_ufunc(
-            _weighted_average,
-            array,
-            weights,
-            input_core_dims=[dims, dims],
-            kwargs=kwargs,
-            dask="allowed",
-        )
+        return array.weighted(weights.fillna(0.0)).mean(dims)
 
 
 def vertical_tapering_scale_factors(n_levels: int, cutoff: int, rate: float):


### PR DESCRIPTION
Using the xarray weighting feature simplifies our code and also gives us more reasonable results in the case of there being NaNs in the quantity-to-be-averaged.

Significant internal changes:
- vcm.weighted_average now uses the xarray `.weighted` accessor
- one breaking change: if an array consists entirely of NaNs, the resulting weighted average will now also be a NaN instead of 0 (the current behavior)

- [x] Tests added

Resolves #2048 

Coverage reports (updated automatically):
- test_unit: [83%](https://output.circle-artifacts.com/output/job/269f47a5-909a-49c1-ae3b-691f4cca43ae/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)