### PR TITLE
Print duration of slowest unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ test_%:
 	cd external/$* && tox -- $(ARGS)
 
 test_unit: test_fv3kube test_vcm test_fv3fit test_artifacts
-	coverage run -m pytest -m "not regression" --mpl --mpl-baseline-path=tests/baseline_images $(ARGS)
+	coverage run -m pytest -m "not regression" --durations=20 $(ARGS)
 	coverage combine \
 		--append \
 		external/fv3kube/.coverage \

--- a/external/fv3fit/tox.ini
+++ b/external/fv3fit/tox.ini
@@ -17,7 +17,7 @@ deps =
     ../loaders
     ../artifacts
 commands =
-    coverage run -m pytest {posargs}
+    coverage run -m pytest --durations=30 {posargs}
 passenv =
     GOOGLE_APPLICATION_CREDENTIALS
     NIX_SSL_CERT_FILE

--- a/external/vcm/tox.ini
+++ b/external/vcm/tox.ini
@@ -13,7 +13,7 @@ deps =
     coverage
     ../mappm
 commands =
-    coverage run -m pytest {posargs}
+    coverage run -m pytest --durations=20 {posargs}
 passenv =
     GOOGLE_APPLICATION_CREDENTIALS
     NIX_SSL_CERT_FILE


### PR DESCRIPTION
Useful for monitoring unit test duration (although the unit test CI logs are very long, filled with warnings and difficult to parse).

Coverage reports (updated automatically):
- test_unit: [83%](https:\/\/output.circle-artifacts.com\/output\/job\/544449e7-d278-4078-ae45-75b321964f76\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)