### PR TITLE
Update fv3gfs submodule

### DIFF
--- a/external/emulation/emulation/_emulate/microphysics.py
+++ b/external/emulation/emulation/_emulate/microphysics.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import datetime
-from typing import Callable, Optional, List
+from typing import Callable
 import cftime
 import gc
 import numpy as np
@@ -66,7 +66,6 @@ class MicrophysicsHook:
         """
 
         self.name = "microphysics emulator"
-        self.orig_outputs: Optional[List[str]] = None
         self.garbage_collection_interval = garbage_collection_interval
         self.mask = mask
         self._calls_since_last_collection = 0
@@ -96,17 +95,6 @@ class MicrophysicsHook:
         model_outputs = {
             name: np.asarray(tensor).T for name, tensor in predictions.items()
         }
-
-        # fields stay in global state so check overwrites on first step
-        if self.orig_outputs is None:
-            self.orig_outputs = sorted(set(state).intersection(model_outputs))
-            logger.debug(f"Overwriting existing state fields: {self.orig_outputs}")
-
-        microphysics_diag = {
-            f"{name}_physics_diag": state[name] for name in self.orig_outputs
-        }
-
         model_outputs.update(self.mask(state, model_outputs))
         state.update(model_outputs)
-        state.update(microphysics_diag)
         self._maybe_garbage_collect()

--- a/external/emulation/emulation/_monitor/monitor.py
+++ b/external/emulation/emulation/_monitor/monitor.py
@@ -273,12 +273,16 @@ class StorageHook:
             logger.debug(
                 f"Store flags: save_zarr={self.save_zarr}, save_nc={self.save_nc}"
             )
+            try:
+                if self.save_zarr:
+                    _store_zarr(state, time, self.monitor, self.metadata)
 
-            if self.save_zarr:
-                _store_zarr(state, time, self.monitor, self.metadata)
+                if self.save_nc:
+                    _store_netcdf(state, time, self.nc_dump_path, self.metadata)
 
-            if self.save_nc:
-                _store_netcdf(state, time, self.nc_dump_path, self.metadata)
-
-            if self.save_tfrecord:
-                self._store_tfrecord(state, time)
+                if self.save_tfrecord:
+                    self._store_tfrecord(state, time)
+            except Exception as e:
+                shapes = {key: np.shape(val) for key, val in state.items()}
+                logger.critical("Failed to store state with shapes: %s", shapes)
+                raise e

--- a/external/emulation/emulation/_monitor/monitor.py
+++ b/external/emulation/emulation/_monitor/monitor.py
@@ -19,7 +19,7 @@ from emulation._time import translate_time
 logger = logging.getLogger(__name__)
 
 TIME_FMT = "%Y%m%d.%H%M%S"
-DIMS_MAP = {1: ["sample"], 2: ["sample", "z"], 3: ["sample", "z", "category"]}
+DIMS_MAP = {0: [], 1: ["sample"], 2: ["sample", "z"], 3: ["sample", "z", "category"]}
 
 
 @dataclasses.dataclass

--- a/external/emulation/tests/test_microphysics.py
+++ b/external/emulation/tests/test_microphysics.py
@@ -40,11 +40,7 @@ def test_Hook_integration(saved_model_path):
 
         # microphysics saves any key overwrites as a diagnostic
         updated = state["air_temperature_dummy"]
-        diag = state["air_temperature_dummy_physics_diag"]
-
-        np.testing.assert_array_equal(diag, input)
         np.testing.assert_array_almost_equal(input + 1, updated)
-
         state["air_temperature_input"] = updated
 
 

--- a/external/emulation/tests/test_models.py
+++ b/external/emulation/tests/test_models.py
@@ -20,6 +20,10 @@ def test_ModelWithClassifier():
     transformed_model = ModelWithClassifier(model, classifier)
 
     x = {"a": np.ones([100, 10])}
+
+    # include singleton input in input vector to avoid batching related bugs
+    x["singleton_vector"] = np.ones([1])
+
     out = transformed_model(x)
     assert out
     assert set(out) >= set(CLASS_NAMES)

--- a/external/emulation/tests/test_models.py
+++ b/external/emulation/tests/test_models.py
@@ -17,7 +17,9 @@ def test_ModelWithClassifier():
     )(inputs["a"])
     classifier = tf.keras.Model([inputs["a"]], [zero_tendency])
 
-    transformed_model = ModelWithClassifier(model, classifier)
+    transformed_model = ModelWithClassifier(
+        model, classifier, inputs_to_ignore=["singleton_vector"]
+    )
 
     x = {"a": np.ones([100, 10])}
 

--- a/external/emulation/tests/test_zc_emu_monitor.py
+++ b/external/emulation/tests/test_zc_emu_monitor.py
@@ -48,9 +48,14 @@ def test__get_attrs():
     assert isinstance(dat, Mapping)
 
 
-def get_state_meta_for_conversion():
+@pytest.mark.parametrize(
+    "convert_func, expected_type",
+    [(_convert_to_quantities, Quantity), (_convert_to_xr_dataset, DataArray)],
+    ids=["to-quantity", "to-xr-dataset"],
+)
+def test__conversions(convert_func, expected_type):
 
-    metadata = dict(
+    meta = dict(
         field_A={"units": "beepboop", "real-name": "missingno"},
         field_B={"units": "goobgob", "real-name": "trivial"},
     )
@@ -61,22 +66,14 @@ def get_state_meta_for_conversion():
         "singleton": np.array([1]),
     }
 
-    return state, metadata
-
-
-@pytest.mark.parametrize(
-    "convert_func, expected_type",
-    [(_convert_to_quantities, Quantity), (_convert_to_xr_dataset, DataArray)],
-    ids=["to-quantity", "to-xr-dataset"],
-)
-def test__conversions(convert_func, expected_type):
-
-    state, meta = get_state_meta_for_conversion()
     quantities = convert_func(state, meta)
+
+    assert quantities["field_A"].values.shape == (25, 2)
+    assert quantities["field_B"].values.shape == (25, 2)
+    assert quantities["singleton"].values.shape == ()
 
     for data in quantities.values():
         assert isinstance(data, expected_type)
-        assert data.values.shape == (25, 2)
 
 
 def test__translate_time():

--- a/external/emulation/tests/test_zc_emu_monitor.py
+++ b/external/emulation/tests/test_zc_emu_monitor.py
@@ -58,6 +58,7 @@ def get_state_meta_for_conversion():
     state = {
         "field_A": np.ones(50).reshape(2, 25),
         "field_B": np.ones(50).reshape(2, 25),
+        "singleton": np.array([1]),
     }
 
     return state, metadata

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_regression.test_fv3run_emulation_nc_out[microphys_emulation].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_regression.test_fv3run_emulation_nc_out[microphys_emulation].out
@@ -4,6 +4,8 @@ dimensions:
 	z = 63 ;
 
 variables:
+	float32 rank() ;
+		rank:units = unknown ;
 	float32 latitude(sample) ;
 		latitude:fortran_name = "xlat" ;
 		latitude:standard_name = "latitude" ;
@@ -114,6 +116,8 @@ variables:
 		surface_air_pressure_after_last_gscond:intent = "inout" ;
 		surface_air_pressure_after_last_gscond:optional = "F" ;
 		surface_air_pressure_after_last_gscond:units = "Pa" ;
+	float32 rhc(sample, z) ;
+		rhc:units = unknown ;
 	float32 specific_humidity_after_gscond(sample, z) ;
 		specific_humidity_after_gscond:units = unknown ;
 	float32 air_temperature_after_gscond(sample, z) ;
@@ -158,46 +162,6 @@ variables:
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:units = "kg kg-1 s-1" ;
 	float32 air_temperature_dummy(sample, z) ;
 		air_temperature_dummy:units = unknown ;
-	float32 air_pressure_physics_diag(sample, z) ;
-		air_pressure_physics_diag:units = unknown ;
-	float32 air_temperature_after_gscond_physics_diag(sample, z) ;
-		air_temperature_after_gscond_physics_diag:units = unknown ;
-	float32 air_temperature_after_last_gscond_physics_diag(sample, z) ;
-		air_temperature_after_last_gscond_physics_diag:units = unknown ;
-	float32 air_temperature_after_precpd_physics_diag(sample, z) ;
-		air_temperature_after_precpd_physics_diag:units = unknown ;
-	float32 air_temperature_input_physics_diag(sample, z) ;
-		air_temperature_input_physics_diag:units = unknown ;
-	float32 cloud_water_mixing_ratio_after_gscond_physics_diag(sample, z) ;
-		cloud_water_mixing_ratio_after_gscond_physics_diag:units = unknown ;
-	float32 cloud_water_mixing_ratio_after_precpd_physics_diag(sample, z) ;
-		cloud_water_mixing_ratio_after_precpd_physics_diag:units = unknown ;
-	float32 cloud_water_mixing_ratio_input_physics_diag(sample, z) ;
-		cloud_water_mixing_ratio_input_physics_diag:units = unknown ;
-	float32 latitude_physics_diag(sample) ;
-		latitude_physics_diag:units = unknown ;
-	float32 longitude_physics_diag(sample) ;
-		longitude_physics_diag:units = unknown ;
-	float32 pressure_thickness_of_atmospheric_layer_physics_diag(sample, z) ;
-		pressure_thickness_of_atmospheric_layer_physics_diag:units = unknown ;
-	float32 ratio_of_snowfall_to_rainfall_physics_diag(sample) ;
-		ratio_of_snowfall_to_rainfall_physics_diag:units = unknown ;
-	float32 specific_humidity_after_gscond_physics_diag(sample, z) ;
-		specific_humidity_after_gscond_physics_diag:units = unknown ;
-	float32 specific_humidity_after_last_gscond_physics_diag(sample, z) ;
-		specific_humidity_after_last_gscond_physics_diag:units = unknown ;
-	float32 specific_humidity_after_precpd_physics_diag(sample, z) ;
-		specific_humidity_after_precpd_physics_diag:units = unknown ;
-	float32 specific_humidity_input_physics_diag(sample, z) ;
-		specific_humidity_input_physics_diag:units = unknown ;
-	float32 surface_air_pressure_physics_diag(sample) ;
-		surface_air_pressure_physics_diag:units = unknown ;
-	float32 surface_air_pressure_after_last_gscond_physics_diag(sample) ;
-		surface_air_pressure_after_last_gscond_physics_diag:units = unknown ;
-	float32 tendency_of_rain_water_mixing_ratio_due_to_microphysics_physics_diag(sample, z) ;
-		tendency_of_rain_water_mixing_ratio_due_to_microphysics_physics_diag:units = unknown ;
-	float32 total_precipitation_physics_diag(sample) ;
-		total_precipitation_physics_diag:units = unknown ;
 	object time() ;
 	int64 tile() ;
 

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_regression.test_fv3run_emulation_zarr_out[microphys_emulation].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_regression.test_fv3run_emulation_zarr_out[microphys_emulation].out
@@ -16,12 +16,8 @@ variables:
 		air_pressure:standard_name = "air_pressure" ;
 		air_pressure:type = "real" ;
 		air_pressure:units = "Pa" ;
-	float32 air_pressure_physics_diag(time, tile, sample, z) ;
-		air_pressure_physics_diag:units = unknown ;
 	float32 air_temperature_after_gscond(time, tile, sample, z) ;
 		air_temperature_after_gscond:units = unknown ;
-	float32 air_temperature_after_gscond_physics_diag(time, tile, sample, z) ;
-		air_temperature_after_gscond_physics_diag:units = unknown ;
 	float32 air_temperature_after_last_gscond(time, tile, sample, z) ;
 		air_temperature_after_last_gscond:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		air_temperature_after_last_gscond:fortran_name = "tp" ;
@@ -32,12 +28,8 @@ variables:
 		air_temperature_after_last_gscond:standard_name = "air_temperature_after_last_gscond" ;
 		air_temperature_after_last_gscond:type = "real" ;
 		air_temperature_after_last_gscond:units = "K" ;
-	float32 air_temperature_after_last_gscond_physics_diag(time, tile, sample, z) ;
-		air_temperature_after_last_gscond_physics_diag:units = unknown ;
 	float32 air_temperature_after_precpd(time, tile, sample, z) ;
 		air_temperature_after_precpd:units = unknown ;
-	float32 air_temperature_after_precpd_physics_diag(time, tile, sample, z) ;
-		air_temperature_after_precpd_physics_diag:units = unknown ;
 	float32 air_temperature_dummy(time, tile, sample, z) ;
 		air_temperature_dummy:units = unknown ;
 	float32 air_temperature_input(time, tile, sample, z) ;
@@ -50,16 +42,10 @@ variables:
 		air_temperature_input:standard_name = "air_temperature" ;
 		air_temperature_input:type = "real" ;
 		air_temperature_input:units = "K" ;
-	float32 air_temperature_input_physics_diag(time, tile, sample, z) ;
-		air_temperature_input_physics_diag:units = unknown ;
 	float32 cloud_water_mixing_ratio_after_gscond(time, tile, sample, z) ;
 		cloud_water_mixing_ratio_after_gscond:units = unknown ;
-	float32 cloud_water_mixing_ratio_after_gscond_physics_diag(time, tile, sample, z) ;
-		cloud_water_mixing_ratio_after_gscond_physics_diag:units = unknown ;
 	float32 cloud_water_mixing_ratio_after_precpd(time, tile, sample, z) ;
 		cloud_water_mixing_ratio_after_precpd:units = unknown ;
-	float32 cloud_water_mixing_ratio_after_precpd_physics_diag(time, tile, sample, z) ;
-		cloud_water_mixing_ratio_after_precpd_physics_diag:units = unknown ;
 	float32 cloud_water_mixing_ratio_input(time, tile, sample, z) ;
 		cloud_water_mixing_ratio_input:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		cloud_water_mixing_ratio_input:fortran_name = "cwm" ;
@@ -70,8 +56,6 @@ variables:
 		cloud_water_mixing_ratio_input:standard_name = "cloud_water_mixing_ratio" ;
 		cloud_water_mixing_ratio_input:type = "real" ;
 		cloud_water_mixing_ratio_input:units = "kg kg-1" ;
-	float32 cloud_water_mixing_ratio_input_physics_diag(time, tile, sample, z) ;
-		cloud_water_mixing_ratio_input_physics_diag:units = unknown ;
 	float32 latitude(time, tile, sample) ;
 		latitude:field_dims = "(horizontal_dimension)" ;
 		latitude:fortran_name = "xlat" ;
@@ -82,8 +66,6 @@ variables:
 		latitude:standard_name = "latitude" ;
 		latitude:type = "real" ;
 		latitude:units = "radians" ;
-	float32 latitude_physics_diag(time, tile, sample) ;
-		latitude_physics_diag:units = unknown ;
 	float32 longitude(time, tile, sample) ;
 		longitude:field_dims = "(horizontal_dimension)" ;
 		longitude:fortran_name = "xlon" ;
@@ -94,8 +76,6 @@ variables:
 		longitude:standard_name = "longitude" ;
 		longitude:type = "real" ;
 		longitude:units = "radians" ;
-	float32 longitude_physics_diag(time, tile, sample) ;
-		longitude_physics_diag:units = unknown ;
 	float32 pressure_thickness_of_atmospheric_layer(time, tile, sample, z) ;
 		pressure_thickness_of_atmospheric_layer:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		pressure_thickness_of_atmospheric_layer:fortran_name = "del" ;
@@ -106,8 +86,8 @@ variables:
 		pressure_thickness_of_atmospheric_layer:standard_name = "air_pressure_difference_between_midlayers" ;
 		pressure_thickness_of_atmospheric_layer:type = "real" ;
 		pressure_thickness_of_atmospheric_layer:units = "Pa" ;
-	float32 pressure_thickness_of_atmospheric_layer_physics_diag(time, tile, sample, z) ;
-		pressure_thickness_of_atmospheric_layer_physics_diag:units = unknown ;
+	float32 rank(time, tile) ;
+		rank:units = unknown ;
 	float32 ratio_of_snowfall_to_rainfall(time, tile, sample) ;
 		ratio_of_snowfall_to_rainfall:field_dims = ["horizontal_dimension"] ;
 		ratio_of_snowfall_to_rainfall:fortran_name = "sr" ;
@@ -118,12 +98,10 @@ variables:
 		ratio_of_snowfall_to_rainfall:standard_name = "ratio_of_snowfall_to_rainfall" ;
 		ratio_of_snowfall_to_rainfall:type = "real" ;
 		ratio_of_snowfall_to_rainfall:units = "frac" ;
-	float32 ratio_of_snowfall_to_rainfall_physics_diag(time, tile, sample) ;
-		ratio_of_snowfall_to_rainfall_physics_diag:units = unknown ;
+	float32 rhc(time, tile, sample, z) ;
+		rhc:units = unknown ;
 	float32 specific_humidity_after_gscond(time, tile, sample, z) ;
 		specific_humidity_after_gscond:units = unknown ;
-	float32 specific_humidity_after_gscond_physics_diag(time, tile, sample, z) ;
-		specific_humidity_after_gscond_physics_diag:units = unknown ;
 	float32 specific_humidity_after_last_gscond(time, tile, sample, z) ;
 		specific_humidity_after_last_gscond:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		specific_humidity_after_last_gscond:fortran_name = "qp1" ;
@@ -134,12 +112,8 @@ variables:
 		specific_humidity_after_last_gscond:standard_name = "specific_humidity_after_last_gscond" ;
 		specific_humidity_after_last_gscond:type = "real" ;
 		specific_humidity_after_last_gscond:units = "kg kg-1" ;
-	float32 specific_humidity_after_last_gscond_physics_diag(time, tile, sample, z) ;
-		specific_humidity_after_last_gscond_physics_diag:units = unknown ;
 	float32 specific_humidity_after_precpd(time, tile, sample, z) ;
 		specific_humidity_after_precpd:units = unknown ;
-	float32 specific_humidity_after_precpd_physics_diag(time, tile, sample, z) ;
-		specific_humidity_after_precpd_physics_diag:units = unknown ;
 	float32 specific_humidity_input(time, tile, sample, z) ;
 		specific_humidity_input:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		specific_humidity_input:fortran_name = "q" ;
@@ -150,8 +124,6 @@ variables:
 		specific_humidity_input:standard_name = "specific_humidity" ;
 		specific_humidity_input:type = "real" ;
 		specific_humidity_input:units = "kg kg-1" ;
-	float32 specific_humidity_input_physics_diag(time, tile, sample, z) ;
-		specific_humidity_input_physics_diag:units = unknown ;
 	float32 surface_air_pressure(time, tile, sample) ;
 		surface_air_pressure:field_dims = ["horizontal_dimension"] ;
 		surface_air_pressure:fortran_name = "ps" ;
@@ -172,10 +144,6 @@ variables:
 		surface_air_pressure_after_last_gscond:standard_name = "surface_air_pressure_after_last_gscond" ;
 		surface_air_pressure_after_last_gscond:type = "real" ;
 		surface_air_pressure_after_last_gscond:units = "Pa" ;
-	float32 surface_air_pressure_after_last_gscond_physics_diag(time, tile, sample) ;
-		surface_air_pressure_after_last_gscond_physics_diag:units = unknown ;
-	float32 surface_air_pressure_physics_diag(time, tile, sample) ;
-		surface_air_pressure_physics_diag:units = unknown ;
 	float32 tendency_of_rain_water_mixing_ratio_due_to_microphysics(time, tile, sample, z) ;
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:field_dims = ["horizontal_dimension", "vertical_dimension"] ;
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:fortran_name = "rainp" ;
@@ -186,8 +154,6 @@ variables:
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:standard_name = "tendency_of_rain_water_mixing_ratio_due_to_microphysics" ;
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:type = "real" ;
 		tendency_of_rain_water_mixing_ratio_due_to_microphysics:units = "kg kg-1 s-1" ;
-	float32 tendency_of_rain_water_mixing_ratio_due_to_microphysics_physics_diag(time, tile, sample, z) ;
-		tendency_of_rain_water_mixing_ratio_due_to_microphysics_physics_diag:units = unknown ;
 	object time(time) ;
 	float32 total_precipitation(time, tile, sample) ;
 		total_precipitation:field_dims = ["horizontal_dimension"] ;
@@ -199,8 +165,6 @@ variables:
 		total_precipitation:standard_name = "total_precipitation" ;
 		total_precipitation:type = "real" ;
 		total_precipitation:units = "m" ;
-	float32 total_precipitation_physics_diag(time, tile, sample) ;
-		total_precipitation_physics_diag:units = unknown ;
 
 // global attributes:
 }


### PR DESCRIPTION
Update fv3gfs-fortran submodule to a version with GAEA config files and new emulation outputs. In so doing, I had to fix some bugs that were blocking this (#2060).

Coverage reports (updated automatically):
- test_unit: [82%](https:\/\/output.circle-artifacts.com\/output\/job\/1743a4b3-8ba0-47e7-8ff8-042f494d5d3b\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)