### PR TITLE
Prognostic run: Simpler radiation stepper factory

### DIFF
--- a/workflows/prognostic_c48_run/runtime/factories.py
+++ b/workflows/prognostic_c48_run/runtime/factories.py
@@ -16,12 +16,8 @@ from runtime.config import UserConfig
 from runtime.transformers.core import StepTransformer
 from runtime.transformers.tendency_prescriber import TendencyPrescriber
 from runtime.steppers.prescriber import PrescriberConfig, Prescriber
-from runtime.steppers.radiation import RadiationStepperConfig, RadiationStepper
-from runtime.steppers.machine_learning import (
-    MachineLearningConfig,
-    PureMLStepper,
-    open_model,
-)
+from runtime.steppers.radiation import RadiationStepper
+from runtime.steppers.machine_learning import PureMLStepper
 from runtime.interpolate import time_interpolate_func, label_to_time
 from runtime.derived_state import DerivedFV3State
 import runtime.transformers.fv3fit
@@ -162,21 +158,13 @@ def get_prescriber(
 
 
 def get_radiation_stepper(
-    stepper_config: RadiationStepperConfig,
     comm,
     physics_namelist: Mapping[Hashable, Any],
     timestep: float,
     tracer_metadata: Mapping[Hashable, Mapping[Hashable, int]],
+    input_generator: Optional[Union[PureMLStepper, Prescriber]],
 ) -> RadiationStepper:
     radiation_config = radiation.RadiationConfig.from_physics_namelist(physics_namelist)
-    if isinstance(stepper_config.input_generator, MachineLearningConfig):
-        input_generator: Optional[Union[PureMLStepper, Prescriber]] = PureMLStepper(
-            open_model(stepper_config.input_generator), timestep, hydrostatic=False
-        )
-    elif isinstance(stepper_config.input_generator, PrescriberConfig):
-        input_generator = get_prescriber(stepper_config.input_generator, comm)
-    else:
-        input_generator = None
     tracer_inds: Mapping[str, int] = {
         str(name): metadata["i_tracer"] for name, metadata in tracer_metadata.items()
     }

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -282,7 +282,8 @@ class TimeLoop(
                 stepper_config, self._get_communicator()
             )
             self._log_info(
-                f"Using Prescriber for variables {stepper_config.variables} at {step}."
+                f"Using Prescriber for variables {list(stepper_config.variables)}"
+                f" at {step}."
             )
         return stepper
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -282,8 +282,8 @@ class TimeLoop(
                 stepper_config, self._get_communicator()
             )
             self._log_info(
-                f"Using Prescriber for variables {list(stepper_config.variables)}"
-                f" at {step}."
+                "Using Prescriber for variables "
+                f"{list(stepper_config.variables.values())} at {step}."
             )
         return stepper
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import tempfile
 from typing import (
     Any,
@@ -12,6 +11,8 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    Mapping,
+    Hashable,
 )
 import cftime
 import pace.util
@@ -217,18 +218,9 @@ class TimeLoop(
         self._log_debug(f"States to output: {self._states_to_output}")
         self._prephysics_stepper = self._get_prephysics_stepper(config, hydrostatic)
         self._postphysics_stepper = self._get_postphysics_stepper(config, hydrostatic)
-        if config.radiation_scheme:
-            self._radiation_stepper: Optional[
-                Stepper
-            ] = runtime.factories.get_radiation_stepper(
-                config.radiation_scheme,
-                self.comm,
-                namelist["gfs_physics_nml"],
-                self._timestep,
-                self._fv3gfs.get_tracer_metadata(),
-            )
-        else:
-            self._radiation_stepper = None
+        self._radiation_stepper = self._get_radiation_stepper(
+            config, namelist["gfs_physics_nml"]
+        )
         self._log_info(self._fv3gfs.get_tracer_metadata())
         MPI.COMM_WORLD.barrier()  # wait for initialization to finish
 
@@ -273,6 +265,27 @@ class TimeLoop(
         else:
             return func
 
+    def _get_prescriber_or_ml_stepper(
+        self,
+        stepper_config: Union[PrescriberConfig, MachineLearningConfig],
+        step: str,
+        hydrostatic: bool = False,
+    ) -> Union[PureMLStepper, Prescriber]:
+        if isinstance(stepper_config, MachineLearningConfig):
+            model = self._open_model(stepper_config)
+            stepper: Union[PureMLStepper, Prescriber] = PureMLStepper(
+                model, self._timestep, hydrostatic
+            )
+            self._log_info(f"Using PureMLStepper at {step}.")
+        else:
+            stepper = runtime.factories.get_prescriber(
+                stepper_config, self._get_communicator()
+            )
+            self._log_info(
+                f"Using Prescriber for variables {stepper_config.variables} at {step}."
+            )
+        return stepper
+
     def _get_prephysics_stepper(
         self, config: UserConfig, hydrostatic: bool
     ) -> Optional[Stepper]:
@@ -280,26 +293,12 @@ class TimeLoop(
         if config.prephysics is None:
             self._log_info("No prephysics computations")
             stepper = None
-
         else:
             prephysics_steppers: List[Union[Prescriber, PureMLStepper]] = []
             for prephysics_config in config.prephysics:
-                if isinstance(prephysics_config, MachineLearningConfig):
-                    self._log_info("Using PureMLStepper for prephysics")
-                    model = self._open_model(prephysics_config, "_prephysics")
-                    prephysics_steppers.append(
-                        PureMLStepper(model, self._timestep, hydrostatic)
-                    )
-                elif isinstance(prephysics_config, PrescriberConfig):
-                    self._log_info(
-                        "Using Prescriber for prephysics for variables "
-                        f"{prephysics_config.variables}"
-                    )
-                    prephysics_steppers.append(
-                        runtime.factories.get_prescriber(
-                            prephysics_config, self._get_communicator()
-                        )
-                    )
+                prephysics_steppers.append(
+                    self._get_prescriber_or_ml_stepper(prephysics_config, "prephysics")
+                )
             stepper = CombinedStepper(prephysics_steppers)
         return stepper
 
@@ -314,7 +313,7 @@ class TimeLoop(
                 self._log_info(
                     "Using old non-MSE-conserving moisture limiter for postphysics"
                 )
-            model = self._open_model(config.scikit_learn, "_postphysics")
+            model = self._open_model(config.scikit_learn)
             stepper: Optional[Stepper] = PureMLStepper(
                 model,
                 self._timestep,
@@ -329,13 +328,35 @@ class TimeLoop(
             stepper = None
         return stepper
 
-    def _open_model(self, ml_config: MachineLearningConfig, step: str):
+    def _get_radiation_stepper(
+        self, config: UserConfig, physics_namelist: Mapping[Hashable, Any]
+    ) -> Optional[Stepper]:
+        if config.radiation_scheme is not None:
+            radiation_input_generator_config = config.radiation_scheme.input_generator
+            if radiation_input_generator_config is not None:
+                radiation_input_generator: Optional[
+                    Union[PureMLStepper, Prescriber]
+                ] = self._get_prescriber_or_ml_stepper(
+                    radiation_input_generator_config, "radiation_inputs"
+                )
+            else:
+                radiation_input_generator = None
+            stepper: Optional[Stepper] = runtime.factories.get_radiation_stepper(
+                self.comm,
+                physics_namelist,
+                self._timestep,
+                self._fv3gfs.get_tracer_metadata(),
+                radiation_input_generator,
+            )
+        else:
+            stepper = None
+        return stepper
+
+    def _open_model(self, ml_config: MachineLearningConfig):
         self._log_info("Downloading ML Model")
         with tempfile.TemporaryDirectory() as tmpdir:
             if self.rank == 0:
-                local_model_paths = download_model(
-                    ml_config, os.path.join(tmpdir, step)
-                )
+                local_model_paths = download_model(ml_config, tmpdir)
             else:
                 local_model_paths = None  # type: ignore
             local_model_paths = self.comm.bcast(local_model_paths, root=0)

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple, Optional, Callable
+from typing import Sequence, Tuple, Optional, Callable, Union, Mapping
 import dataclasses
 import logging
 import cftime
@@ -18,7 +18,9 @@ class PrescriberConfig:
 
     Attributes:
         dataset_key: path of zarr dataset
-        variables: sequence of variable names in the dataset to prescribe
+        variables: sequence of variable names in the dataset to prescribe, or a
+            mapping from the non-standard names in the dataset to the standard names
+            to be prescribed
         consolidated: whether desired dataset has consolidated metadata;
             defaults to True
         reference_initial_time: if time interpolating, time of first point in dataset
@@ -38,7 +40,7 @@ class PrescriberConfig:
     """  # noqa
 
     dataset_key: str
-    variables: Sequence[str]
+    variables: Union[Sequence[str], Mapping[str, str]]
     consolidated: bool = True
     reference_initial_time: Optional[str] = None
     reference_frequency_seconds: float = 900

--- a/workflows/prognostic_c48_run/runtime/steppers/radiation.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/radiation.py
@@ -31,8 +31,7 @@ class RadiationStepper:
     def __call__(
         self, time: cftime.DatetimeJulian, state: State,
     ):
-        if self._input_generator is not None:
-            state = self._generate_inputs(state, time)
+        state = self._generate_inputs(state, time)
         diagnostics = self._radiation(time, state)
         return {}, diagnostics, {}
 

--- a/workflows/prognostic_c48_run/tests/test_config.py
+++ b/workflows/prognostic_c48_run/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 from runtime.config import get_model_urls, UserConfig
 import dataclasses
 
-dummy_prescriber = {"dataset_key": "data_url", "variables": ["a"]}
+dummy_prescriber = {"dataset_key": "data_url", "variables": {"a": "a"}}
 
 
 @pytest.mark.parametrize(

--- a/workflows/prognostic_c48_run/tests/test_prescriber.py
+++ b/workflows/prognostic_c48_run/tests/test_prescriber.py
@@ -44,9 +44,9 @@ def get_dataarray(y, x, value, coords):
 @pytest.fixture(scope="module")
 def external_dataset_path(tmpdir_factory):
     vars_ = {
-        "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface": 10.0,
-        "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface": 5.0,
-        "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface": 8.0,
+        "DSWRFsfc": 10.0,
+        "DLWRFsfc": 5.0,
+        "NSWRFsfc": 8.0,
     }
     sizes = {"y": NXY, "x": NXY}
     ds = get_dataset(vars_, sizes, TIME_COORD)
@@ -58,11 +58,19 @@ def external_dataset_path(tmpdir_factory):
 def get_prescriber_config(external_dataset_path):
     return PrescriberConfig(
         dataset_key=external_dataset_path,
-        variables=[
-            "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface",
-            "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface",
-            "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",
-        ],
+        variables={
+            "DSWRFsfc": (
+                "override_for_time_adjusted_total_sky_"
+                "downward_shortwave_flux_at_surface"
+            ),
+            "NSWRFsfc": (
+                "override_for_time_adjusted_total_sky_net_shortwave_flux_at_surface"
+            ),
+            "DLWRFsfc": (
+                "override_for_time_adjusted_total_sky_"
+                "downward_longwave_flux_at_surface"
+            ),
+        },
     )
 
 


### PR DESCRIPTION
Adds a cleaner factory method for the radiation stepper, separating out the construction of the prescriber/ML stepper that generates inputs to the radiation stepper, from the construction of the stepper itself. This new prescriber/ML stepper constructor is then shared across the radiation and prephysics stepper construction. Previously running the radiation stepper with prescribed inputs was blocked due to a bug about its factory method's MPI comm input arg. 

Also in a breaking change for prescribing states, now requires providing a mapping for renaming variables on disk to standard names. 

Refactored public API:
- `runtime.PrescriberConfig.variables` now must be a mapping of variable names on disk to standard names for prescribing (previously was a list of names and no renaming was possible). 

Significant internal changes:
- In the prognostic run loop, the prephysics and radiation input steppers are now generated by a common method, `_get_prescriber_or_ml_stepper`

[X] Tests added


Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/463c30d8-7944-49d8-ad25-4843a165adb5/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)