### PR TITLE
Radiation: Updating solar constant

### DIFF
--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -7,7 +7,7 @@ FORCING_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/
 
 @dataclasses.dataclass
 class GFSPhysicsControl:
-    """A ported version of the Fortran GFS_physics_control structure.
+    """A ported version of the Fortran GFS_physics_control structure aka 'model'.
     
     Args:
         levs: Number of model levels.
@@ -154,7 +154,7 @@ class RadiationConfig:
     lnoprec: bool = False
     iswcliq: int = 1
     gfs_physics_control: GFSPhysicsControl = dataclasses.field(
-        default_factory=GFSPhysicsControl
+        default_factory=lambda: GFSPhysicsControl()
     )
 
     @classmethod

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -8,14 +8,35 @@ FORCING_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/
 @dataclasses.dataclass
 class RadiationConfig:
     """A configuration class for the radiation wrapper. These namelist flags and
-    other attributes control the wrapper behavior.
+    other attributes control the wrapper behavior. The documentation here is largely
+    cut and pasted from the Fortran radiation routines.
     
     Args:
-        imp_physics: Surface emissivity control flag. In physics namelist.
-        iemsflg: In physics namelist as 'iems'.
+        imp_physics: Choice of microphysics scheme:
+            11: GFDL microphysics scheme
+            8: Thompson microphysics scheme
+            10: Morrison-Gettelman microphysics scheme
+        iemsflg: Surface emissivity control flag. In physics namelist as 'iems'.
         ioznflg: Ozone data source control flag.
         ictmflg: Data IC time/date control flag.
-        isolar: Solar constant control flag. In physics namelist as 'isol'.
+            yyyy#, external data ic time/date control flag
+            -2: same as 0, but superimpose seasonal cycle from climatology data set.
+            -1: use user provided external data for the forecast time, no
+                extrapolation.
+            0: use data at initial cond time, if not available, use latest, no
+                extrapolation.
+            1: use data at the forecast time, if not available, use latest and
+                extrapolation.
+            yyyy0: use yyyy data for the forecast time no further data extrapolation.
+            yyyy1: use yyyy data for the fcst. if needed, do extrapolation to match
+                the fcst time.
+        isolar: Solar constant cntrl. In physics namelist as 'isol'.
+            0: use the old fixed solar constant in "physcon"
+            10: use the new fixed solar constant in "physcon"
+            1: use noaa ann-mean tsi tbl abs-scale with cycle apprx
+            2: use noaa ann-mean tsi tbl tim-scale with cycle apprx
+            3: use cmip5 ann-mean tsi tbl tim-scale with cycl apprx
+            4: use cmip5 mon-mean tsi tbl tim-scale with cycl apprx
         ico2flg: CO2 data source control flag. In physics namelist as 'ico2'.
         iaerflg: Volcanic aerosols. In physics namelist as 'iaer'.
         ialbflg: Surface albedo control flag. In physics namelist as 'ialb'.
@@ -33,7 +54,7 @@ class RadiationConfig:
         iswcliq: Optical property for liquid clouds for SW.
         fhswr: Shortwave radiation timestep in seconds. In physics namelist.
         fhlwr: Longwave radiation timestep in seconds. In physics namelist.
-        lsswr
+        lsswr: logical flags for sw radiation calculations
         lslwr
         nfxr
         ncld: In physics namelist.

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -74,7 +74,6 @@ class RadiationConfig:
         pertalb
         do_only_clearsky_rad
         swhtr: In physics namelist.
-        solcon
         lprnt
         lwhtr: In physics namelist.
         lssav
@@ -122,7 +121,6 @@ class RadiationConfig:
     )
     do_only_clearsky_rad: bool = False
     swhtr: bool = True
-    solcon: float = 1320.8872136343873
     lprnt: bool = False
     lwhtr: bool = True
     lssav: bool = True

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -1,8 +1,93 @@
-from typing import Sequence, Mapping, Hashable, Any
+from typing import Sequence, Mapping, Hashable, Any, Optional
 import dataclasses
 
 LOOKUP_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/lookupdata/lookup.tar.gz"  # noqa: E501
 FORCING_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/data.tar.gz"  # noqa: 501
+
+
+@dataclasses.dataclass
+class GFSPhysicsControl:
+    """A ported version of the Fortran GFS_physics_control structure.
+    
+    Args:
+        levs: Number of model levels.
+        levr: Number of model levels.
+        ntcw: Tracer index of cloud liquid water.
+        ntrw: Tracer index of rain water.
+        ntiw: Tracer index of cloud ice water.
+        ntsw: Tracer index of snow water.
+        ntgl: Tracer index of graupel water.
+        ntoz: Tracer index of ozone.
+        ntclamt: Tracer index of cloud amount.
+        ntrac: Number of tracers.
+        nfxr:
+        ncld: In physics namelist.
+        ncnd: In physics namelist.
+        fhswr: Shortwave radiation timestep in seconds. In physics namelist.
+        fhlwr: Longwave radiation timestep in seconds. In physics namelist.
+        lsswr: Logical flag for SW radiation calculations
+        lslwr: Logical flag for LW radiation calculations
+        imp_physics: Choice of microphysics scheme:
+            11: GFDL microphysics scheme (only ported option)
+            8: Thompson microphysics scheme
+            10: Morrison-Gettelman microphysics scheme
+        lgfdlmprad:
+        uni_cld:
+        effr_in:
+        indcld:
+        num_p3d:
+        npdf3d:
+        ncnvcld3d:
+        lmfdeep2:
+        lmfshal:
+        sup:
+        kdt:
+        do_sfcperts:
+        pertalb:
+        do_only_clearsky_rad:
+        swhtr: In physics namelist.
+        lprnt:
+        lwhtr: In physics namelist.
+        lssav:
+    """
+
+    levs: Optional[int] = None
+    levr: Optional[int] = None
+    ntcw: Optional[int] = None
+    ntrw: Optional[int] = None
+    ntiw: Optional[int] = None
+    ntsw: Optional[int] = None
+    ntgl: Optional[int] = None
+    ntoz: Optional[int] = None
+    ntrac: Optional[int] = None
+    nfxr: int = 45
+    ncld: int = 5
+    ncnd: int = 5
+    fhswr: float = 3600.0
+    fhlwr: float = 3600.0
+    lsswr: bool = True
+    lslwr: bool = True
+    imp_physics: int = 11
+    lgfdlmprad: bool = False
+    uni_cld: bool = False
+    effr_in: bool = False
+    indcld: int = -1
+    num_p3d: int = 1
+    npdf3d: int = 0
+    ncnvcld3d: int = 0
+    lmfdeep2: bool = True
+    lmfshal: bool = True
+    sup: float = 1.0
+    kdt: int = 1
+    do_sfcperts: bool = False
+    pertalb: Sequence[Sequence[float]] = dataclasses.field(
+        default_factory=lambda: [[-999.0], [-999.0], [-999.0], [-999.0], [-999.0]]
+    )
+    do_only_clearsky_rad: bool = False
+    swhtr: bool = True
+    lprnt: bool = False
+    lwhtr: bool = True
+    lssav: bool = True
 
 
 @dataclasses.dataclass
@@ -12,10 +97,6 @@ class RadiationConfig:
     cut and pasted from the Fortran radiation routines.
     
     Args:
-        imp_physics: Choice of microphysics scheme:
-            11: GFDL microphysics scheme
-            8: Thompson microphysics scheme
-            10: Morrison-Gettelman microphysics scheme
         iemsflg: Surface emissivity control flag. In physics namelist as 'iems'.
         ioznflg: Ozone data source control flag.
         ictmflg: Data IC time/date control flag.
@@ -52,34 +133,9 @@ class RadiationConfig:
         lcnorm: Control flag for in-cld condensate.
         lnoprec: Precip effect on radiation flag (ferrier microphysics).
         iswcliq: Optical property for liquid clouds for SW.
-        fhswr: Shortwave radiation timestep in seconds. In physics namelist.
-        fhlwr: Longwave radiation timestep in seconds. In physics namelist.
-        lsswr: logical flags for sw radiation calculations
-        lslwr
-        nfxr
-        ncld: In physics namelist.
-        ncnd: In physics namelist.
-        lgfdlmprad
-        uni_cld
-        effr_in
-        indcld
-        num_p3d
-        npdf3d
-        ncnvcld3d
-        lmfdeep2
-        lmfshal
-        sup
-        kdt
-        do_sfcperts
-        pertalb
-        do_only_clearsky_rad
-        swhtr: In physics namelist.
-        lprnt
-        lwhtr: In physics namelist.
-        lssav
+        gfs_physics_control: GFSPhysicsControl data class
     """
 
-    imp_physics: int = 11
     iemsflg: int = 1
     ioznflg: int = 7
     ictmflg: int = 1
@@ -97,33 +153,9 @@ class RadiationConfig:
     lcnorm: bool = False
     lnoprec: bool = False
     iswcliq: int = 1
-    fhswr: float = 3600.0
-    fhlwr: float = 3600.0
-    lsswr: bool = True
-    lslwr: bool = True
-    nfxr: int = 45
-    ncld: int = 5
-    ncnd: int = 5
-    lgfdlmprad: bool = False
-    uni_cld: bool = False
-    effr_in: bool = False
-    indcld: int = -1
-    num_p3d: int = 1
-    npdf3d: int = 0
-    ncnvcld3d: int = 0
-    lmfdeep2: bool = True
-    lmfshal: bool = True
-    sup: float = 1.0
-    kdt: int = 1
-    do_sfcperts: bool = False
-    pertalb: Sequence[Sequence[float]] = dataclasses.field(
-        default_factory=lambda: [[-999.0], [-999.0], [-999.0], [-999.0], [-999.0]]
+    gfs_physics_control: GFSPhysicsControl = dataclasses.field(
+        default_factory=GFSPhysicsControl
     )
-    do_only_clearsky_rad: bool = False
-    swhtr: bool = True
-    lprnt: bool = False
-    lwhtr: bool = True
-    lssav: bool = True
 
     @classmethod
     def from_physics_namelist(
@@ -133,8 +165,17 @@ class RadiationConfig:
         identical. Remaining values from RadiationConfig defaults.
         """
 
-        return cls(
+        gfs_physics_control = GFSPhysicsControl(
             imp_physics=physics_namelist["imp_physics"],
+            ncld=physics_namelist["ncld"],
+            ncnd=physics_namelist["ncld"],
+            fhswr=physics_namelist["fhswr"],
+            fhlwr=physics_namelist["fhlwr"],
+            swhtr=physics_namelist["swhtr"],
+            lwhtr=physics_namelist["lwhtr"],
+        )
+
+        return cls(
             iemsflg=physics_namelist["iems"],
             isolar=physics_namelist["isol"],
             ico2flg=physics_namelist["ico2"],
@@ -142,10 +183,5 @@ class RadiationConfig:
             ialbflg=physics_namelist["ialb"],
             isubcsw=physics_namelist["isubc_sw"],
             isubclw=physics_namelist["isubc_lw"],
-            ncld=physics_namelist["ncld"],
-            ncnd=physics_namelist["ncld"],
-            fhswr=physics_namelist["fhswr"],
-            fhlwr=physics_namelist["fhlwr"],
-            swhtr=physics_namelist["swhtr"],
-            lwhtr=physics_namelist["lwhtr"],
+            gfs_physics_control=gfs_physics_control,
         )

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -59,6 +59,7 @@ class GFSPhysicsControl:
     ntsw: Optional[int] = None
     ntgl: Optional[int] = None
     ntoz: Optional[int] = None
+    ntclamt: Optional[int] = None
     ntrac: Optional[int] = None
     nfxr: int = 45
     ncld: int = 5

--- a/external/radiation/radiation/radiation_aerosols.py
+++ b/external/radiation/radiation/radiation_aerosols.py
@@ -350,7 +350,7 @@ class AerosolClass:
 
     wvn550 = 1.0e4 / 0.55
 
-    def __init__(self, NLAY, me, iaerflg, ivflip, aerosol_dict):
+    def __init__(self, NLAY, rank, iaerflg, ivflip, aerosol_dict):
         self.NSWBND = nbdsw
         self.NLWBND = NBDLW
         self.NSWLWBD = nbdsw * NBDLW
@@ -390,7 +390,7 @@ class AerosolClass:
 
         # -# Call wrt_aerlog() to write aerosol parameter configuration to output logs.
 
-        if me == 0:
+        if rank == 0:
             self.wrt_aerlog()  # write aerosol param info to log file
 
         if self.iaerflg == 0:
@@ -703,7 +703,7 @@ class AerosolClass:
         #  inputs:  (in-scope variables, module constants)                     !
         #   solfwv(:)    - real, solar flux for individual wavenumber (w/m2)   !
         #   eirfwv(:)    - real, lw flux(273k) for individual wavenum (w/m2)   !
-        #   me           - integer, select cpu number as print control flag    !
+        #   rank         - integer, select cpu number as print control flag    !
         #                                                                      !
         #  outputs: (to the module variables)                                  !
         #                                                                      !
@@ -1230,7 +1230,7 @@ class AerosolClass:
 
                 self.extstra[ib] = sumk * rirbd
 
-    def aer_update(self, iyear, imon, me, kprfg, idxcg, cmixg, denng, cline):
+    def aer_update(self, iyear, imon, rank, kprfg, idxcg, cmixg, denng, cline):
         #  ==================================================================
         #
         #  aer_update checks and update time varying climatology aerosol
@@ -1239,7 +1239,7 @@ class AerosolClass:
         #  inputs:                                          size
         #     iyear   - 4-digit calender year                 1
         #     imon    - month of the year                     1
-        #     me      - print message control flag            1
+        #     rank    - print message control flag            1
         #
         #  outputs: ( none )
         #
@@ -1259,7 +1259,7 @@ class AerosolClass:
 
         self.iyear = iyear
         self.imon = imon
-        self.me = me
+        self.rank = rank
 
         if self.imon < 1 or self.imon > 12:
             raise ValueError(
@@ -1322,7 +1322,7 @@ class AerosolClass:
         self.cmixg = cmixg
         self.denng = denng
 
-        if self.me == 0:
+        if self.rank == 0:
             print(f"  --- Reading {cline[self.imon-1]}")
 
     def volc_update(self):
@@ -1377,7 +1377,7 @@ class AerosolClass:
 
             if self.iyear < self.MINVYR or self.iyear > self.MAXVYR:
                 self.ivolae = np.ones((12, 4, 10))  # set as lowest value
-                if self.me == 0:
+                if self.rank == 0:
                     print(
                         "Requested volcanic date out of range,",
                         " optical depth set to lowest value",
@@ -1389,7 +1389,7 @@ class AerosolClass:
                     # ds = xr.open_dataset(volcano_file)
                     # cline = ds["cline"]
                     #  ---  check print
-                    if self.me == 0:
+                    if self.rank == 0:
                         print(f"Opened volcanic data file: {volcano_file}")
                     #    print(cline)
 
@@ -1401,7 +1401,7 @@ class AerosolClass:
                     )
 
         #  ---  check print
-        if self.me == 0:
+        if self.rank == 0:
             k = (self.kyrsav % 10) + 1
             print(
                 "CHECK: Sample Volcanic data used for month, year: ",

--- a/external/radiation/radiation/radiation_astronomy.py
+++ b/external/radiation/radiation/radiation_astronomy.py
@@ -413,6 +413,7 @@ class AstronomyClass:
         eqsec = sixty * eqt
 
         print(
+            "***Begin update from Python port of the Fortran RRTMG radiation scheme***"
             f"0 FORECAST DATE {iday},{month[imon-1]},{iyear} AT {ihr} HRS, {xmin} MINS",
             f"  JULIAN DAY {jd} PLUS {fjd}",
         )
@@ -428,6 +429,7 @@ class AstronomyClass:
         )
         print(f"  EQUATION OF TIME {eqt} MINS, OR {eqsec} SECS, OR {sollag} RADIANS")
         print(f"  SOLAR CONSTANT {solc} (DISTANCE AJUSTED)")
+        print("***End update from Python port of the Fortran RRTMG radiation scheme***")
         print(" ")
         print(" ")
 

--- a/external/radiation/radiation/radiation_astronomy.py
+++ b/external/radiation/radiation/radiation_astronomy.py
@@ -15,7 +15,7 @@ class AstronomyClass:
     czlimt = 0.0001  # ~ cos(89.99427)
     pid12 = con_pi / f12  # angle per hour
 
-    def __init__(self, me, isolar, solar_filename):
+    def __init__(self, rank, isolar, solar_filename):
         self.sollag = 0.0
         self.sindec = 0.0
         self.cosdec = 0.0
@@ -24,7 +24,7 @@ class AstronomyClass:
         self.iyr_sav = 0
         self.nstp = 6
 
-        if me == 0:
+        if rank == 0:
             print(self.VTAGAST)  # print out version tag
 
         #  ---  initialization
@@ -36,14 +36,14 @@ class AstronomyClass:
 
         if isolar == 0:
             self.solc0 = con_solr_old
-            if me == 0:
+            if rank == 0:
                 print(f"- Using old fixed solar constant = {self.solc0}")
         elif isolar == 10:
-            if me == 0:
+            if rank == 0:
                 print(f"- Using new fixed solar constant = {self.solc0}")
         elif isolar == 1:  # noaa ann-mean tsi in absolute scale
 
-            if me == 0:
+            if rank == 0:
                 print(
                     "- Using NOAA annual mean TSI table in ABS scale",
                     " with cycle approximation (old values)!",
@@ -53,7 +53,7 @@ class AstronomyClass:
             if not file_exist:
                 self.isolflg = 10
 
-                if me == 0:
+                if rank == 0:
                     warnings.warn(
                         f'Requested solar data file "{self.solar_fname}" not found!',
                         f"Using the default solar constant value = {self.solc0}",
@@ -62,7 +62,7 @@ class AstronomyClass:
 
         elif isolar == 2:  # noaa ann-mean tsi in tim scale
 
-            if me == 0:
+            if rank == 0:
                 print(
                     " - Using NOAA annual mean TSI table in TIM scale",
                     " with cycle approximation (new values)!",
@@ -72,7 +72,7 @@ class AstronomyClass:
             if not file_exist:
                 self.isolflg = 10
 
-                if me == 0:
+                if rank == 0:
                     warnings.warn(
                         f'Requested solar data file "{self.solar_fname}" not found!',
                         f"Using the default solar constant value = {self.solc0}",
@@ -81,7 +81,7 @@ class AstronomyClass:
 
         elif isolar == 3:  # cmip5 ann-mean tsi in tim scale
 
-            if me == 0:
+            if rank == 0:
                 print(
                     "- Using CMIP5 annual mean TSI table in TIM scale",
                     " with cycle approximation",
@@ -91,7 +91,7 @@ class AstronomyClass:
             if not file_exist:
                 self.isolflg = 10
 
-                if me == 0:
+                if rank == 0:
                     warnings.warn(
                         f'Requested solar data file "{self.solar_fname}" not found!',
                         f"Using the default solar constant value = {self.solc0}",
@@ -100,7 +100,7 @@ class AstronomyClass:
 
         elif isolar == 4:  # cmip5 mon-mean tsi in tim scale
 
-            if me == 0:
+            if rank == 0:
                 print(
                     "- Using CMIP5 monthly mean TSI table in TIM scale",
                     " with cycle approximation",
@@ -110,7 +110,7 @@ class AstronomyClass:
             if not file_exist:
                 self.isolflg = 10
 
-                if me == 0:
+                if rank == 0:
                     warnings.warn(
                         f'Requested solar data file "{self.solar_fname}" not found!',
                         f"Using the default solar constant value = {self.solc0}",
@@ -119,7 +119,7 @@ class AstronomyClass:
         else:  # selection error
             self.isolflg = 10
 
-            if me == 0:
+            if rank == 0:
                 warnings.warn(
                     "- !!! ERROR in selection of solar constant data",
                     f" source, ISOL = {isolar}",
@@ -133,7 +133,7 @@ class AstronomyClass:
         outdict = {"solar_fname": self.solar_fname}
         return outdict
 
-    def sol_update(self, jdate, kyear, deltsw, deltim, lsol_chg, me, solar_data):
+    def sol_update(self, jdate, kyear, deltsw, deltim, lsol_chg, rank, solar_data):
         #  ===================================================================  !
         #                                                                       !
         #  sol_update computes solar parameters at forecast time                !
@@ -147,7 +147,7 @@ class AstronomyClass:
         #     deltsw  - time duration in seconds per sw calculation             !
         #     deltim  - timestep in seconds                                     !
         #     lsol_chg- logical flags for change solar constant                 !
-        #     me      - print message control flag                              !
+        #     rank    - print message control flag                              !
         #                                                                       !
         #  outputs:                                                             !
         #    slag          - equation of time in radians                        !
@@ -218,7 +218,7 @@ class AstronomyClass:
                     icy1 = solar_data["yr_cyc1"].values
                     icy2 = solar_data["yr_cyc2"].values
                     smean = solar_data["smean"].values
-                    if me == 0:
+                    if rank == 0:
                         print("Updating solar constant with cycle approx")
                         print(f"Opened solar constant data file: {self.solar_fname}")
                     # check if there is a upper year limit put on the data table
@@ -228,7 +228,7 @@ class AstronomyClass:
                         )  # range of the earlest cycle in data table
                         while iyr < iyr1:
                             iyr += icy
-                        if me == 0:
+                        if rank == 0:
                             warnings.warn(
                                 f"*** Year {iyear} out of table range!",
                                 f"{iyr1}, {iyr2}",
@@ -238,7 +238,7 @@ class AstronomyClass:
                         icy = iyr2 - icy2 + 1  # range of the latest cycle in data table
                         while iyr > iyr2:
                             iyr -= icy
-                        if me == 0:
+                        if rank == 0:
                             warnings.warn(
                                 f"*** Year {iyear} out of table range!",
                                 f"{iyr1}, {iyr2}",
@@ -248,7 +248,7 @@ class AstronomyClass:
                     if self.isolflg < 4:  # use annual mean data tables
                         solc1 = solar_data["solc1"].sel(year=iyr).values
                         self.solc0 = smean + solc1
-                        if me == 0:
+                        if rank == 0:
                             print(
                                 "CHECK: Solar constant data used for year",
                                 f"{iyr}, {solc1}, {self.solc0}",
@@ -262,7 +262,7 @@ class AstronomyClass:
                                 for nn in range(12):
                                     self.smon_sav[nn] = smean + smon[nn]
                                 self.solc0 = smean + smon[imon]
-                                if me == 0:
+                                if rank == 0:
                                     print("CHECK: Solar constant data used for year")
                                     print(f"{iyr} and month {imon}")
 
@@ -303,7 +303,7 @@ class AstronomyClass:
 
         #  --- ...  diagnostic print out
 
-        if me == 0:
+        if rank == 0:
             self.prtime(jd, fjd, dlt, alp, r1, self.solcon, sollag)
 
         #  --- ...  setting up calculation parameters used by subr coszmn
@@ -314,7 +314,7 @@ class AstronomyClass:
         self.nstp = max(6, nswr)
         self.anginc = pid12 * dtswh / float(self.nstp)
 
-        if me == 0:
+        if rank == 0:
             print(
                 "for cosz calculations: nswr,deltim,deltsw,dtswh =",
                 f"{nswr}, {deltim}, {deltsw}, {dtswh}, anginc, nstp =",
@@ -616,7 +616,7 @@ class AstronomyClass:
 
         return IYEAR, MONTH, IDAY, IDAYWK, IDAYYR
 
-    def coszmn(self, xlon, sinlat, coslat, solhr, IM, me):
+    def coszmn(self, xlon, sinlat, coslat, solhr, IM):
         #  ===================================================================  !
         #                                                                       !
         #  coszmn computes mean cos solar zenith angle over sw calling interval !
@@ -628,7 +628,6 @@ class AstronomyClass:
         #    coslat(IM)    - cosine of the corresponding latitudes              !
         #    solhr         - time after 00z in hours                            !
         #    IM            - num of grids in horizontal dimension               !
-        #    me            - print message control flag                         !
         #                                                                       !
         #  outputs:                                                             !
         #    coszen(IM)    - average of cosz for daytime only in sw call interval

--- a/external/radiation/radiation/radiation_clouds.py
+++ b/external/radiation/radiation/radiation_clouds.py
@@ -20,18 +20,18 @@ class CloudClass:
     cldssa_def = 0.99
     cldasy_def = 0.84
 
-    def __init__(self, si, NLAY, imp_physics, me, ivflip, icldflg, iovrsw, iovrlw):
+    def __init__(self, si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw):
 
         self.iovr = max(iovrsw, iovrlw)
         self.ivflip = ivflip
 
-        if me == 0:
+        if rank == 0:
             print(self.VTAGCLD)  # print out version tag
 
         if icldflg == 0:
             print(" - Diagnostic Cloud Method has been discontinued")
         else:
-            if me == 0:
+            if rank == 0:
                 print("- Using Prognostic Cloud Method")
                 if imp_physics == 99:
                     print("   --- Zhao/Carr/Sundqvist microphysics")
@@ -426,7 +426,7 @@ class CloudClass:
         deltaq,
         sup,
         kdt,
-        me,
+        rank,
         iovrsw,
         iovrlw,
     ):

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -333,7 +333,7 @@ class RadiationDriver:
 
     def GFS_radiation_driver(
         self,
-        GFSPhysicsControl,
+        gfs_physics_control,
         solcon,
         solhr,
         Statein,
@@ -349,7 +349,7 @@ class RadiationDriver:
     ):
 
         return self._GFS_radiation_driver(
-            GFSPhysicsControl,
+            gfs_physics_control,
             solcon,
             solhr,
             Statein,
@@ -362,7 +362,7 @@ class RadiationDriver:
 
     def _GFS_radiation_driver(
         self,
-        GFSPhysicsControl,
+        gfs_physics_control,
         solcon,
         solhr,
         Statein,
@@ -372,30 +372,30 @@ class RadiationDriver:
         lwdict,
         swdict,
     ):
-        if GFSPhysicsControl["uni_cld"]:
+        if gfs_physics_control.uni_cld:
             raise FileNotFoundError(f"uni_cld = True Not implemented")
 
-        if GFSPhysicsControl["effr_in"]:
+        if gfs_physics_control.effr_in:
             raise FileNotFoundError(f"effr_in = True Not implemented")
 
-        if not (GFSPhysicsControl["lsswr"] or GFSPhysicsControl["lslwr"]):
+        if not (gfs_physics_control.lsswr or gfs_physics_control.lslwr):
             return
 
         # --- set commonly used integers
-        LM = GFSPhysicsControl["levr"]
-        LEVS = GFSPhysicsControl["levs"]
+        LM = gfs_physics_control.levr
+        LEVS = gfs_physics_control.levs
         IM = Grid["xlon"].shape[0]
-        # NFXR = GFSPhysicsControl["nfxr"] # never used according to lint
-        NTRAC = GFSPhysicsControl[
-            "ntrac"
-        ]  # tracers in grrad strip off sphum - start tracer1(2:NTRAC)
-        ntcw = GFSPhysicsControl["ntcw"]
-        ntiw = GFSPhysicsControl["ntiw"]
-        # ncld = GFSPhysicsControl["ncld"] # never used according to lint
-        ntrw = GFSPhysicsControl["ntrw"]
-        ntsw = GFSPhysicsControl["ntsw"]
-        ntgl = GFSPhysicsControl["ntgl"]
-        ncndl = min(GFSPhysicsControl["ncnd"], 4)
+        # NFXR = gfs_physics_control.nfxr"] # never used according to lint
+        NTRAC = (
+            gfs_physics_control.ntrac
+        )  # tracers in grrad strip off sphum - start tracer1(2:NTRAC)
+        ntcw = gfs_physics_control.ntcw
+        ntiw = gfs_physics_control.ntiw
+        # ncld = gfs_physics_control.ncld"] # never used according to lint
+        ntrw = gfs_physics_control.ntrw
+        ntsw = gfs_physics_control.ntsw
+        ntgl = gfs_physics_control.ntgl
+        ncndl = min(gfs_physics_control.ncnd, 4)
 
         LP1 = LM + 1  # num of in/out levels
 
@@ -406,36 +406,32 @@ class RadiationDriver:
         alb1d = np.zeros(IM)
         idxday = np.zeros(IM, dtype=DTYPE_INT)
 
-        plvl = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP + 1))
-        tlvl = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP + 1))
-        tem2db = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP + 1))
+        plvl = np.zeros((IM, gfs_physics_control.levr + self.LTP + 1))
+        tlvl = np.zeros((IM, gfs_physics_control.levr + self.LTP + 1))
+        tem2db = np.zeros((IM, gfs_physics_control.levr + self.LTP + 1))
 
-        plyr = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        tlyr = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        olyr = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        qlyr = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        rhly = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        tvly = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        delp = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        qstl = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        cldcov = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        deltaq = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        cnvc = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        cnvw = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        dz = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        prslk1 = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
-        tem2da = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
+        plyr = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        tlyr = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        olyr = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        qlyr = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        rhly = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        tvly = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        delp = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        qstl = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        cldcov = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        deltaq = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        cnvc = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        cnvw = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        dz = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        prslk1 = np.zeros((IM, gfs_physics_control.levr + self.LTP))
+        tem2da = np.zeros((IM, gfs_physics_control.levr + self.LTP))
 
-        tracer1 = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP, NTRAC))
+        tracer1 = np.zeros((IM, gfs_physics_control.levr + self.LTP, NTRAC))
         ccnd = np.zeros(
-            (
-                IM,
-                GFSPhysicsControl["levr"] + self.LTP,
-                min(4, GFSPhysicsControl["ncnd"]),
-            )
+            (IM, gfs_physics_control.levr + self.LTP, min(4, gfs_physics_control.ncnd),)
         )
 
-        cldtausw = np.zeros((IM, GFSPhysicsControl["levr"] + self.LTP))
+        cldtausw = np.zeros((IM, gfs_physics_control.levr + self.LTP))
 
         Coupling = {}
         scmpsw = {}
@@ -443,9 +439,9 @@ class RadiationDriver:
         Radtend = {}
         Radtend["coszen"] = np.zeros(IM)
         Radtend["coszdg"] = np.zeros(IM)
-        Radtend["htrsw"] = np.zeros((IM, GFSPhysicsControl["levs"]))
-        Radtend["swhc"] = np.zeros((IM, GFSPhysicsControl["levs"]))
-        Radtend["lwhc"] = np.zeros((IM, GFSPhysicsControl["levs"]))
+        Radtend["htrsw"] = np.zeros((IM, gfs_physics_control.levs))
+        Radtend["swhc"] = np.zeros((IM, gfs_physics_control.levs))
+        Radtend["lwhc"] = np.zeros((IM, gfs_physics_control.levs))
         Radtend["semis"] = np.zeros(IM)
         Radtend["tsflw"] = np.zeros(IM)
         Radtend["sfcfsw"] = dict()
@@ -461,7 +457,7 @@ class RadiationDriver:
         Radtend["sfcfsw"]["dnfxc"] = np.zeros(IM)
         Radtend["sfcfsw"]["upfx0"] = np.zeros(IM)
         Radtend["sfcfsw"]["dnfx0"] = np.zeros(IM)
-        Radtend["htrlw"] = np.zeros((IM, GFSPhysicsControl["levs"]))
+        Radtend["htrlw"] = np.zeros((IM, gfs_physics_control.levs))
 
         lhlwb = False
         lhlw0 = True
@@ -496,7 +492,7 @@ class RadiationDriver:
                 kt = 0  # index diff between lyr and upper bound
                 kb = 1  # index diff between lyr and lower bound
 
-        raddt = min(GFSPhysicsControl["fhswr"], GFSPhysicsControl["fhlwr"])
+        raddt = min(gfs_physics_control.fhswr, gfs_physics_control.fhlwr)
 
         # -# Setup surface ground temperature and ground/air skin temperature
         # if required.
@@ -582,18 +578,18 @@ class RadiationDriver:
         #  - Get layer ozone mass mixing ratio (if use ozone climatology data,
         #    call getozn()).
 
-        if GFSPhysicsControl["ntoz"] > 0:  # interactive ozone generation
+        if gfs_physics_control.ntoz > 0:  # interactive ozone generation
             for k in range(LMK):
                 for i in range(IM):
                     olyr[i, k] = max(
-                        self.QMIN, tracer1[i, k, GFSPhysicsControl["ntoz"] - 1]
+                        self.QMIN, tracer1[i, k, gfs_physics_control.ntoz - 1]
                     )
         else:  # climatological ozone
             print("Climatological ozone not implemented")
 
         #  - Call coszmn(), to compute cosine of zenith angle (only when SW is called)
 
-        if GFSPhysicsControl["lsswr"]:
+        if gfs_physics_control.lsswr:
             Radtend["coszen"], Radtend["coszdg"] = self.sol.coszmn(
                 Grid["xlon"], Grid["sinlat"], Grid["coslat"], solhr, IM
             )
@@ -721,8 +717,8 @@ class RadiationDriver:
             IM,
             LMK,
             LMP,
-            GFSPhysicsControl["lsswr"],
-            GFSPhysicsControl["lslwr"],
+            gfs_physics_control.lsswr,
+            gfs_physics_control.lslwr,
         )
 
         #  - Obtain cloud information for radiation calculations
@@ -736,23 +732,23 @@ class RadiationDriver:
 
         #  --- ...  obtain cloud information for radiation calculations
 
-        if GFSPhysicsControl["ncnd"] == 1:  # Zhao_Carr_Sundqvist
+        if gfs_physics_control.ncnd == 1:  # Zhao_Carr_Sundqvist
             for k in range(LMK):
                 for i in range(IM):
                     ccnd[i, k, 0] = tracer1[i, k, ntcw - 1]  # liquid water/ice
-        elif GFSPhysicsControl["ncnd"] == 2:  # MG
+        elif gfs_physics_control.ncnd == 2:  # MG
             for k in range(LMK):
                 for i in range(IM):
                     ccnd[i, k, 0] = tracer1[i, k, ntcw - 1]  # liquid water
                     ccnd[i, k, 1] = tracer1[i, k, ntiw - 1]  # ice water
-        elif GFSPhysicsControl["ncnd"] == 4:  # MG2
+        elif gfs_physics_control.ncnd == 4:  # MG2
             for k in range(LMK):
                 for i in range(IM):
                     ccnd[i, k, 0] = tracer1[i, k, ntcw - 1]  # liquid water
                     ccnd[i, k, 1] = tracer1[i, k, ntiw - 1]  # ice water
                     ccnd[i, k, 2] = tracer1[i, k, ntrw - 1]  # rain water
                     ccnd[i, k, 3] = tracer1[i, k, ntsw - 1]  # snow water
-        elif GFSPhysicsControl["ncnd"] == 5:  # GFDL MP, Thompson, MG3
+        elif gfs_physics_control.ncnd == 5:  # GFDL MP, Thompson, MG3
             for k in range(LMK):
                 for i in range(IM):
                     ccnd[i, k, 0] = tracer1[i, k, ntcw - 1]  # liquid water
@@ -768,8 +764,8 @@ class RadiationDriver:
                     if ccnd[i, k, n] < con_epsq:
                         ccnd[i, k, n] = 0.0
 
-        if GFSPhysicsControl["imp_physics"] == 11:
-            if not GFSPhysicsControl["lgfdlmprad"]:
+        if gfs_physics_control.imp_physics == 11:
+            if not gfs_physics_control.lgfdlmprad:
 
                 # rsun the  summation methods and
                 # order make the difference in calculation
@@ -783,12 +779,12 @@ class RadiationDriver:
                 for i in range(IM):
                     if ccnd[i, k, 0] < self.EPSQ:
                         ccnd[i, k, 0] = 0.0
-        if GFSPhysicsControl["uni_cld"]:
+        if gfs_physics_control.uni_cld:
             raise Exception("effr_in = True not implemented")
 
-        elif GFSPhysicsControl["imp_physics"] == 11:  # GFDL MP
+        elif gfs_physics_control.imp_physics == 11:  # GFDL MP
             cldcov[:IM, kd : LM + kd] = tracer1[
-                :IM, :LM, GFSPhysicsControl["ntclamt"] - 1
+                :IM, :LM, gfs_physics_control.ntclamt - 1
             ]
 
         else:  # neither of the other two cases
@@ -801,9 +797,9 @@ class RadiationDriver:
         #          ferrier's (imp_phys=5) microphysics schemes
 
         if (
-            GFSPhysicsControl["num_p3d"] == 1
-            and GFSPhysicsControl["npdf3d"] == 0
-            and GFSPhysicsControl["ncnvcld3d"] == 0
+            gfs_physics_control.num_p3d == 1
+            and gfs_physics_control.npdf3d == 0
+            and gfs_physics_control.ncnvcld3d == 0
         ):  # all the rest
             for k in range(LMK):
                 for i in range(IM):
@@ -818,7 +814,7 @@ class RadiationDriver:
                 cnvw[i, lyb - 1] = cnvw[i, lya - 1]
                 cnvc[i, lyb - 1] = cnvc[i, lya - 1]
 
-        if GFSPhysicsControl["imp_physics"] == 99:
+        if gfs_physics_control.imp_physics == 99:
             ccnd[:IM, :LMK, 0] = ccnd[:IM, :LMK, 0] + cnvw[:IM, :LMK]
 
         clouds, cldsa, mtopa, mbota, de_lgth = self.cld.progcld4(
@@ -851,12 +847,12 @@ class RadiationDriver:
         #  perturbation size
         #  ---  turn vegetation fraction pattern into percentile pattern
 
-        if GFSPhysicsControl["do_sfcperts"]:
+        if gfs_physics_control.do_sfcperts:
             print("Surface perturbation not implemented!")
 
         # mg, sfc-perts
 
-        if GFSPhysicsControl["do_only_clearsky_rad"]:
+        if gfs_physics_control.do_only_clearsky_rad:
             clouds[:, :, 0] = 0.0  # layer total cloud fraction
             clouds[:, :, 1] = 0.0  # layer cloud liq water path
             clouds[:, :, 3] = 0.0  # layer cloud ice water path
@@ -865,7 +861,7 @@ class RadiationDriver:
             cldsa[:, :] = 0.0  # fraction of clouds for low, mid, hi, tot, bl
 
         # Start SW radiation calculations
-        if GFSPhysicsControl["lsswr"]:
+        if gfs_physics_control.lsswr:
 
             #  - Call module_radiation_surface::setalb() to setup surface albedo.
             #  for SW radiation.
@@ -890,7 +886,7 @@ class RadiationDriver:
                 Sfcprop["tisfc"],
                 IM,
                 alb1d,
-                GFSPhysicsControl["pertalb"],
+                gfs_physics_control.pertalb,
             )
 
             # Approximate mean surface albedo from vis- and nir-  diffuse values.
@@ -906,7 +902,7 @@ class RadiationDriver:
                 #  - Call module_radsw_main::swrad(), to compute SW heating rates and
                 #   fluxes.
 
-                if GFSPhysicsControl["swhtr"]:
+                if gfs_physics_control.swhtr:
                     (
                         htswc,
                         Diag["topfsw"]["upfxc"],
@@ -945,7 +941,7 @@ class RadiationDriver:
                         IM,
                         LMK,
                         LMP,
-                        GFSPhysicsControl["lprnt"],
+                        gfs_physics_control.lprnt,
                         lhswb,
                         lhsw0,
                         lflxprf,
@@ -991,7 +987,7 @@ class RadiationDriver:
                         IM,
                         LMK,
                         LMP,
-                        GFSPhysicsControl["lprnt"],
+                        gfs_physics_control.lprnt,
                         lhswb,
                         lhsw0,
                         lflxprf,
@@ -1010,7 +1006,7 @@ class RadiationDriver:
                     for k in range(LM, LEVS):
                         Radtend["htrsw"][:IM, k] = Radtend["htrsw"][:IM, LM - 1]
 
-                if GFSPhysicsControl["swhtr"]:
+                if gfs_physics_control.swhtr:
                     for k in range(LM):
                         k1 = k + kd
                         Radtend["swhc"][:IM, k] = htsw0[:IM, k1]
@@ -1046,7 +1042,7 @@ class RadiationDriver:
                 Coupling["visbmui"] = np.zeros(IM)
                 Coupling["visdfui"] = np.zeros(IM)
 
-                if GFSPhysicsControl["swhtr"]:
+                if gfs_physics_control.swhtr:
                     Radtend["swhc"][:, :] = 0
                     cldtausw[:, :] = 0.0
 
@@ -1055,7 +1051,7 @@ class RadiationDriver:
             Coupling["sfcdsw"] = Radtend["sfcfsw"]["dnfxc"]
 
         # Start LW radiation calculations
-        if GFSPhysicsControl["lslwr"]:
+        if gfs_physics_control.lslwr:
 
             #  - Call module_radiation_surface::setemis(),to setup surface
             # emissivity for LW radiation.
@@ -1076,7 +1072,7 @@ class RadiationDriver:
             #  - Call module_radlw_main::lwrad(), to compute LW heating rates and
             #    fluxes.
 
-            if GFSPhysicsControl["lwhtr"]:
+            if gfs_physics_control.lwhtr:
                 (
                     htlwc,
                     Diag["topflw"]["upfxc"],
@@ -1105,7 +1101,7 @@ class RadiationDriver:
                     IM,
                     LMK,
                     LMP,
-                    GFSPhysicsControl["lprnt"],
+                    gfs_physics_control.lprnt,
                     lhlwb,
                     lhlw0,
                     lflxprf,
@@ -1140,7 +1136,7 @@ class RadiationDriver:
                     IM,
                     LMK,
                     LMP,
-                    GFSPhysicsControl["lprnt"],
+                    gfs_physics_control.lprnt,
                     lhlwb,
                     lhlw0,
                     lflxprf,
@@ -1161,7 +1157,7 @@ class RadiationDriver:
                 for k in range(LM, LEVS):
                     Radtend["htrlw"][IM, k] = Radtend["htrlw"][:IM, LM - 1]
 
-            if GFSPhysicsControl["lwhtr"]:
+            if gfs_physics_control.lwhtr:
                 for k in range(LM):
                     k1 = k + kd
                     Radtend["lwhc"][:IM, k] = htlw0[:IM, k1]
@@ -1182,69 +1178,69 @@ class RadiationDriver:
 
         #  --- ...  collect the fluxr data for wrtsfc
 
-        if GFSPhysicsControl["lssav"]:
-            if GFSPhysicsControl["lsswr"]:
+        if gfs_physics_control.lssav:
+            if gfs_physics_control.lsswr:
                 for i in range(IM):
                     Diag["fluxr"][i, 33] = (
-                        Diag["fluxr"][i, 33] + GFSPhysicsControl["fhswr"] * aerodp[i, 0]
+                        Diag["fluxr"][i, 33] + gfs_physics_control.fhswr * aerodp[i, 0]
                     )  # total aod at 550nm
                     Diag["fluxr"][i, 34] = (
-                        Diag["fluxr"][i, 34] + GFSPhysicsControl["fhswr"] * aerodp[i, 1]
+                        Diag["fluxr"][i, 34] + gfs_physics_control.fhswr * aerodp[i, 1]
                     )  # DU aod at 550nm
                     Diag["fluxr"][i, 35] = (
-                        Diag["fluxr"][i, 35] + GFSPhysicsControl["fhswr"] * aerodp[i, 2]
+                        Diag["fluxr"][i, 35] + gfs_physics_control.fhswr * aerodp[i, 2]
                     )  # BC aod at 550nm
                     Diag["fluxr"][i, 36] = (
-                        Diag["fluxr"][i, 36] + GFSPhysicsControl["fhswr"] * aerodp[i, 3]
+                        Diag["fluxr"][i, 36] + gfs_physics_control.fhswr * aerodp[i, 3]
                     )  # OC aod at 550nm
                     Diag["fluxr"][i, 37] = (
-                        Diag["fluxr"][i, 37] + GFSPhysicsControl["fhswr"] * aerodp[i, 4]
+                        Diag["fluxr"][i, 37] + gfs_physics_control.fhswr * aerodp[i, 4]
                     )  # SU aod at 550nm
                     Diag["fluxr"][i, 38] = (
-                        Diag["fluxr"][i, 38] + GFSPhysicsControl["fhswr"] * aerodp[i, 5]
+                        Diag["fluxr"][i, 38] + gfs_physics_control.fhswr * aerodp[i, 5]
                     )  # SS aod at 550nm
 
             #  ---  save lw toa and sfc fluxes
-            if GFSPhysicsControl["lslwr"]:
+            if gfs_physics_control.lslwr:
                 #  ---  lw total-sky fluxes
                 for i in range(IM):
                     Diag["fluxr"][i, 0] = (
                         Diag["fluxr"][i, 0]
-                        + GFSPhysicsControl["fhlwr"] * Diag["topflw"]["upfxc"][i]
+                        + gfs_physics_control.fhlwr * Diag["topflw"]["upfxc"][i]
                     )  # total sky top lw up
                     Diag["fluxr"][i, 18] = (
                         Diag["fluxr"][i, 18]
-                        + GFSPhysicsControl["fhlwr"] * Radtend["sfcflw"]["dnfxc"][i]
+                        + gfs_physics_control.fhlwr * Radtend["sfcflw"]["dnfxc"][i]
                     )  # total sky sfc lw dn
                     Diag["fluxr"][i, 19] = (
                         Diag["fluxr"][i, 19]
-                        + GFSPhysicsControl["fhlwr"] * Radtend["sfcflw"]["upfxc"][i]
+                        + gfs_physics_control.fhlwr * Radtend["sfcflw"]["upfxc"][i]
                     )  # total sky sfc lw up
                     #  ---  lw clear-sky fluxes
                     Diag["fluxr"][i, 27] = (
                         Diag["fluxr"][i, 27]
-                        + GFSPhysicsControl["fhlwr"] * Diag["topflw"]["upfx0"][i]
+                        + gfs_physics_control.fhlwr * Diag["topflw"]["upfx0"][i]
                     )  # clear sky top lw up
                     Diag["fluxr"][i, 29] = (
                         Diag["fluxr"][i, 29]
-                        + GFSPhysicsControl["fhlwr"] * Radtend["sfcflw"]["dnfx0"][i]
+                        + gfs_physics_control.fhlwr * Radtend["sfcflw"]["dnfx0"][i]
                     )  # clear sky sfc lw dn
                     Diag["fluxr"][i, 32] = (
                         Diag["fluxr"][i, 32]
-                        + GFSPhysicsControl["fhlwr"] * Radtend["sfcflw"]["upfx0"][i]
+                        + gfs_physics_control.fhlwr * Radtend["sfcflw"]["upfx0"][i]
                     )  # clear sky sfc lw up
 
             # save sw toa and sfc fluxes with proper diurnal sw wgt.
             # coszen=mean cosz over daylight
             # part of sw calling interval, while coszdg= mean
             # cosz over entire interval
-            if GFSPhysicsControl["lsswr"]:
+            if gfs_physics_control.lsswr:
                 for i in range(IM):
                     if Radtend["coszen"][i] > 0.0:
                         #  --- sw total-sky fluxes
                         #      -------------------
                         tem0d = (
-                            GFSPhysicsControl["fhswr"]
+                            gfs_physics_control.fhswr
                             * Radtend["coszdg"][i]
                             / Radtend["coszen"][i]
                         )
@@ -1298,7 +1294,7 @@ class RadiationDriver:
 
             #  ---  save total and boundary layer clouds
 
-            if GFSPhysicsControl["lsswr"] or GFSPhysicsControl["lslwr"]:
+            if gfs_physics_control.lsswr or gfs_physics_control.lslwr:
                 for i in range(IM):
                     Diag["fluxr"][i, 16] = Diag["fluxr"][i, 16] + raddt * cldsa[i, 3]
                     Diag["fluxr"][i, 17] = Diag["fluxr"][i, 17] + raddt * cldsa[i, 4]

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -182,6 +182,10 @@ class RadiationDriver:
 
             return aer_dict, sol_dict, gas_dict, sfc_dict, cld_dict, rlw_dict, rsw_dict
 
+    @property
+    def solar_constant(self):
+        return self.sol.solcon
+
     def radupdate(
         self,
         idate,
@@ -328,9 +332,6 @@ class RadiationDriver:
             gasdict = self.gas.return_updatedata()
 
             return soldict, aerdict, gasdict
-
-        else:
-            return slag, sdec, cdec, solcon
 
     def GFS_radiation_driver(
         self,

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -196,6 +196,7 @@ class RadiationDriver:
         cline,
         solar_data,
         gas_data,
+        me,
         do_test=False,
     ):
         # =================   subprogram documentation block   ================ !
@@ -298,13 +299,13 @@ class RadiationDriver:
             self.iyear0 = iyear
 
             slag, sdec, cdec, solcon = self.sol.sol_update(
-                jdate, kyear, deltsw, deltim, lsol_chg, 0, solar_data
+                jdate, kyear, deltsw, deltim, lsol_chg, me, solar_data
             )
 
         # Call module_radiation_aerosols::aer_update(), monthly update, no
         # time interpolation
         if lmon_chg:
-            self.aer.aer_update(iyear, imon, 0, kprfg, idxcg, cmixg, denng, cline)
+            self.aer.aer_update(iyear, imon, me, kprfg, idxcg, cmixg, denng, cline)
 
         # -# Call co2 and other gases update routine:
         # module_radiation_gases::gas_update()
@@ -315,7 +316,7 @@ class RadiationDriver:
             lco2_chg = False
 
         self.gas.gas_update(
-            kyear, kmon, kday, khour, self.loz1st, lco2_chg, 0, gas_data
+            kyear, kmon, kday, khour, self.loz1st, lco2_chg, me, gas_data
         )
 
         if self.loz1st:

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -54,7 +54,7 @@ class RadiationDriver:
         si,
         NLAY,
         imp_physics,
-        me,
+        rank,
         iemsflg,
         ioznflg,
         ictmflg,
@@ -85,7 +85,7 @@ class RadiationDriver:
         self.monthd = 0
         self.isolar = isolar
 
-        if me == 0:
+        if rank == 0:
             print("NEW RADIATION PROGRAM STRUCTURES BECAME OPER. May 01 2007")
             print(self.VTAGRAD)  # print out version tag
             print(" ")
@@ -155,21 +155,21 @@ class RadiationDriver:
 
         # -# Initialization
         #  --- ...  astronomy initialization routine
-        self.sol = AstronomyClass(me, isolar, solar_filename)
+        self.sol = AstronomyClass(rank, isolar, solar_filename)
         #  --- ...  aerosols initialization routine
-        self.aer = AerosolClass(NLAY, me, iaerflg, ivflip, aerosol_dict)
+        self.aer = AerosolClass(NLAY, rank, iaerflg, ivflip, aerosol_dict)
         #  --- ...  co2 and other gases initialization routine
-        self.gas = GasClass(me, ioznflg, ico2flg, ictmflg)
+        self.gas = GasClass(rank, ioznflg, ico2flg, ictmflg)
         #  --- ...  surface initialization routine
-        self.sfc = SurfaceClass(me, ialbflg, iemsflg, semis_file, semis_data)
+        self.sfc = SurfaceClass(rank, ialbflg, iemsflg, semis_file, semis_data)
         #  --- ...  cloud initialization routine
         self.cld = CloudClass(
-            si, NLAY, imp_physics, me, ivflip, icldflg, iovrsw, iovrlw
+            si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw
         )
         #  --- ...  lw radiation initialization routine
-        self.rlw = RadLWClass(me, iovrlw, isubclw)
+        self.rlw = RadLWClass(rank, iovrlw, isubclw)
         #  --- ...  sw radiation initialization routine
-        self.rsw = RadSWClass(me, iovrsw, isubcsw, iswcliq)
+        self.rsw = RadSWClass(rank, iovrsw, isubcsw, iswcliq)
 
         if do_test:
             sol_dict = self.sol.return_initdata()
@@ -200,7 +200,7 @@ class RadiationDriver:
         cline,
         solar_data,
         gas_data,
-        me,
+        rank,
         do_test=False,
     ):
         # =================   subprogram documentation block   ================ !
@@ -225,7 +225,7 @@ class RadiationDriver:
         #   deltsw         : sw radiation calling frequency in seconds          !
         #   deltim         : model timestep in seconds                          !
         #   lsswr          : logical flags for sw radiation calculations        !
-        #   me             : print control flag                                 !
+        #   rank           : print control flag                                 !
         #                                                                       !
         #  outputs:                                                             !
         #   slag           : equation of time in radians                        !
@@ -303,13 +303,13 @@ class RadiationDriver:
             self.iyear0 = iyear
 
             slag, sdec, cdec, solcon = self.sol.sol_update(
-                jdate, kyear, deltsw, deltim, lsol_chg, me, solar_data
+                jdate, kyear, deltsw, deltim, lsol_chg, rank, solar_data
             )
 
         # Call module_radiation_aerosols::aer_update(), monthly update, no
         # time interpolation
         if lmon_chg:
-            self.aer.aer_update(iyear, imon, me, kprfg, idxcg, cmixg, denng, cline)
+            self.aer.aer_update(iyear, imon, rank, kprfg, idxcg, cmixg, denng, cline)
 
         # -# Call co2 and other gases update routine:
         # module_radiation_gases::gas_update()
@@ -319,9 +319,7 @@ class RadiationDriver:
         else:
             lco2_chg = False
 
-        self.gas.gas_update(
-            kyear, kmon, kday, khour, self.loz1st, lco2_chg, me, gas_data
-        )
+        self.gas.gas_update(kyear, kmon, kday, khour, self.loz1st, lco2_chg, gas_data)
 
         if self.loz1st:
             self.loz1st = False
@@ -365,7 +363,6 @@ class RadiationDriver:
             return
 
         # --- set commonly used integers
-        me = Model["me"]
         LM = Model["levr"]
         LEVS = Model["levs"]
         IM = Grid["xlon"].shape[0]
@@ -571,7 +568,7 @@ class RadiationDriver:
 
         if Model["lsswr"]:
             Radtend["coszen"], Radtend["coszdg"] = self.sol.coszmn(
-                Grid["xlon"], Grid["sinlat"], Grid["coslat"], Model["solhr"], IM, me
+                Grid["xlon"], Grid["sinlat"], Grid["coslat"], Model["solhr"], IM
             )
 
         #  - Call getgases(), to set up non-prognostic gas volume mixing

--- a/external/radiation/radiation/radiation_gases.py
+++ b/external/radiation/radiation/radiation_gases.py
@@ -25,17 +25,17 @@ class GasClass:
     cl4vmr_def = 1.397e-10
     f113vmr_def = 8.2000e-11
 
-    def __init__(self, me, iozn, ico2, ictm):
+    def __init__(self, rank, iozn, ico2, ictm):
         self.kyrsav = 0
         self.kmonsav = 1
 
-        self.me = me
+        self.rank = rank
         self.ioznflg = iozn
         self.ico2flg = ico2
         self.ictmflg = ictm
 
         if self.ioznflg > 0:
-            if self.me == 0:
+            if self.rank == 0:
                 print(" - Using interactive ozone distribution")
         else:
             print("Climatological ozone data not implemented")
@@ -46,7 +46,7 @@ class GasClass:
         self.gco2cyc = np.zeros(12)
 
         if self.ico2flg == 0:
-            if me == 0:
+            if rank == 0:
                 print(f"- Using prescribed co2 global mean value={self.co2vmr_def}")
 
         else:
@@ -58,7 +58,7 @@ class GasClass:
                     print("Using observed co2 global annual mean value")
 
                 elif self.ico2flg == 2:
-                    if me == 0:
+                    if rank == 0:
                         print("Using observed co2 monthly 2-d data")
                         self.co2vmr_sav = np.zeros((self.IMXCO2, self.JMXCO2, 12))
 
@@ -76,7 +76,7 @@ class GasClass:
         outdict = {"co2vmr_sav": self.co2vmr_sav, "gco2cyc": self.gco2cyc}
         return outdict
 
-    def gas_update(self, iyear, imon, iday, ihour, loz1st, ldoco2, me, data_gases):
+    def gas_update(self, iyear, imon, iday, ihour, loz1st, ldoco2, data_gases):
         #  ===================================================================  !
         #                                                                       !
         #  gas_update reads in 2-d monthly co2 data set for a specified year.   !
@@ -89,7 +89,6 @@ class GasClass:
         #     ihour   - hour of the day                             1           !
         #     loz1st  - clim ozone 1st time update control flag     1           !
         #     ldoco2  - co2 update control flag                     1           !
-        #     me      - print message control flag                  1           !
         #                                                                       !
         #  outputs: (to the module variables)                                   !
         #    ( none )                                                           !
@@ -206,7 +205,7 @@ class GasClass:
         co2g1 = data_gases["co2g1"]
         co2g2 = data_gases["co2g2"]
 
-        if me == 0:
+        if self.rank == 0:
             print(f"{iyr}, {cline} {co2g1},  GROWTH RATE = {co2g2}")
         #  --- ...  add growth rate if needed
         if lextpl:
@@ -215,7 +214,7 @@ class GasClass:
             rate = 0.0
 
         self.co2_glb = (co2g1 + rate) * 1.0e-6
-        if me == 0:
+        if self.rank == 0:
             print(f"Global annual mean CO2 data for year {iyear} = {self.co2_glb}")
 
         if self.ictmflg == -2:  # need to calc ic time annual mean first
@@ -225,7 +224,7 @@ class GasClass:
                 co2dat = data_gases["co2dat"]
                 co2vmr_sav = (co2dat + rate) * 1.0e-6
 
-                if me == 0:
+                if self.rank == 0:
                     print(
                         "CHECK: Sample of selected months of CO2 ",
                         f"data used for year: {iyear}",

--- a/external/radiation/radiation/radiation_sfc.py
+++ b/external/radiation/radiation/radiation_sfc.py
@@ -11,13 +11,13 @@ class SurfaceClass:
     IMXEMS = 360
     JMXEMS = 180
 
-    def __init__(self, me, ialb, iems, semis_file, semis_data):
+    def __init__(self, rank, ialb, iems, semis_file, semis_data):
 
         self.ialbflg = ialb
         self.iemsflg = iems
         self.semis_file = semis_file
 
-        if me == 0:
+        if rank == 0:
             print(self.VTAGSFC)  # print out version tag
 
         # - Initialization of surface albedo section
@@ -26,11 +26,11 @@ class SurfaceClass:
         # = 1: using MODIS based land surface albedo for SW
 
         if self.ialbflg == 0:
-            if me == 0:
+            if rank == 0:
                 print("- Using climatology surface albedo scheme for sw")
 
         elif self.ialbflg == 1:
-            if me == 0:
+            if rank == 0:
                 print("- Using MODIS based land surface albedo for sw")
         else:
             raise ValueError(f"!! ERROR in Albedo Scheme Setting, IALB={self.ialbflg}")
@@ -42,13 +42,13 @@ class SurfaceClass:
 
         self.iemslw = self.iemsflg % 10  # emissivity control
         if self.iemslw == 0:  # fixed sfc emis at 1.0
-            if me == 0:
+            if rank == 0:
                 print("- Using Fixed Surface Emissivity = 1.0 for lw")
 
         elif self.iemslw == 1:  # input sfc emiss type map
             file_exist = os.path.isfile(self.semis_file)
             if not file_exist:
-                if me == 0:
+                if rank == 0:
                     print("- Using Varying Surface Emissivity for lw")
                     print(f'Requested data file "{semis_file}" not found!')
                     print("Change to fixed surface emissivity = 1.0 !")
@@ -59,7 +59,7 @@ class SurfaceClass:
                 cline = semis_data["cline"].values
                 idxems = semis_data["idxems"].values
 
-                if me == 0:
+                if rank == 0:
                     print("- Using Varying Surface Emissivity for lw")
                     print(f"Opened data file: {semis_file}")
                     print(cline)

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -209,7 +209,7 @@ class Radiation:
         gfs_physics_control.levs = nz
         gfs_physics_control.levr = nz
         for tracer_name, index in self._tracer_inds.items():
-            if tracer_name in tracer_name_mapping:
+            if hasattr(gfs_physics_control, tracer_name_mapping[tracer_name]):
                 setattr(gfs_physics_control, tracer_name_mapping[tracer_name], index)
         gfs_physics_control.ntrac = max(self._tracer_inds.values())
         return gfs_physics_control

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -209,7 +209,9 @@ class Radiation:
         gfs_physics_control.levs = nz
         gfs_physics_control.levr = nz
         for tracer_name, index in self._tracer_inds.items():
-            if hasattr(gfs_physics_control, tracer_name_mapping[tracer_name]):
+            if tracer_name in tracer_name_mapping and hasattr(
+                gfs_physics_control, tracer_name_mapping[tracer_name]
+            ):
                 setattr(gfs_physics_control, tracer_name_mapping[tracer_name], index)
         gfs_physics_control.ntrac = max(self._tracer_inds.values())
         return gfs_physics_control

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -178,12 +178,12 @@ class Radiation:
         """Compute the radiative fluxes"""
         # todo: update wrapper with fix to avoid having to be one timestep off to
         # compute solar hour, see https://github.com/ai2cm/fv3net/issues/2071
-        solhr = (_solar_hour(time - timedelta(seconds=self._timestep)),)
+        solhr = _solar_hour(time - timedelta(seconds=self._timestep))
         statein = get_statein(state, self._tracer_inds, self._rad_config.ivflip)
         grid, coords = get_grid(state)
         sfcprop = get_sfcprop(state)
         ncolumns, nz = statein["tgrs"].shape[0], statein["tgrs"].shape[1]
-        gfs_physics_control = self._get_gfs_physics_control(time, nz,)
+        gfs_physics_control = self._get_gfs_physics_control(time, nz)
         random_numbers = io.generate_random_numbers(ncolumns, nz, NGPTSW, NGPTLW)
         out = self._driver._GFS_radiation_driver(
             gfs_physics_control,

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -203,7 +203,8 @@ class Radiation:
             "ncnd": self._rad_config.ncnd,
             "fhswr": self._rad_config.fhswr,
             "fhlwr": self._rad_config.fhlwr,
-            # todo: why does solar hour need to be one timestep behind time to validate?
+            # todo: update wrapper with fix to avoid having to be one timestep off
+            # see https://github.com/ai2cm/fv3net/issues/2071
             "solhr": _solar_hour(time - timedelta(seconds=self._timestep)),
             "lsswr": self._rad_config.lsswr,
             "lslwr": self._rad_config.lslwr,

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -154,6 +154,7 @@ class Radiation:
             self._aerosol_data["cline"],
             self._solar_data,
             self._gas_data,
+            self._comm.rank,
         )
 
     def _rad_compute(self, state: State, time: cftime.DatetimeJulian,) -> Diagnostics:

--- a/external/radiation/radiation/wrapper_api.py
+++ b/external/radiation/radiation/wrapper_api.py
@@ -196,7 +196,6 @@ class Radiation:
         tracer_name_mapping: Mapping[str, str] = TRACER_NAMES_IN_MAPPING,
     ) -> MutableMapping[Hashable, Any]:
         model: MutableMapping[Hashable, Any] = {
-            "me": self._comm.rank,
             "levs": nz,
             "levr": nz,
             "nfxr": self._rad_config.nfxr,

--- a/external/radiation/tests/test_driver.py
+++ b/external/radiation/tests/test_driver.py
@@ -1,8 +1,10 @@
 import pathlib
+import dataclasses
 import time
 import serialbox as ser
 from radiation import io
 from radiation.radiation_driver import RadiationDriver
+from radiation.config import GFSPhysicsControl
 from util import compare_data
 from variables_to_read import vars_dict as variables
 
@@ -24,6 +26,12 @@ def getscalars(indict):
                 indict[var] = indict[var][0]
 
     return indict
+
+
+def get_gfs_physics_control(indict):
+    names = [field.name for field in dataclasses.fields(GFSPhysicsControl)]
+    kwargs = {name: indict[name] for name in names}
+    return GFSPhysicsControl(**kwargs)
 
 
 startTime = time.time()
@@ -196,8 +204,10 @@ def test_radiation_valiation():
         solcon = Model.pop("solcon")
         solhr = Model.pop("solhr")
 
+        gfs_physics_control = get_gfs_physics_control(Model)
+
         Radtendout, Diagout, Couplingout = driver.GFS_radiation_driver(
-            Model,
+            gfs_physics_control,
             solcon,
             solhr,
             Statein,

--- a/external/radiation/tests/test_driver.py
+++ b/external/radiation/tests/test_driver.py
@@ -193,9 +193,13 @@ def test_radiation_valiation():
         randomdict = io.load_random_numbers(LOOKUP_DIR, rank)
         lwdict = io.load_lw(LOOKUP_DIR)
         swdict = io.load_sw(LOOKUP_DIR)
+        solcon = Model.pop("solcon")
+        solhr = Model.pop("solhr")
 
         Radtendout, Diagout, Couplingout = driver.GFS_radiation_driver(
             Model,
+            solcon,
+            solhr,
             Statein,
             Sfcprop,
             Coupling,

--- a/external/radiation/tests/test_driver.py
+++ b/external/radiation/tests/test_driver.py
@@ -107,7 +107,7 @@ updatedict = dict()
 for var in invars:
     updatedict[var] = serial.read(var, serial.savepoint["rad-update"])
 
-slag, sdec, cdec, solcon = driver.radupdate(
+driver.radupdate(
     updatedict["idat"],
     updatedict["jdat"],
     updatedict["fhswr"],
@@ -120,6 +120,7 @@ slag, sdec, cdec, solcon = driver.radupdate(
     aer_dict["cline"],
     solar_data,
     gas_data,
+    me,
 )
 
 


### PR DESCRIPTION
Previously the radiation port effectively hardcoded the solar constant which prevented validation outside of the original validation timestep. This PR makes the updated solar constant available to the radiation wrapper. It also refactors and renames a preprocessing function (`get_model`) that uses the solar constant to be a wrapper method instead ( (`_get_gfs_physics_control), since the `model` data structure is more about internal configuration of the radiation driver than preprocessing external state. 

See [notebook](https://github.com/ai2cm/explore/blob/master/brianh/2022-09-14-fine-cloud-fluxes/2022-09-23-validate-clearsky.ipynb) showing TOA downward shortwave errors after this fix (about 0.05 W/m^2 RMSE, still not zero due to radiation port vs Fortran scheme time difference to be fixed in another PR) versus [before](https://github.com/ai2cm/explore/blob/master/brianh/2022-09-14-fine-cloud-fluxes/2022-09-14-validate-rad-port.ipynb) (about 0.4 W/m^2). 

Significant internal changes:
- `radiation.Radiation` now has a `_get_gfs_physics_control` method to return flags/scalar configuration parameters needed to call the driver; `gfs_physics_control` is now a typed object nested with the `RadiationConfig` class.
- the time-varying solar constant and solar hour are now passed separately to the radiation driver call
- various renaming of radiation driver variables to improve clarity

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/6eafc1d2-4178-444a-aa5d-0de5454ca36a/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)
