### PR TITLE
Request more cpu for argo report jobs

### DIFF
--- a/workflows/argo/prognostic_run_diags.yaml
+++ b/workflows/argo/prognostic_run_diags.yaml
@@ -50,10 +50,10 @@ spec:
       resources:
         requests:
           memory: "6Gi"
-          cpu: "1000m"
+          cpu: "2000m"
         limits:
           memory: "8Gi"
-          cpu: "1000m"
+          cpu: "2500m"
       command: ["bash", "-c", "-x", "-e"]
       args:
       - |
@@ -87,7 +87,7 @@ spec:
       resources:
         requests:
           memory: "6Gi"
-          cpu: "1000m"
+          cpu: "2000m"
       command: ["bash", "-c", "-x", "-e"]
       args:
       - |

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -1,8 +1,6 @@
 import logging
 from collections import defaultdict
-from functools import partial
-from typing import Tuple, Mapping, MutableMapping, Optional
-from joblib import Parallel, delayed
+from typing import Tuple, Mapping, MutableMapping
 import xarray as xr
 
 import cartopy.crs as ccrs
@@ -70,7 +68,6 @@ def plot_2d_matplotlib(
     dims: Tuple[str, str],
     contour=False,
     figsize=None,
-    n_jobs=1,
     **opts,
 ) -> RawHTML:
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
@@ -82,20 +79,32 @@ def plot_2d_matplotlib(
     ylabel = opts.pop("ylabel", "")
     x, y = dims
 
-    _partialed_plot = partial(
-        _plot_2d_matplotlib, run_diags, contour, figsize, ylabel, x, y
-    )
-
     variables_to_plot = run_diags.matching_variables(varfilter)
-    out = Parallel(n_jobs=n_jobs, verbose=True)(
-        delayed(_partialed_plot)(run, varname, **opts)
-        for run in run_diags.runs
-        for varname in variables_to_plot
-    )
-    for i, varname in enumerate(variables_to_plot):
-        for j, run in enumerate(run_diags.runs):
-            data[varname][run] = out[i + j * len(variables_to_plot)]
-
+    for varname in variables_to_plot:
+        if not contour:
+            opts["vmin"], opts["vmax"], opts["cmap"] = _get_cmap_kwargs(
+                run_diags, varname, robust=False, ignore_poles=True
+            )
+        for run in run_diags.runs:
+            logging.info(f"plotting {varname} in {run}")
+            v = run_diags.get_variable(run, varname)
+            long_name = v.attrs.get("long_name", varname)
+            units = v.attrs.get("units", "")
+            long_name_and_units = f"{long_name} [{units}]"
+            fig, ax = plt.subplots(figsize=figsize)
+            if contour:
+                levels = CONTOUR_LEVELS.get(varname)
+                xr.plot.contourf(
+                    v, ax=ax, x=x, y=y, levels=levels, extend="both", **opts
+                )
+            else:
+                v.plot(ax=ax, x=x, y=y, **opts)
+            if ylabel:
+                ax.set_ylabel(ylabel)
+            ax.set_title(long_name_and_units)
+            plt.tight_layout()
+            data[varname][run] = MatplotlibFigure(fig, width="500px")
+            plt.close(fig)
     return RawHTML(
         template.render(
             images=data,
@@ -107,39 +116,11 @@ def plot_2d_matplotlib(
     )
 
 
-def _plot_2d_matplotlib(
-    run_diags, contour, figsize, ylabel, x, y, run, varname, **opts
-):
-    logging.info(f"plotting {varname} in {run}")
-    if not contour:
-        opts["vmin"], opts["vmax"], opts["cmap"] = _get_cmap_kwargs(
-            run_diags, varname, robust=False, ignore_poles=True
-        )
-    v = run_diags.get_variable(run, varname)
-    long_name = v.attrs.get("long_name", varname)
-    units = v.attrs.get("units", "")
-    long_name_and_units = f"{long_name} [{units}]"
-    fig, ax = plt.subplots(figsize=figsize)
-    if contour:
-        levels = CONTOUR_LEVELS.get(varname)
-        xr.plot.contourf(v, ax=ax, x=x, y=y, levels=levels, extend="both", **opts)
-    else:
-        v.plot(ax=ax, x=x, y=y, **opts)
-    if ylabel:
-        ax.set_ylabel(ylabel)
-    ax.set_title(long_name_and_units)
-    plt.tight_layout()
-    output = MatplotlibFigure(fig, width="500px")
-    plt.close(fig)
-    return output
-
-
 def plot_cubed_sphere_map(
     run_diags: RunDiagnostics,
     run_metrics: RunMetrics,
     varfilter: str,
-    metrics_for_title: Optional[Mapping[str, str]] = None,
-    n_jobs=1,
+    metrics_for_title: Mapping[str, str] = None,
 ) -> str:
     """Plot horizontal maps of cubed-sphere data for diagnostics which match varfilter.
 
@@ -149,7 +130,6 @@ def plot_cubed_sphere_map(
         varfilter: pattern to filter variable names
         metrics_for_title: metrics to put in plot title. Mapping from label to use in
             plot title to metric_type.
-        n_jobs: number of CPU to use for generating plots.
 
     Note:
         All matching diagnostics must have tile, x and y dimensions and each dataset in
@@ -161,20 +141,23 @@ def plot_cubed_sphere_map(
         metrics_for_title = {}
 
     variables_to_plot = run_diags.matching_variables(varfilter)
-
-    _partialed_plot = partial(
-        _plot_cubed_sphere_map, run_diags, run_metrics, varfilter, metrics_for_title
-    )
-
-    out = Parallel(n_jobs=n_jobs, verbose=True)(
-        delayed(_partialed_plot)(run, varname)
-        for run in run_diags.runs
-        for varname in variables_to_plot
-    )
-    for i, varname in enumerate(variables_to_plot):
-        for j, run in enumerate(run_diags.runs):
-            data[varname][run] = out[i + j * len(variables_to_plot)]
-
+    for varname in variables_to_plot:
+        vmin, vmax, cmap = _get_cmap_kwargs(run_diags, varname, robust=True)
+        for run in run_diags.runs:
+            logging.info(f"plotting {varname} in {run}")
+            shortname = varname.split(varfilter)[0][:-1]
+            ds = run_diags.get_variables(run, COORD_VARS + [varname])
+            plot_title = _render_map_title(
+                run_metrics, shortname, run, metrics_for_title
+            )
+            fig, ax = plt.subplots(
+                figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()}
+            )
+            fv3viz.plot_cube(ds, varname, ax=ax, vmin=vmin, vmax=vmax, cmap=cmap)
+            ax.set_title(plot_title)
+            plt.subplots_adjust(left=0.01, right=0.75, bottom=0.02)
+            data[varname][run] = MatplotlibFigure(fig, width="500px")
+            plt.close(fig)
     return RawHTML(
         template.render(
             images=data,
@@ -184,23 +167,6 @@ def plot_cubed_sphere_map(
             variable_long_names=run_diags.long_names,
         )
     )
-
-
-def _plot_cubed_sphere_map(
-    run_diags, run_metrics, varfilter, metrics_for_title, run, varname
-):
-    vmin, vmax, cmap = _get_cmap_kwargs(run_diags, varname, robust=True)
-    logging.info(f"plotting {varname} in {run}")
-    shortname = varname.split(varfilter)[0][:-1]
-    ds = run_diags.get_variables(run, COORD_VARS + [varname])
-    plot_title = _render_map_title(run_metrics, shortname, run, metrics_for_title)
-    fig, ax = plt.subplots(figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()})
-    fv3viz.plot_cube(ds, varname, ax=ax, vmin=vmin, vmax=vmax, cmap=cmap)
-    ax.set_title(plot_title)
-    plt.subplots_adjust(left=0.01, right=0.75, bottom=0.02)
-    output = MatplotlibFigure(fig, width="500px")
-    plt.close(fig)
-    return output
 
 
 def plot_histogram(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -179,10 +179,8 @@ def plot_histogram(
     bin_name = varname.replace("histogram", "bins")
     for run in run_diags.runs:
         v = run_diags.get_variable(run, varname)
-        if run == "verification":
-            ax.step(v[bin_name], v, label=run, where="post", linewidth=1, color="k")
-        else:
-            ax.step(v[bin_name], v, label=run, where="post", linewidth=1)
+        kwargs = dict(color="k") if run == "verification" else {}
+        ax.step(v[bin_name], v, label=run, where="post", linewidth=1, **kwargs)
     ax.set_xlabel(f"{v.long_name} [{v.units}]")
     ax.set_ylabel(f"Frequency [({v.units})^-1]")
     ax.set_xscale(xscale)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -275,16 +275,12 @@ def zonal_mean_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(
-        diagnostics, "zonal_mean_value", ["time", "latitude"], n_jobs=-1
-    )
+    return plot_2d_matplotlib(diagnostics, "zonal_mean_value", ["time", "latitude"])
 
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(
-        diagnostics, "zonal_mean_bias", ["time", "latitude"], n_jobs=-1
-    )
+    return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
 def infer_duration_seconds(diagnostics: RunDiagnostics) -> float:
@@ -314,7 +310,6 @@ def deep_tropical_meridional_mean_hovmoller_plots(
         "deep_tropical_meridional_mean_value",
         ["longitude", "high_frequency_time"],
         figsize=figsize,
-        n_jobs=-1,
     )
 
 
@@ -326,7 +321,6 @@ def time_mean_cubed_sphere_maps(
         metrics,
         "time_mean_value",
         metrics_for_title={"Mean": "time_and_global_mean_value"},
-        n_jobs=-1,
     )
 
 
@@ -341,7 +335,6 @@ def time_mean_bias_cubed_sphere_maps(
             "Mean": "time_and_global_mean_bias",
             "RMSE": "rmse_of_time_mean",
         },
-        n_jobs=-1,
     )
 
 
@@ -353,7 +346,6 @@ def zonal_pressure_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
         ["latitude", "pressure"],
         yincrease=False,
         ylabel="Pressure [Pa]",
-        n_jobs=-1,
     )
 
 
@@ -367,7 +359,6 @@ def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
         cmap="RdBu_r",
         yincrease=False,
         ylabel="Pressure [Pa]",
-        n_jobs=-1,
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -275,12 +275,16 @@ def zonal_mean_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(diagnostics, "zonal_mean_value", ["time", "latitude"])
+    return plot_2d_matplotlib(
+        diagnostics, "zonal_mean_value", ["time", "latitude"], n_jobs=-1
+    )
 
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
+    return plot_2d_matplotlib(
+        diagnostics, "zonal_mean_bias", ["time", "latitude"], n_jobs=-1
+    )
 
 
 def infer_duration_seconds(diagnostics: RunDiagnostics) -> float:
@@ -310,6 +314,7 @@ def deep_tropical_meridional_mean_hovmoller_plots(
         "deep_tropical_meridional_mean_value",
         ["longitude", "high_frequency_time"],
         figsize=figsize,
+        n_jobs=-1,
     )
 
 
@@ -321,6 +326,7 @@ def time_mean_cubed_sphere_maps(
         metrics,
         "time_mean_value",
         metrics_for_title={"Mean": "time_and_global_mean_value"},
+        n_jobs=-1,
     )
 
 
@@ -335,6 +341,7 @@ def time_mean_bias_cubed_sphere_maps(
             "Mean": "time_and_global_mean_bias",
             "RMSE": "rmse_of_time_mean",
         },
+        n_jobs=-1,
     )
 
 
@@ -346,6 +353,7 @@ def zonal_pressure_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
         ["latitude", "pressure"],
         yincrease=False,
         ylabel="Pressure [Pa]",
+        n_jobs=-1,
     )
 
 
@@ -359,6 +367,7 @@ def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
         cmap="RdBu_r",
         yincrease=False,
         ylabel="Pressure [Pa]",
+        n_jobs=-1,
     )
 
 


### PR DESCRIPTION
EDIT: based on some tests, I found a roughly 40% speedup by using joblib parallelization, but at a significant cost of increased complexity and potential debugging challenges.

So I opted for a simpler change (request more cpu) which gives about a 20% speedup but for no increased code complexity.


**Previous PR description:**

Add some parallelization so that prognostic reports generate more quickly.

To test, I ran the folllowing command on my mac:

```
prognostic_run_diags report gs://vcm-ml-scratch/test-prognostic-report/c6df7d08b8e3 gs://vcm-ml-scratch/test-prognostic-report/c6df7d08b8e3
```

Timing:
on master (three trials): 178s, 172s, 179s
on speed-report-generation branch: 130s, 118s, 120s

It's a disappointing speedup, but may be worth testing on a VM or actual GKE machine. And on a more realistic report with more plots (the test data has fewer variables than most of our runs, so the report ends up having fewer plots).

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/c0122c95-f98a-4f5a-a093-e5c09a576da4/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)