### PR TITLE
Plot 3-day bias drifts on hovmoller page

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -163,6 +163,14 @@ class RunDiagnostics:
     def is_verification(run: str) -> bool:
         return run == "verification"
 
+    def trim_duration(
+        self, duration: np.timedelta64, time_name: str = "time"
+    ) -> "RunDiagnostics":
+        trimmed_diagnostics = [
+            _trim(ds, duration, time_name) for ds in self.diagnostics
+        ]
+        return RunDiagnostics(trimmed_diagnostics)
+
 
 @dataclass
 class RunMetrics:
@@ -226,6 +234,16 @@ class RunMetrics:
     def _get_metric(self, metric_type: str, variable: str, run: str) -> pd.Series:
         _metrics = self.get_metric_all_runs(metric_type, variable)
         return _metrics[_metrics.run == run]
+
+
+def _trim(ds: xr.Dataset, length, dim: str) -> xr.Dataset:
+    if dim in ds.dims:
+        start = ds[dim].values[0]
+        end = start + length
+        end = min(end, ds[dim].values[-1])
+        return ds.sel({dim: slice(start, end)})
+    else:
+        return ds
 
 
 def load_metrics(rundirs) -> pd.DataFrame:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -2,7 +2,7 @@
 
 """
 import json
-from typing import Iterable, Hashable, Sequence, Tuple, Any, Set, Mapping
+from typing import Iterable, Hashable, Sequence, Tuple, Any, Set, Mapping, Optional
 import os
 import xarray as xr
 import numpy as np
@@ -152,9 +152,15 @@ class RunDiagnostics:
         variables = [self.get_variable(run, v) for v in varnames]
         return xr.merge(variables)
 
-    def matching_variables(self, varfilter: str) -> Set[str]:
-        """The available variabes that include varfilter in their names."""
-        return set(v for v in self.variables if varfilter in v)
+    def matching_variables(
+        self, varfilter: str, varnames: Optional[Sequence[str]] = None
+    ) -> Set[str]:
+        """The available variables that include varfilter and at least one of the
+        optional varnames in their names."""
+        matching = set(v for v in self.variables if varfilter in v)
+        if varnames:
+            matching = set(v for v in matching if any(vn in v for vn in varnames))
+        return matching
 
     def is_baseline(self, run: str) -> bool:
         return self._attrs[run]["baseline"]

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -68,6 +68,7 @@ def plot_2d_matplotlib(
     dims: Tuple[str, str],
     contour=False,
     figsize=None,
+    title=None,
     **opts,
 ) -> RawHTML:
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
@@ -110,7 +111,7 @@ def plot_2d_matplotlib(
             images=data,
             runs=sorted(run_diags.runs),
             variables_to_plot=sorted(variables_to_plot),
-            varfilter=varfilter,
+            varfilter=title or varfilter,
             variable_long_names=run_diags.long_names,
         )
     )

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -69,6 +69,7 @@ def plot_2d_matplotlib(
     contour=False,
     figsize=None,
     title=None,
+    plot_vars=None,
     **opts,
 ) -> RawHTML:
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
@@ -80,7 +81,7 @@ def plot_2d_matplotlib(
     ylabel = opts.pop("ylabel", "")
     x, y = dims
 
-    variables_to_plot = run_diags.matching_variables(varfilter)
+    variables_to_plot = run_diags.matching_variables(varfilter, varnames=plot_vars)
     for varname in variables_to_plot:
         if not contour:
             opts["vmin"], opts["vmax"], opts["cmap"] = _get_cmap_kwargs(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -282,6 +282,15 @@ def zonal_mean_hovmoller_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
+@hovmoller_plot_manager.register
+def zonal_mean_short_term_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
+    return plot_2d_matplotlib(
+        diagnostics.trim_duration(np.timedelta64(3, "D")),
+        "zonal_mean_bias",
+        ["time", "latitude"],
+    )
+
+
 def infer_duration_seconds(diagnostics: RunDiagnostics) -> float:
     run, *_ = diagnostics.runs
     time = diagnostics.get_variable(run, "high_frequency_time")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -290,7 +290,7 @@ def zonal_mean_short_term_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
         "zonal_mean_bias",
         ["time", "latitude"],
         title="3-day zonal mean bias",
-        plot_vars=GLOBAL_AVERAGE_DYCORE_VARS,
+        plot_vars=[v.lower() for v in GLOBAL_AVERAGE_DYCORE_VARS],
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -31,6 +31,7 @@ from fv3net.diagnostics.prognostic_run.constants import (
     DEFAULT_FIGURE_HEIGHT,
     REFERENCE_HOVMOLLER_DURATION_SECONDS,
     MovieUrls,
+    GLOBAL_AVERAGE_DYCORE_VARS,
 )
 from fv3net.diagnostics._shared.constants import WVP, COL_DRYING
 
@@ -289,6 +290,7 @@ def zonal_mean_short_term_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
         "zonal_mean_bias",
         ["time", "latitude"],
         title="3-day zonal mean bias",
+        plot_vars=GLOBAL_AVERAGE_DYCORE_VARS,
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 import os
-import xarray as xr
 import fsspec
 import numpy as np
 import pandas as pd
@@ -247,39 +246,39 @@ metrics_plot_manager = PlotManager()
 
 # Routines for plotting the "diagnostics"
 @timeseries_plot_manager.register
-def rms_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def rms_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d(diagnostics, varfilter="rms_global")
 
 
 @timeseries_plot_manager.register
-def spatial_mean_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def spatial_mean_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d_with_region_bar(diagnostics, varfilter="spatial_mean")
 
 
 @timeseries_plot_manager.register
-def spatial_minmax_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def spatial_minmax_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d_min_max_with_region_bar(
         diagnostics, varfilter_min="spatial_min", varfilter_max="spatial_max"
     )
 
 
 @timeseries_plot_manager.register
-def custom_timeseries_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def custom_timeseries_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d(diagnostics, varfilter="timeseries")
 
 
 @zonal_mean_plot_manager.register
-def zonal_mean_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def zonal_mean_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d(diagnostics, varfilter="zonal_and_time_mean")
 
 
 @hovmoller_plot_manager.register
-def zonal_mean_hovmoller_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
+def zonal_mean_hovmoller_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_2d_matplotlib(diagnostics, "zonal_mean_value", ["time", "latitude"])
 
 
 @hovmoller_plot_manager.register
-def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
+def zonal_mean_hovmoller_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
@@ -314,7 +313,7 @@ def deep_tropical_meridional_mean_hovmoller_plots(
 
 
 def time_mean_cubed_sphere_maps(
-    diagnostics: Iterable[xr.Dataset], metrics: pd.DataFrame
+    diagnostics: RunDiagnostics, metrics: pd.DataFrame
 ) -> HVPlot:
     return plot_cubed_sphere_map(
         diagnostics,
@@ -325,7 +324,7 @@ def time_mean_cubed_sphere_maps(
 
 
 def time_mean_bias_cubed_sphere_maps(
-    diagnostics: Iterable[xr.Dataset], metrics: pd.DataFrame
+    diagnostics: RunDiagnostics, metrics: pd.DataFrame
 ) -> HVPlot:
     return plot_cubed_sphere_map(
         diagnostics,
@@ -339,7 +338,7 @@ def time_mean_bias_cubed_sphere_maps(
 
 
 @zonal_pressure_plot_manager.register
-def zonal_pressure_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
+def zonal_pressure_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_2d_matplotlib(
         diagnostics,
         "pressure_level_zonal_time_mean",
@@ -350,7 +349,7 @@ def zonal_pressure_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
 
 
 @zonal_pressure_plot_manager.register
-def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
+def zonal_pressure_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_2d_matplotlib(
         diagnostics,
         "pressure_level_zonal_bias",
@@ -363,34 +362,34 @@ def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
 
 
 @diurnal_plot_manager.register
-def diurnal_cycle_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def diurnal_cycle_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d_with_region_bar(diagnostics, varfilter="diurnal")
 
 
 @diurnal_plot_manager.register
-def diurnal_cycle_component_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def diurnal_cycle_component_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return diurnal_component_plot(diagnostics)
 
 
 @histogram_plot_manager.register
-def precip_histogram_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def precip_histogram_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_histogram(
         diagnostics, f"{PRECIP_RATE}_histogram", xscale="log", yscale="log"
     )
 
 
 @histogram_plot_manager.register
-def water_vapor_path_histogram_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def water_vapor_path_histogram_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_histogram(diagnostics, f"{WVP}_histogram")
 
 
 @histogram_plot_manager.register
-def histogram2d_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def histogram2d_plots(diagnostics: RunDiagnostics) -> RawHTML:
     return plot_histogram2d(diagnostics, WVP, COL_DRYING)
 
 
 @histogram_plot_manager.register
-def conditional_average_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
+def conditional_average_plots(diagnostics: RunDiagnostics) -> HVPlot:
     return plot_1d(diagnostics, varfilter="conditional_average")
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -288,6 +288,7 @@ def zonal_mean_short_term_bias_plots(diagnostics: RunDiagnostics) -> RawHTML:
         diagnostics.trim_duration(np.timedelta64(3, "D")),
         "zonal_mean_bias",
         ["time", "latitude"],
+        title="3-day zonal mean bias",
     )
 
 

--- a/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
+++ b/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
@@ -145,6 +145,22 @@ def test_RunDiagnostics_list_variables():
     assert diagnostics.variables == {"a", "b", "c", "d"}
 
 
+def test_RunDiagnostics_matching_variables():
+    ds = xarray.Dataset({})
+    diagnostics = RunDiagnostics(
+        [
+            ds.assign(foo_mean=1, bar_mean=1, foo_bias=2).assign_attrs(run="1"),
+            ds.assign(foo_mean=1, foo_bias=2).assign_attrs(run="2"),
+            ds.assign(baz_mean=2, bar_mean=4).assign_attrs(run="3"),
+        ]
+    )
+    expected_variables = {"foo_mean", "bar_mean", "baz_mean"}
+    assert diagnostics.matching_variables("mean") == expected_variables
+    assert diagnostics.matching_variables("bias") == {"foo_bias"}
+    expected_variables = {"foo_mean", "bar_mean"}
+    assert diagnostics.matching_variables("mean", ["foo", "bar"]) == expected_variables
+
+
 def test_RunDiagnostics_long_names():
     ds = xarray.Dataset({})
     a = xarray.DataArray(1, attrs={"long_name": "foo"})

--- a/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
+++ b/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
@@ -14,6 +14,7 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     RunDiagnostics,
     RunMetrics,
     DiagnosticFolder,
+    _trim,
 )
 
 
@@ -230,3 +231,22 @@ def test_ComputeDiagnosticsList_find_movie_urls(url):
     diags = ComputedDiagnosticsList.from_directory(url)
     movie_urls = diags.find_movie_urls()
     assert isinstance(movie_urls, MutableMapping)
+
+
+def test__trim():
+    ds = xarray.Dataset({"a": xarray.DataArray([1, 2, 3], coords={"x": [0, 2, 4]})})
+    out = _trim(ds, 3, "x")
+    assert out.sizes["x"] == 2
+    expected_coord = ds.x.isel(x=slice(2))
+    xarray.testing.assert_identical(out.x, expected_coord)
+
+
+def test__trim_not_existing_dim():
+    ds = xarray.Dataset({"a": xarray.DataArray([1, 2, 3], coords={"x": [0, 2, 4]})})
+    _trim(ds, 1, "time")
+
+
+def test__trim_dim_size_small():
+    ds = xarray.Dataset({"a": xarray.DataArray([1, 2, 3], coords={"x": [0, 2, 4]})})
+    out = _trim(ds, 6, "x")
+    assert out.sizes["x"] == 3

--- a/workflows/diagnostics/tests/prognostic/test_integration.sh
+++ b/workflows/diagnostics/tests/prognostic/test_integration.sh
@@ -7,37 +7,40 @@ set -xe
 RUN=gs://vcm-ml-code-testing-data/sample-prognostic-run-output-v4
 
 random=$(openssl rand --hex 6)
+tmpdir=/tmp/$random
 OUTPUT=gs://vcm-ml-scratch/test-prognostic-report/$random
 
-cd workflows/diagnostics
+mkdir -p $tmpdir
+
 # test shell
-cat << EOF > report.script
+cd workflows/diagnostics
+cat << EOF > $tmpdir/report.script
 load $RUN
 print
 hovmoller PWAT
 avg2d PWAT
 map2d PWAT
-eval 3d.script
+eval $tmpdir/3d.script
 jupyter
 EOF
 
-cat << EOF > 3d.script
+cat << EOF > $tmpdir/3d.script
 meridional air_temperature
 zonal air_temperature
 zonalavg air_temperature
 column air_temperature
 avg3d air_temperature
 EOF
-prognostic_run_diags shell report.script
+prognostic_run_diags shell $tmpdir/report.script
 # assert an image has been output
 [[ -f image.png ]]
+rm image.png  # cleanup
 
 # compute diagnostics/mterics for a short sample prognostic run
-mkdir -p /tmp/$random
-prognostic_run_diags save $RUN /tmp/$random/diags.nc --n-jobs=4
-prognostic_run_diags metrics /tmp/$random/diags.nc > /tmp/$random/metrics.json
-gsutil cp /tmp/$random/diags.nc $OUTPUT/run1/diags.nc
-gsutil cp /tmp/$random/metrics.json $OUTPUT/run1/metrics.json
+prognostic_run_diags save $RUN $tmpdir/diags.nc --n-jobs=4
+prognostic_run_diags metrics $tmpdir/diags.nc > $tmpdir/metrics.json
+gsutil cp $tmpdir/diags.nc $OUTPUT/run1/diags.nc
+gsutil cp $tmpdir/metrics.json $OUTPUT/run1/metrics.json
 
 # generate movies for short sample prognostic run
 prognostic_run_diags movie --n_jobs 1 --n_timesteps 2 $RUN $OUTPUT/run1
@@ -46,7 +49,7 @@ prognostic_run_diags movie --n_jobs 1 --n_timesteps 2 $RUN $OUTPUT/run1
 prognostic_run_diags report $OUTPUT $OUTPUT
 
 # cleanup
-rm -r /tmp/$random
+rm -r $tmpdir
 
 echo "Yay! Prognostic run report integration test passed. You can view the generated report at:"
 echo "https://storage.cloud.google.com/vcm-ml-scratch/test-prognostic-report/${random}/index.html"


### PR DESCRIPTION
Add hovmoller bias plots which are restricted to at most 3 days long. This allows viewing of the initial bias spinup.

Example [report](https://storage.googleapis.com/vcm-ml-public/argo/2022-10-06t151239-a67f50858510/hovmoller.html) (see bottom of the page).

Significant internal changes:
- added `trim_duration` method to `RunDiagnostics`
- add section of 3-day hovmoller bias plots

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/c74d1132-0af3-4a95-be2e-2dc038d6ff66/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)