### PR TITLE
Small fixes to fv3fit.pytorch for full model emulation

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
@@ -30,6 +30,7 @@ class DiscriminatorConfig:
 
     n_convolutions: int = 3
     kernel_size: int = 3
+    strided_kernel_size: int = 3
     max_filters: int = 256
 
     def build(
@@ -39,6 +40,7 @@ class DiscriminatorConfig:
             in_channels=channels,
             n_convolutions=self.n_convolutions,
             kernel_size=self.kernel_size,
+            strided_kernel_size=self.strided_kernel_size,
             max_filters=self.max_filters,
             convolution=convolution,
         )
@@ -54,6 +56,7 @@ class Discriminator(nn.Module):
         in_channels: int,
         n_convolutions: int,
         kernel_size: int,
+        strided_kernel_size: int,
         max_filters: int,
         convolution: ConvolutionFactory = single_tile_convolution,
     ):
@@ -62,7 +65,8 @@ class Discriminator(nn.Module):
             in_channels: number of input channels
             n_convolutions: number of strided convolutional layers before the
                 final convolutional output layers, must be at least 1
-            kernel_size: size of convolutional kernels
+            kernel_size: size of non-strided convolutional kernels
+            strided_kernel_size: size of 2-strided convolutional kernels
             max_filters: maximum number of filters in any convolutional layer,
                 equal to the number of filters in the final strided convolutional layer
                 and in the convolutional layer just before the output layer
@@ -78,7 +82,7 @@ class Discriminator(nn.Module):
                 in_channels=in_channels,
                 out_channels=min_filters,
                 convolution_factory=curry(convolution)(
-                    kernel_size=kernel_size, stride=2,
+                    kernel_size=strided_kernel_size, stride=2,
                 ),
                 activation_factory=leakyrelu_activation(
                     negative_slope=0.2, inplace=True
@@ -92,7 +96,7 @@ class Discriminator(nn.Module):
                     in_channels=min_filters * 2 ** (i - 1),
                     out_channels=min_filters * 2 ** i,
                     convolution_factory=curry(convolution)(
-                        kernel_size=kernel_size, stride=2
+                        kernel_size=strided_kernel_size, stride=2
                     ),
                     activation_factory=leakyrelu_activation(
                         negative_slope=0.2, inplace=True

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -5,7 +5,7 @@ import torch
 from .modules import (
     ConvBlock,
     ConvolutionFactory,
-    FoldTileDimension,
+    FoldFirstDimension,
     single_tile_convolution,
     relu_activation,
     ResnetBlock,
@@ -156,7 +156,7 @@ class Generator(nn.Module):
                 convolution(
                     kernel_size=7, in_channels=channels, out_channels=min_filters,
                 ),
-                FoldTileDimension(nn.InstanceNorm2d(min_filters)),
+                FoldFirstDimension(nn.InstanceNorm2d(min_filters)),
                 relu_activation()(),
             )
 

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
@@ -71,15 +71,15 @@ class CurriedModuleFactory(Protocol):
         ...
 
 
-class FoldTileDimension(nn.Module):
+class FoldFirstDimension(nn.Module):
     """
-    Module wrapping a module which takes [batch, channel, x, y] data into one
-    which takes [batch, tile, channel, x, y] data by folding the tile dimension
-    into the batch dimension.
+    Module wrapping a module which takes e.g. [batch, channel, x, y] data into one
+    which takes [batch, tile, channel, x, y] data by folding the first dimension
+    into the second dimension.
     """
 
     def __init__(self, wrapped):
-        super(FoldTileDimension, self).__init__()
+        super(FoldFirstDimension, self).__init__()
         self._wrapped = wrapped
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
@@ -142,7 +142,7 @@ def single_tile_convolution(
         )
     else:
         raise ValueError(f"Invalid stride_type: {stride_type}")
-    return FoldTileDimension(conv)
+    return FoldFirstDimension(conv)
 
 
 def halo_convolution(
@@ -546,7 +546,7 @@ class ConvBlock(nn.Module):
         # of normalization, while debugging.
         self.conv_block = nn.Sequential(
             convolution_factory(in_channels=in_channels, out_channels=out_channels),
-            FoldTileDimension(nn.InstanceNorm2d(out_channels)),
+            FoldFirstDimension(nn.InstanceNorm2d(out_channels)),
             activation_factory(),
         )
 

--- a/external/fv3fit/fv3fit/pytorch/graph/graph_builder.py
+++ b/external/fv3fit/fv3fit/pytorch/graph/graph_builder.py
@@ -74,6 +74,7 @@ def build_dgl_graph_with_edge(nx_tile: int) -> Tuple[dgl.DGLGraph, torch.Tensor]
     graph_data = build_graph(nx_tile)
     graph_tensor = torch.tensor(graph_data)
     xyz = get_grid_xyz(nx_tile)
+    xyz = xyz.reshape(xyz.shape[0] * xyz.shape[1] * xyz.shape[2], 3)
     xyz_neighbour = xyz[graph_tensor[1], :]
     xyz_reference = xyz[graph_tensor[0], :]
     edge_relation = xyz_neighbour - xyz_reference

--- a/external/fv3fit/fv3fit/pytorch/predict.py
+++ b/external/fv3fit/fv3fit/pytorch/predict.py
@@ -276,7 +276,7 @@ def _load_pytorch(cls: Type[_PytorchDumpable], path: str):
     fs = vcm.get_fs(path)
     model_filename = os.path.join(path, cls._MODEL_FILENAME)
     with fs.open(model_filename, "rb") as f:
-        model = torch.load(f).to(DEVICE)
+        model = torch.load(f, map_location=DEVICE)
     with fs.open(os.path.join(path, cls._SCALERS_FILENAME), "rb") as f:
         scalers = load_mapping(StandardScaler, f)
     with open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
@@ -343,9 +343,12 @@ def _pack_to_tensor(
                 n_windows, timesteps, *data.shape[1:]
             )
             # append first time of next window to end of each window
-            end_data = np.concatenate(
-                [data[1:, :1, :], normalized_data[None, -1:, :]], axis=0
-            )
+            if n_windows > 1:
+                end_data = np.concatenate(
+                    [data[1:, :1, :], normalized_data[None, -1:, :]], axis=0
+                )
+            else:
+                end_data = normalized_data[None, -1:, :]
             data = np.concatenate([data, end_data], axis=1)
         else:
             data = normalized_data

--- a/external/vcm/vcm/grid.py
+++ b/external/vcm/vcm/grid.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import numpy as np
 from vcm.catalog import catalog
 
@@ -61,13 +62,13 @@ def xyz_to_lon_lat(xyz, np):
     return lon, lat
 
 
-def get_grid_xyz(nx: int):
+def get_grid_xyz(nx: int) -> np.ndarray:
     """
     Args:
         nx: number of horizontal grid points on each tile of the cubed sphere
 
     Returns:
-        lon, lat data corresponding to nx.
+        x, y, z data on a unit sphere corresponding to nx, of shape [tile, x, y, 3].
     """
     grid = catalog["grid/c48"].read()
     lat = grid.lat.load()
@@ -87,14 +88,21 @@ def get_grid_xyz(nx: int):
                 + xyz[:, 1::2, 1::2]
                 + xyz[:, :-1:2, :-1:2]
             )
-        xyz = xyz.reshape((6 * nx * nx, 3))
     else:
         raise ValueError("nx must be one of 48, 24, 12, 6, 3, " f"got {nx}")
     return xyz
 
 
-def get_grid(nx):
+def get_grid(nx) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Args:
+        nx: number of horizontal grid points on each tile of the cubed sphere
+
+    Returns:
+        lon, lat data corresponding to nx, of shape [tile, x, y].
+    """
     xyz = get_grid_xyz(nx)
+    xyz = xyz.reshape((6 * nx * nx, 3))
     lon, lat = xyz_to_lon_lat(xyz, np)
     lon = lon.reshape((6, nx, nx))
     lat = lat.reshape((6, nx, nx))


### PR DESCRIPTION
This PR contains some small fixes and additions that were done in the course of working on convolutional full model emulation, to be reviewed separately.

Refactored public API:
- added time_stride argument to WindowedZarrLoader
- added strided_kernel_size argument to Discriminator
- renamed FoldTileDImension to FoldFirstDimension
- fixed fv3fit.pytorch.predict for loading models that were saved on different device type and loading data which contains only a single window
- update get_grid_xyz to return a [tile, x, y, feature] array instead of a [sample, feature] array
- updated docs in vcm.grid

- [ ] Tests added

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/918aec80-c63d-4e2b-8869-fee73520e48c/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)