### PR TITLE
Add from_dict method to ComputedDiagnosticsList

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/__init__.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/__init__.py
@@ -1,4 +1,5 @@
 from .config import get_verification_entries
+from .computed_diagnostics import ComputedDiagnosticsList, RunDiagnostics
 
 
 __all__ = dir()

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -47,10 +47,6 @@ class ComputedDiagnosticsList:
         """Open computed diagnostics at the specified urls
         """
 
-        def url_to_folder(url):
-            fs, _, path = fsspec.get_fs_token_paths(url)
-            return DiagnosticFolder(fs, path[0])
-
         return ComputedDiagnosticsList(
             {str(k): url_to_folder(url) for k, url in enumerate(urls)}
         )
@@ -61,10 +57,6 @@ class ComputedDiagnosticsList:
     ) -> "ComputedDiagnosticsList":
         """Open labeled computed diagnostics at urls specified in given JSON."""
 
-        def url_to_folder(url):
-            fs, _, path = fsspec.get_fs_token_paths(url)
-            return DiagnosticFolder(fs, path[0])
-
         with fsspec.open(url) as f:
             rundirs = json.load(f)
 
@@ -74,6 +66,20 @@ class ComputedDiagnosticsList:
 
         return ComputedDiagnosticsList(
             {item["name"]: url_to_folder(item["url"]) for item in rundirs}
+        )
+
+    @staticmethod
+    def from_dict(
+        urls: Mapping[str, str], urls_are_rundirs: bool = False
+    ) -> "ComputedDiagnosticsList":
+        """Open labeled computed diagnostics given mapping of name to url."""
+        urls = {
+            name: url + "_diagnostics" if urls_are_rundirs else url
+            for name, url in urls.items()
+        }
+
+        return ComputedDiagnosticsList(
+            {name: url_to_folder(url) for name, url in urls.items()}
         )
 
     def load_metrics(self) -> "RunMetrics":
@@ -89,6 +95,11 @@ class ComputedDiagnosticsList:
 
     def find_movie_urls(self) -> MovieUrls:
         return {name: folder.movie_urls for name, folder in self.folders.items()}
+
+
+def url_to_folder(url):
+    fs, _, path = fsspec.get_fs_token_paths(url)
+    return DiagnosticFolder(fs, path[0])
 
 
 @dataclass

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -46,10 +46,8 @@ class ComputedDiagnosticsList:
     def from_urls(urls: Sequence[str]) -> "ComputedDiagnosticsList":
         """Open computed diagnostics at the specified urls
         """
-
-        return ComputedDiagnosticsList(
-            {str(k): url_to_folder(url) for k, url in enumerate(urls)}
-        )
+        urls_dict = {str(k): url for k, url in enumerate(urls)}
+        return ComputedDiagnosticsList.from_dict(urls_dict)
 
     @staticmethod
     def from_json(
@@ -60,13 +58,8 @@ class ComputedDiagnosticsList:
         with fsspec.open(url) as f:
             rundirs = json.load(f)
 
-        if urls_are_rundirs:
-            for item in rundirs:
-                item["url"] += "_diagnostics"
-
-        return ComputedDiagnosticsList(
-            {item["name"]: url_to_folder(item["url"]) for item in rundirs}
-        )
+        urls_dict = {item["name"]: item["url"] for item in rundirs}
+        return ComputedDiagnosticsList.from_dict(urls_dict, urls_are_rundirs)
 
     @staticmethod
     def from_dict(

--- a/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
+++ b/workflows/diagnostics/tests/prognostic/test_computed_diagnostics.py
@@ -88,6 +88,20 @@ def test_ComputedDiagnosticsList_from_json_urls_are_rundirs(tmpdir):
     assert result.folders["run1"].path == "/rundir1_diagnostics"
 
 
+def test_ComputedDiagnosticsList_from_dict():
+    input_ = {"run1": "rundir1_diagnostics", "run2": "rundir2_diagnostics"}
+    result = ComputedDiagnosticsList.from_dict(input_)
+    assert len(result.folders) == 2
+    assert isinstance(result.folders["run1"], DiagnosticFolder)
+    assert isinstance(result.folders["run2"], DiagnosticFolder)
+
+
+def test_ComputedDiagnosticsList_from_dict_urls_are_rundirs():
+    input_ = {"run1": "/rundir1"}
+    result = ComputedDiagnosticsList.from_dict(input_, urls_are_rundirs=True)
+    assert result.folders["run1"].path == "/rundir1_diagnostics"
+
+
 def test_movie_urls(tmpdir):
     rundir = tmpdir.mkdir("baseline_run")
     rundir.join("movie1.mp4").write("foobar")


### PR DESCRIPTION
Add `from_dict` method to `ComputedDiagnosticsList`. I find this is a more convenient interface for interactive use. It also allows deletion of some duplicated code.

Added public API:
- `ComputedDiagnosticsList.from_dict`

Significant internal changes:
- use `from_dict` method in `from_json` and `from_urls`

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/ed960e81-68e6-4931-bf69-cd10405e66ba/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)
