### PR TITLE
Override volume mount for `external/fv3gfs-fortran` in `make enter` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ BEAM_VERSION = 2.37.0
 UBUNTU_IMAGE = ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
 # prognostic base image is updated manually, not on every commit
 PROGNOSTIC_BASE_VERSION = 1.1.0
+
+# Explicitly mount the /fv3net/external/fv3gfs-fortran directory to prevent
+# it from being overriden by the user's.  Historically we only interactively
+# develop the Python dependencies of the images in fv3net.
 DOCKER_INTERACTIVE_ARGS = \
 	--tty \
 	--interactive \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DOCKER_INTERACTIVE_ARGS = \
 	-v $(shell pwd)/external:/fv3net/external \
 	-v $(shell pwd)/workflows:/fv3net/workflows \
 	-v $(shell pwd)/projects:/fv3net/projects \
+	-v /fv3net/external/fv3gfs-fortran \
 	--mount source=bash_history,target=/root/.bash_history \
 	-e HISTFILE=/root/.bash_history/history
 


### PR DESCRIPTION
This is a simple way to address #2080.  If, in addition to the general mount of the user's full `external` directory, we add a specific mount of `/fv3net/external/fv3gfs-fortran`, docker will use the image's `fv3gfs-fortran` directory, but the user's `external` directory for everything else.

In images that don't use fv3gfs-fortran, this will add an empty directory (but previously, in those images we were adding the full user's directory of fv3gfs-fortran, which wasn't really necessary either, so I don't think this is necessarily a step back).  

Resolves #2080 

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/ff61922f-e4a1-45d7-ae2f-54b676a1da17/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)