### PR TITLE
Fix typo in `KuramotoSivashinskyConfig` class name

### DIFF
--- a/projects/reservoir/ks.py
+++ b/projects/reservoir/ks.py
@@ -123,7 +123,7 @@ def generate_ks_time_series(
 
 
 @dataclass
-class KiramotoSivashinskyConfig:
+class KuramotoSivashinskyConfig:
     """ Generates 1D Kuramoto-Sivashinsky solution time series
     N: number spatial points in final output vectors
     domain_size: periodic domain size

--- a/projects/reservoir/train_ks.py
+++ b/projects/reservoir/train_ks.py
@@ -12,7 +12,7 @@ from fv3fit.reservoir import (
     ReservoirComputingModel,
 )
 from fv3fit.reservoir.config import ReservoirTrainingConfig
-from ks import KiramotoSivashinskyConfig
+from ks import KuramotoSivashinskyConfig
 
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     parser = _get_parser()
     args = parser.parse_args()
     with open(args.ks_config, "r") as f:
-        ks_config = dacite.from_dict(KiramotoSivashinskyConfig, yaml.safe_load(f))
+        ks_config = dacite.from_dict(KuramotoSivashinskyConfig, yaml.safe_load(f))
     with open(args.train_config, "r") as f:
         train_config_dict = yaml.safe_load(f)
         train_config = ReservoirTrainingConfig.from_dict(train_config_dict)


### PR DESCRIPTION
@AnnaKwa apologies -- I think I introduced this typo inadvertently in my suggestion earlier.  This PR fixes it.

Coverage reports (updated automatically):
- test_unit: [82%](https:\/\/output.circle-artifacts.com\/output\/job\/e7ab6535-64f4-4f9d-9e9c-7dea16aa81b6\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)