### PR TITLE
Fix RC model prediction bugs

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -22,7 +22,7 @@ class ReservoirComputingModel:
         self.readout = readout
 
     def predict(self):
-        prediction = self.readout.predict(self.reservoir.state)
+        prediction = self.readout.predict(self.reservoir.state).reshape(-1)
         self.reservoir.increment_state(prediction)
         return prediction
 

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -18,7 +18,7 @@ class MultiOutputMeanRegressor:
     def predict(self, input):
         # returns vector of size n_outputs, with each element
         # the mean of the input vector elements
-        return np.full(self.n_outputs, np.mean(input))
+        return np.full(self.n_outputs, np.mean(input)).reshape(1, -1)
 
 
 def _sparse_allclose(A, B, atol=1e-8):

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -16,7 +16,7 @@ class MultiOutputMeanRegressor:
         self.n_outputs = n_outputs
 
     def predict(self, input):
-        # returns vector of size n_outputs, with each element
+        # returns array of shape (1, n_outputs), with each element
         # the mean of the input vector elements
         return np.full(self.n_outputs, np.mean(input)).reshape(1, -1)
 
@@ -52,6 +52,27 @@ def test_dump_load_preserves_reservoir(tmpdir):
     loaded_predictor = ReservoirComputingModel.load(output_path)
     assert _sparse_allclose(loaded_predictor.reservoir.W_in, predictor.reservoir.W_in)
     assert _sparse_allclose(loaded_predictor.reservoir.W_res, predictor.reservoir.W_res)
+
+
+def test_prediction_shape():
+    input_size = 15
+    hyperparameters = ReservoirHyperparameters(
+        input_size=input_size,
+        state_size=1000,
+        adjacency_matrix_sparsity=0.9,
+        spectral_radius=1.0,
+        input_coupling_sparsity=0,
+    )
+    reservoir = Reservoir(hyperparameters)
+    lr = DummyRegressor(strategy="constant", constant=np.ones(input_size))
+    lr.fit(reservoir.state.reshape(1, -1), np.ones((1, input_size)))
+    readout = ReservoirComputingReadout(
+        linear_regressor=lr, square_half_hidden_state=True,
+    )
+    predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
+    # ReservoirComputingModel.predict reshapes the prediction to remove
+    # the first dim of length 1 (sklearn regressors predict 2D arrays)
+    assert predictor.predict().shape == (input_size,)
 
 
 def test_ReservoirComputingModel_state_increment():

--- a/projects/reservoir/train_ks.py
+++ b/projects/reservoir/train_ks.py
@@ -32,7 +32,7 @@ def _get_parser() -> argparse.ArgumentParser:
 
 
 def add_input_noise(arr, stddev):
-    return np.random.normal(loc=0, scale=stddev, size=arr.shape)
+    return arr + np.random.normal(loc=0, scale=stddev, size=arr.shape)
 
 
 def transform_inputs_to_reservoir_states(X, reservoir):

--- a/projects/reservoir/train_ks.py
+++ b/projects/reservoir/train_ks.py
@@ -47,15 +47,7 @@ def transform_inputs_to_reservoir_states(X, reservoir):
     return np.array(reservoir_states[:-1])
 
 
-if __name__ == "__main__":
-    parser = _get_parser()
-    args = parser.parse_args()
-    with open(args.ks_config, "r") as f:
-        ks_config = dacite.from_dict(KuramotoSivashinskyConfig, yaml.safe_load(f))
-    with open(args.train_config, "r") as f:
-        train_config_dict = yaml.safe_load(f)
-        train_config = ReservoirTrainingConfig.from_dict(train_config_dict)
-
+def train(ks_config, train_config):
     training_ts = ks_config.generate(
         n_steps=train_config.n_samples + train_config.n_burn, seed=train_config.seed
     )
@@ -84,6 +76,17 @@ if __name__ == "__main__":
     )
     readout.fit(X_train, y_train)
 
-    predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
+    return ReservoirComputingModel(reservoir=reservoir, readout=readout,)
 
+
+if __name__ == "__main__":
+    parser = _get_parser()
+    args = parser.parse_args()
+    with open(args.ks_config, "r") as f:
+        ks_config = dacite.from_dict(KuramotoSivashinskyConfig, yaml.safe_load(f))
+    with open(args.train_config, "r") as f:
+        train_config_dict = yaml.safe_load(f)
+        train_config = ReservoirTrainingConfig.from_dict(train_config_dict)
+
+    predictor = train(ks_config, train_config)
     predictor.dump(args.output_path)


### PR DESCRIPTION
- The readout component's prediction always has 2 dimensions and should be reshaped before being used to increment the state. The test of `ReservoirComputingModel.predict` was erroneously passing because the mock regressor class didn't replicate the output dimensions of the sklearn regressors.

- Fixed egregious error where `add_input_noise` returned the input noise array instead of adding it to the input data and returning the noised data
 
Also some changes for convenience in `train_ks.py`:
- added a dump method to the training config to help with experiment tracking
- moved predictor training into a `train()` function that can be imported in other scripts, notebooks, etc


Coverage reports (updated automatically):
- test_unit: [82%](https:\/\/output.circle-artifacts.com\/output\/job\/d5aea92a-1a1f-43d6-9ea7-c2e9bad85538\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)