### PR TITLE
Enable updateable pcolormesh_cube plots

### DIFF
--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -331,11 +331,11 @@ def _apply_to_non_non_nan_segments(func, lat, lon, array):
     Args:
         func:
             Function to be applied to non-nan segments of array.
-        lon:
-            Array of longitudes with dimensions (tile, ny + 1, nx + 1).
-            Should be given at cell corners.
         lat:
             Array of latitudes with dimensions (tile, ny + 1, nx + 1).
+            Should be given at cell corners.
+        lon:
+            Array of longitudes with dimensions (tile, ny + 1, nx + 1).
             Should be given at cell corners.
         array:
             Array of variables values at cell centers, of dimensions (tile, ny, nx)


### PR DESCRIPTION
The DSL team will soon need to make a video using very high-resolution data. Plotting each frame independently is much slower than running a single pcolormesh and updating its data, but the current interface doesn't allow updating data as it throws away most pcolormesh handles.

This PR refactors the fv3viz pcolormesh_cube code to expose a version of the plotting that retains the handles. This is done intentionally as an "internal" change because the plotting needs for the DSL team are short-term and one-time, but I could make this a public API if reviewers think that's a good idea.

No tests are added.

Significant internal changes:
- Added fv3viz._plot_cube.UpdateablePColormesh

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/c60bfb98-b365-4ef1-9b3c-ad546b441839/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)