### PR TITLE
Add Python implementation of blended coarse-graining

### DIFF
--- a/external/vcm/tests/test_cubedsphere.py
+++ b/external/vcm/tests/test_cubedsphere.py
@@ -12,6 +12,7 @@ from vcm.cubedsphere.coarsen import (
     _xarray_block_reduce_dataarray,
     add_coordinates,
     block_coarsen,
+    block_edge_coarsen,
     block_edge_sum,
     block_median,
     block_upsample,
@@ -384,6 +385,25 @@ def test_block_edge_sum(data, factor, edge, expected_data):
     da = xr.DataArray(data, dims=dims, coords=None, attrs=attrs)
     expected = xr.DataArray(expected_data, dims=dims, coords=None, attrs=attrs)
     result = block_edge_sum(da, factor, x_dim="x_dim", y_dim="y_dim", edge=edge)
+    assert_identical_including_dtype(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("data", "factor", "edge", "expected_data"),
+    [
+        ([[2, 6, 2], [6, 2, 6]], 2, "x", [[2, 2]]),
+        ([[2, 6], [6, 2], [2, 6]], 2, "y", [[2], [2]]),
+    ],
+    ids=["edge='x'", "edge='y'"],
+)
+def test_block_edge_coarsen(data, factor, edge, expected_data):
+    dims = ["x_dim", "y_dim"]
+    attrs = {"units": "m"}
+    da = xr.DataArray(data, dims=dims, coords=None, attrs=attrs)
+    expected = xr.DataArray(expected_data, dims=dims, coords=None, attrs=attrs)
+    result = block_edge_coarsen(
+        da, factor, x_dim="x_dim", y_dim="y_dim", edge=edge, method="min"
+    )
     assert_identical_including_dtype(result, expected)
 
 

--- a/external/vcm/vcm/calc/thermo/constants.py
+++ b/external/vcm/vcm/calc/thermo/constants.py
@@ -14,6 +14,7 @@ _EARTH_RADIUS = 6.3712e6  # m
 _DEFAULT_SURFACE_TEMPERATURE = _FREEZING_TEMPERATURE + 15
 
 _REFERENCE_SURFACE_PRESSURE = 100000  # reference pressure for potential temp [Pa]
+_TOA_PRESSURE = 300.0  # For our default 79-level configuration of FV3GFS [Pa]
 
 _SEC_PER_DAY = 86400
 _KG_M2S_TO_MM_DAY = (1e3 * 86400) / 997.0

--- a/external/vcm/vcm/calc/thermo/vertically_dependent.py
+++ b/external/vcm/vcm/calc/thermo/vertically_dependent.py
@@ -9,9 +9,9 @@ from .constants import (
     _EARTH_RADIUS,
     _SPECIFIC_HEAT_CONST_PRESSURE,
     _KG_M2S_TO_MM_DAY,
+    _TOA_PRESSURE,
 )
 
-_TOA_PRESSURE = 300.0  # Pa
 _REVERSE = slice(None, None, -1)
 
 

--- a/external/vcm/vcm/cubedsphere/coarsen.py
+++ b/external/vcm/vcm/cubedsphere/coarsen.py
@@ -666,12 +666,12 @@ def block_edge_coarsen(
 
     coarsen_kwargs = {coarsen_dim: coarsening_factor}
     copy = obj.copy()  # coarsen destroys attributes on the original object
-    coarsened = getattr(
+    coarsen_obj = (
         copy.coarsen(
             coarsen_kwargs, coord_func=coord_func  # type: ignore
         ),
-        method,
-    )()
+    )
+    coarsened = getattr(coarsen_obj, method)()
     downsample_kwargs = {downsample_dim: slice(None, None, coarsening_factor)}
     result = coarsened.isel(downsample_kwargs)
 

--- a/external/vcm/vcm/cubedsphere/coarsen.py
+++ b/external/vcm/vcm/cubedsphere/coarsen.py
@@ -615,31 +615,15 @@ def block_edge_sum(
     Returns:
         xr.Dataset or xr.DataArray.
     """
-    if edge == "x":
-        coarsen_dim = x_dim
-        downsample_dim = y_dim
-    elif edge == "y":
-        coarsen_dim = y_dim
-        downsample_dim = x_dim
-    else:
-        raise ValueError(f"'edge' most be either 'x' or 'y'; got {edge}.")
-
-    coarsen_kwargs = {coarsen_dim: coarsening_factor}
-    copy = obj.copy()  # coarsen destroys attributes on the original object
-    coarsened = copy.coarsen(
-        coarsen_kwargs, coord_func=coord_func  # type: ignore
-    ).sum()
-    downsample_kwargs = {downsample_dim: slice(None, None, coarsening_factor)}
-    result = coarsened.isel(downsample_kwargs)
-
-    # Separate logic is needed to apply coord_func to the downsample dimension
-    # coordinate (if it exists), because it is not included in the call to
-    # coarsen.
-    result = _coarsen_downsample_coordinate(
-        obj, result, downsample_dim, coarsening_factor, coord_func
+    return block_edge_coarsen(
+        obj,
+        coarsening_factor,
+        x_dim=x_dim,
+        y_dim=y_dim,
+        edge=edge,
+        coord_func=coord_func,
+        method="sum",
     )
-
-    return _propagate_attrs(obj, result)
 
 
 def block_edge_coarsen(

--- a/external/vcm/vcm/cubedsphere/coarsen.py
+++ b/external/vcm/vcm/cubedsphere/coarsen.py
@@ -666,10 +666,8 @@ def block_edge_coarsen(
 
     coarsen_kwargs = {coarsen_dim: coarsening_factor}
     copy = obj.copy()  # coarsen destroys attributes on the original object
-    coarsen_obj = (
-        copy.coarsen(
-            coarsen_kwargs, coord_func=coord_func  # type: ignore
-        ),
+    coarsen_obj = copy.coarsen(
+        coarsen_kwargs, coord_func=coord_func  # type: ignore
     )
     coarsened = getattr(coarsen_obj, method)()
     downsample_kwargs = {downsample_dim: slice(None, None, coarsening_factor)}

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -52,6 +52,18 @@ VTYPE_LAND_ICE = 15.0
 X_DIM = "xaxis_1"
 Y_DIM = "yaxis_1"
 SIGMA_BLEND = 0.9
+FRACTION_TRACERS = ["cld_amt"]  # Always are area-weighted.
+MIXING_RATIO_TRACERS = [
+    "sphum",
+    "liq_wat",
+    "rainwat",
+    "ice_wat",
+    "snowwat",
+    "graupel",
+    "o3mr",
+    "sgs_tke",
+]  # Are area-weighted or mass-weighted depending on the user's choice.
+
 
 dask.config.set(scheduler="single-threaded")
 
@@ -66,6 +78,7 @@ def coarsen_restarts_on_sigma(
     grid_spec: xr.Dataset,
     restarts: Mapping[str, xr.Dataset],
     coarsen_agrid_winds: bool = False,
+    mass_weighted: bool = True,
 ) -> Mapping[str, xr.Dataset]:
     """ Coarsen a complete set of restart data, averaging on model levels and
     using the 'complex' surface coarsening method
@@ -100,6 +113,7 @@ def coarsen_restarts_on_sigma(
         ),
         coarsening_factor,
         coarsen_agrid_winds,
+        mass_weighted,
     )
 
     coarsened["fv_srf_wnd.res"] = _coarse_grain_fv_srf_wnd(
@@ -117,6 +131,7 @@ def coarsen_restarts_on_sigma(
             {COORD_X_CENTER: FV_TRACER_X_CENTER, COORD_Y_CENTER: FV_TRACER_Y_CENTER}
         ),
         coarsening_factor,
+        mass_weighted,
     )
 
     coarsened["sfc_data"] = _coarse_grain_sfc_data_complex(
@@ -230,7 +245,9 @@ def coarsen_restarts_via_hybrid_method(
         coarsen_agrid_winds: flag indicating whether to coarsen A-grid winds in
             "fv_core.res" restart files (default False).
         mass_weighted: flag indicating whether model-level averages are
-            mass-weighted or area-weighted.
+            mass-weighted for the vertical velocity, temperature, and mixing
+            ratio tracers and area-weighted for all other 3D variables, or
+            area-weighted for all 3D variables.
 
     Returns:
         restarts_coarse: a dictionary with the same format as restarts but
@@ -325,7 +342,8 @@ def _coarse_grain_fv_core(
     coarsen_agrid_winds : bool
         Whether to coarse-grain A-grid winds (default False)
     mass_weighted : bool
-        Whether to weight averages using mass instead of area (default True)
+        Whether to weight temperature and vertical velocity using mass instead
+        of area (default True)
 
     Returns
     -------
@@ -498,48 +516,73 @@ def _coarse_grain_fv_core_on_pressure(
     )
 
 
-def _compute_blending_factor(blending_pressure, ps_coarse, pfull_coarse):
-    blending_factor = (ps_coarse - pfull_coarse) / (ps_coarse - blending_pressure)
-    return xr.where(pfull_coarse > blending_pressure, blending_factor, 1.0)
+def compute_blending_weights(blending_pressure, ps_coarse, pfull_coarse):
+    """Compute the weights for blending pressure level and model level coarsened
+    3D fields.
+
+    Args:
+        blending_pressure: xr.DataArray
+            Pressure above which we start blending in the model level coarsened
+            field.
+        ps_coarse: xr.DataArray
+            Coarse surface pressure
+        pfull_coarse:
+            Coarse pressure at vertical level midpoints
+
+    Returns:
+        blending_weights: xr.DataArray
+    """
+    blending_weights = (ps_coarse - pfull_coarse) / (ps_coarse - blending_pressure)
+    return xr.where(pfull_coarse > blending_pressure, blending_weights, 1.0)
 
 
-def _compute_blending_factor_agrid(
-    delp, area, coarsening_factor, x_dim="xaxis_1", y_dim="yaxis_2"
+def _compute_blending_weights_agrid(
+    delp, area, coarsening_factor, x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_CENTER
 ):
     delp_coarse = weighted_block_average(
         delp, area, coarsening_factor, x_dim=x_dim, y_dim=y_dim
     )
     pfull_coarse = pressure_at_midpoint_log(delp_coarse, dim=RESTART_Z_CENTER)
-    ps_fine = surface_pressure_from_delp(delp, vertical_dim=RESTART_Z_CENTER)
+    ps = surface_pressure_from_delp(delp, vertical_dim=RESTART_Z_CENTER)
     ps_coarse = surface_pressure_from_delp(delp_coarse, vertical_dim=RESTART_Z_CENTER)
     blending_pressure = SIGMA_BLEND * block_coarsen(
-        ps_fine, coarsening_factor, x_dim=x_dim, y_dim=y_dim, method="min"
+        ps, coarsening_factor, x_dim=x_dim, y_dim=y_dim, method="min"
     )
-    return _compute_blending_factor(blending_pressure, ps_coarse, pfull_coarse)
+    return compute_blending_weights(blending_pressure, ps_coarse, pfull_coarse)
 
 
-def _compute_blending_factor_dgrid(
-    delp, length, coarsening_factor, edge, x_dim="xaxis_1", y_dim="yaxis_2"
+def _compute_blending_weights_dgrid(
+    delp, length, coarsening_factor, edge, x_dim, y_dim
 ):
     delp_edge = compute_edge_delp(delp, edge, x_dim=x_dim, y_dim=y_dim)
     delp_edge_coarse = edge_weighted_block_average(
         delp_edge, length, coarsening_factor, x_dim=x_dim, y_dim=y_dim, edge=edge
     )
     pfull_coarse = pressure_at_midpoint_log(delp_edge_coarse, dim=RESTART_Z_CENTER)
-    ps_fine = surface_pressure_from_delp(delp_edge, vertical_dim=RESTART_Z_CENTER)
+    ps = surface_pressure_from_delp(delp_edge, vertical_dim=RESTART_Z_CENTER)
     ps_coarse = surface_pressure_from_delp(
         delp_edge_coarse, vertical_dim=RESTART_Z_CENTER
     )
     blending_pressure = SIGMA_BLEND * block_edge_coarsen(
-        ps_fine, coarsening_factor, edge=edge, x_dim=x_dim, y_dim=y_dim, method="min"
+        ps, coarsening_factor, edge=edge, x_dim=x_dim, y_dim=y_dim, method="min"
     )
-    return _compute_blending_factor(blending_pressure, ps_coarse, pfull_coarse)
+    return compute_blending_weights(blending_pressure, ps_coarse, pfull_coarse)
 
 
-def _blend(blending_factor, via_pressure_level, via_model_level):
-    return (
-        blending_factor * via_pressure_level + (1 - blending_factor) * via_model_level
-    )
+def blend(weights, pressure_level, model_level):
+    return weights * pressure_level + (1 - weights) * model_level
+
+
+def _2d_fv_core_names_agrid(ds):
+    return [v for v in ds.data_vars if RESTART_Z_CENTER not in ds[v].dims]
+
+
+def _3d_fv_core_names_agrid(ds):
+    names = []
+    for v, da in ds.data_vars.items():
+        if v not in ["u", "v"] and RESTART_Z_CENTER in da.dims:
+            names.append(v)
+    return names
 
 
 def _coarse_grain_fv_core_via_hybrid_method(
@@ -552,67 +595,54 @@ def _coarse_grain_fv_core_via_hybrid_method(
     coarsen_agrid_winds=False,
     mass_weighted=True,
 ):
-    coarsened_on_model_levels = _coarse_grain_fv_core(
-        ds, delp, area, dx, dy, coarsening_factor, coarsen_agrid_winds, mass_weighted
-    )
-    coarsened_on_pressure_levels = _coarse_grain_fv_core_on_pressure(
+    pressure_level = _coarse_grain_fv_core_on_pressure(
         ds, delp, area, dx, dy, coarsening_factor, coarsen_agrid_winds
     )
-    blending_factor_agrid = _compute_blending_factor_agrid(
-        delp, area, coarsening_factor, x_dim="xaxis_1", y_dim="yaxis_2"
+    model_level = _coarse_grain_fv_core(
+        ds, delp, area, dx, dy, coarsening_factor, coarsen_agrid_winds, mass_weighted
     )
-    blending_factor_dgrid_u = _compute_blending_factor_dgrid(
+    weights_agrid = _compute_blending_weights_agrid(
+        delp, area, coarsening_factor, x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_CENTER
+    )
+    weights_dgrid_u = _compute_blending_weights_dgrid(
         delp, dx, coarsening_factor, "x", x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_OUTER
     )
-    blending_factor_dgrid_v = _compute_blending_factor_dgrid(
+    weights_dgrid_v = _compute_blending_weights_dgrid(
         delp, dy, coarsening_factor, "y", x_dim=FV_CORE_X_OUTER, y_dim=FV_CORE_Y_CENTER
     )
-    agrid_3d_names = [
-        v
-        for v in ds.data_vars
-        if v not in ["u", "v"] and RESTART_Z_CENTER in ds[v].dims
-    ]
-    agrid_2d_names = [v for v in ds.data_vars if RESTART_Z_CENTER not in ds[v].dims]
+    names_2d_agrid = _2d_fv_core_names_agrid(ds)
+    names_3d_agrid = _3d_fv_core_names_agrid(ds)
 
-    agrid_3d_fields = _blend(
-        blending_factor_agrid,
-        coarsened_on_pressure_levels[agrid_3d_names],
-        coarsened_on_model_levels[agrid_3d_names],
+    # 2D fields could come from either the pressure level or model level results
+    fields_2d_agrid = model_level[names_2d_agrid]
+    fields_3d_agrid = blend(
+        weights_agrid, pressure_level[names_3d_agrid], model_level[names_3d_agrid]
     )
-    agrid_2d_fields = coarsened_on_model_levels[
-        agrid_2d_names
-    ]  # Could be from either pressure or model level ds
-    u = _blend(
-        blending_factor_dgrid_u,
-        coarsened_on_pressure_levels.u,
-        coarsened_on_model_levels.u,
-    ).rename("u")
-    v = _blend(
-        blending_factor_dgrid_v,
-        coarsened_on_pressure_levels.v,
-        coarsened_on_model_levels.v,
-    ).rename("v")
-    return xr.merge([agrid_3d_fields, agrid_2d_fields, u, v])
+    u = blend(weights_dgrid_u, pressure_level.u, model_level.u).rename("u")
+    v = blend(weights_dgrid_v, pressure_level.v, model_level.v).rename("v")
+    return xr.merge([fields_2d_agrid, fields_3d_agrid, u, v])
 
 
 def _coarse_grain_fv_tracer_via_hybrid_method(
     ds, delp, area, coarsening_factor, mass_weighted=True
 ):
-    coarsened_on_model_levels = _coarse_grain_fv_tracer(
-        ds, delp, area, coarsening_factor, mass_weighted
-    )
-    coarsened_on_pressure_levels = _coarse_grain_fv_tracer_on_pressure(
+    pressure_level = _coarse_grain_fv_tracer_on_pressure(
         ds, delp, area, coarsening_factor
     )
-    blending_factor = _compute_blending_factor_agrid(
-        delp, area, coarsening_factor, x_dim="xaxis_1", y_dim="yaxis_1"
+    model_level = _coarse_grain_fv_tracer(
+        ds, delp, area, coarsening_factor, mass_weighted
     )
-    return _blend(
-        blending_factor, coarsened_on_pressure_levels, coarsened_on_model_levels
+    weights = _compute_blending_weights_agrid(
+        delp,
+        area,
+        coarsening_factor,
+        x_dim=FV_TRACER_X_CENTER,
+        y_dim=FV_TRACER_Y_CENTER,
     )
+    return blend(weights, pressure_level, model_level)
 
 
-def compute_edge_delp(delp, edge, x_dim="xaxis_1", y_dim="yaxis_2"):
+def compute_edge_delp(delp, edge, x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_CENTER):
     """Compute the pressure thickness on grid cell edges
 
     Args:
@@ -657,36 +687,17 @@ def _coarse_grain_fv_tracer(ds, delp, area, coarsening_factor, mass_weighted=Tru
     coarsening_factor : int
         Coarsening factor to use
     mass_weighted: bool
-        Whether to weight by mass
+        Whether to weight mixing ratios by mass
 
     Returns
     -------
     xr.Dataset
     """
     if mass_weighted:
-        area_weighted_vars = ["cld_amt"]
-        mass_weighted_vars = [
-            "sphum",
-            "liq_wat",
-            "rainwat",
-            "ice_wat",
-            "snowwat",
-            "graupel",
-            "o3mr",
-            "sgs_tke",
-        ]
+        area_weighted_vars = FRACTION_TRACERS
+        mass_weighted_vars = MIXING_RATIO_TRACERS
     else:
-        area_weighted_vars = [
-            "cld_atm",
-            "sphum",
-            "liq_wat",
-            "rainwat",
-            "ice_wat",
-            "snowwat",
-            "graupel",
-            "o3mr",
-            "sgs_tke",
-        ]
+        area_weighted_vars = FRACTION_TRACERS + MIXING_RATIO_TRACERS
         mass_weighted_vars = []
 
     area_weighted = weighted_block_average(
@@ -728,17 +739,8 @@ def _coarse_grain_fv_tracer_on_pressure(ds, delp, area, coarsening_factor):
     -------
     xr.Dataset
     """
-    area_weighted_vars = ["cld_amt"]
-    masked_area_weighted_vars = [
-        "sphum",
-        "liq_wat",
-        "rainwat",
-        "ice_wat",
-        "snowwat",
-        "graupel",
-        "o3mr",
-        "sgs_tke",
-    ]
+    area_weighted_vars = FRACTION_TRACERS
+    masked_area_weighted_vars = MIXING_RATIO_TRACERS
 
     ds_regridded, masked_area = regrid_to_area_weighted_pressure(
         ds,

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -539,7 +539,7 @@ def _compute_blending_weights_agrid(
     delp, area, coarsening_factor, x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_CENTER
 ):
     """Compute the blending weights on the A-grid.
-    
+
     This follows the approach Chris describes in Section 7 of `this document
     <https://drive.google.com/file/d/1FyLTnR1C5_Ab5Tdbbuhtxm52VC-NroJG/view>`_.
     Here the blending pressure is computed to be 0.9 times the value of the
@@ -547,7 +547,7 @@ def _compute_blending_weights_agrid(
     the blending weights are then given by the following equation:
 
     .. math::
-        b_k^c = \begin{cases} 
+        b_k^c = \begin{cases}
             1 & p_k^c \leq p_b^c \\
             \frac{p_s^c - p_k^c}{p_s^c - p_b^c} & p_k^c > p_b^c
         \end{cases}
@@ -556,7 +556,7 @@ def _compute_blending_weights_agrid(
     :math:`p_k^c` is the pressure at the midpoint of level :math:`k` on the
     coarse grid, :math:`p_b^c` is the blending pressure, and :math:`p_s^c` is
     the surface pressure on the coarse grid.
-    """
+    """  # noqa: W605
     delp_coarse = weighted_block_average(
         delp, area, coarsening_factor, x_dim=x_dim, y_dim=y_dim
     )
@@ -580,7 +580,7 @@ def _compute_blending_weights_dgrid(
     then given by the following equation:
 
     .. math::
-        b_k^c = \begin{cases} 
+        b_k^c = \begin{cases}
             1 & p_k^c \leq p_b^c \\
             \frac{p_s^c - p_k^c}{p_s^c - p_b^c} & p_k^c > p_b^c
         \end{cases}
@@ -589,7 +589,7 @@ def _compute_blending_weights_dgrid(
     :math:`p_k^c` is the pressure at the midpoint of level :math:`k` on the
     coarse grid edge, :math:`p_b^c` is the blending pressure, and :math:`p_s^c`
     is the surface pressure on the coarse grid edge.
-    """
+    """  # noqa: W605
     delp_edge = compute_edge_delp(delp, edge, x_dim=x_dim, y_dim=y_dim)
     delp_edge_coarse = edge_weighted_block_average(
         delp_edge, length, coarsening_factor, x_dim=x_dim, y_dim=y_dim, edge=edge
@@ -607,7 +607,7 @@ def _compute_blending_weights_dgrid(
 
 def blend(weights, pressure_level, model_level):
     """Blend two coarse-grained Datasets or DataArrays using the provided weights.
-    
+
     Args:
         weights: xr.DataArray
             Weights used to blend the two sources together.
@@ -722,7 +722,7 @@ def _coarse_grain_fv_tracer_via_hybrid_method(
 
     Returns
     -------
-    xr.Dataset 
+    xr.Dataset
     """
     pressure_level = _coarse_grain_fv_tracer_on_pressure(
         ds, delp, area, coarsening_factor

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -54,7 +54,7 @@ X_DIM = "xaxis_1"
 Y_DIM = "yaxis_1"
 SIGMA_BLEND = 0.9
 FRACTION_TRACERS = ["cld_amt"]  # Always are area-weighted.
-MIXING_RATIO_TRACERS = [
+NON_FRACTION_TRACERS = [
     "sphum",
     "liq_wat",
     "rainwat",
@@ -733,7 +733,7 @@ def _coarse_grain_fv_tracer_via_blended_method(
     coarsening_factor : int
         Coarsening factor to use
     mass_weighted: bool
-        Whether to weight mixing ratios by mass during the model-level
+        Whether to weight mixing ratios and TKE by mass during the model-level
         coarsening process.
 
     Returns
@@ -801,7 +801,7 @@ def _coarse_grain_fv_tracer(ds, delp, area, coarsening_factor, mass_weighted=Tru
     coarsening_factor : int
         Coarsening factor to use
     mass_weighted: bool
-        Whether to weight mixing ratios by mass
+        Whether to weight mixing ratios and TKE by mass
 
     Returns
     -------
@@ -809,9 +809,9 @@ def _coarse_grain_fv_tracer(ds, delp, area, coarsening_factor, mass_weighted=Tru
     """
     if mass_weighted:
         area_weighted_vars = FRACTION_TRACERS
-        mass_weighted_vars = MIXING_RATIO_TRACERS
+        mass_weighted_vars = NON_FRACTION_TRACERS
     else:
-        area_weighted_vars = FRACTION_TRACERS + MIXING_RATIO_TRACERS
+        area_weighted_vars = FRACTION_TRACERS + NON_FRACTION_TRACERS
         mass_weighted_vars = []
 
     area_weighted = weighted_block_average(
@@ -854,7 +854,7 @@ def _coarse_grain_fv_tracer_on_pressure(ds, delp, area, coarsening_factor):
     xr.Dataset
     """
     area_weighted_vars = FRACTION_TRACERS
-    masked_area_weighted_vars = MIXING_RATIO_TRACERS
+    masked_area_weighted_vars = NON_FRACTION_TRACERS
 
     ds_regridded, masked_area = regrid_to_area_weighted_pressure(
         ds,

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -1005,7 +1005,7 @@ def _doubles_to_floats(ds: xr.Dataset):
     for key in ds.data_vars:
         var = ds[key]
         if _is_float(var):
-            data_vars[key] = ds[key].astype(np.float32).drop(var.coords)
+            data_vars[key] = ds[key].astype(np.float32).drop_vars(var.coords)
 
     return xr.Dataset(data_vars, coords=coords)
 

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -238,8 +238,8 @@ def coarsen_restarts_via_hybrid_method(
     Args:
         coarsening_factor: the amount of coarsening to apply. C384 to C48 is a
             factor of 8.
-        grid_spec: Dataset containing the variables area, dx, dy. restarts:
-        dictionary of restart data. Must have the keys
+        grid_spec: Dataset containing the variables area, dx, dy.
+        restarts: dictionary of restart data. Must have the keys
             "fv_core.res", "fv_srf_wnd.res", "fv_tracer.res", and "sfc_data".
         coarsen_agrid_winds: flag indicating whether to coarsen A-grid winds in
             "fv_core.res" restart files (default False).

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -16,6 +16,7 @@ from ..calc.thermo.vertically_dependent import (
     pressure_at_midpoint_log,
     surface_pressure_from_delp,
 )
+from ..calc.thermo.constants import _TOA_PRESSURE
 from .coarsen import (
     block_coarsen,
     block_edge_coarsen,
@@ -541,7 +542,7 @@ def _compute_blending_weights_agrid(
     coarsening_factor,
     x_dim=FV_CORE_X_CENTER,
     y_dim=FV_CORE_Y_CENTER,
-    toa_pressure=300,
+    toa_pressure=_TOA_PRESSURE,
 ):
     """Compute the blending weights on the A-grid.
 
@@ -581,7 +582,7 @@ def _compute_blending_weights_agrid(
 
 
 def _compute_blending_weights_dgrid(
-    delp, length, coarsening_factor, edge, x_dim, y_dim, toa_pressure=300
+    delp, length, coarsening_factor, edge, x_dim, y_dim, toa_pressure=_TOA_PRESSURE
 ):
     """This follows the approach Chris describes in Section 7 of `this document
     <https://drive.google.com/file/d/1FyLTnR1C5_Ab5Tdbbuhtxm52VC-NroJG/view>`_,

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -224,14 +224,14 @@ def coarsen_restarts_on_pressure(
     return coarsened
 
 
-def coarsen_restarts_via_hybrid_method(
+def coarsen_restarts_via_blended_method(
     coarsening_factor: int,
     grid_spec: xr.Dataset,
     restarts: Mapping[str, xr.Dataset],
     coarsen_agrid_winds: bool = False,
     mass_weighted: bool = True,
 ) -> Mapping[str, xr.Dataset]:
-    """Coarsen a complete set of restart files using the hybrid pressure-level
+    """Coarsen a complete set of restart files using the blended pressure-level
     / model-level coarse-graining method for 3D fields and the 'complex' surface
     coarsening method for surface data.
 
@@ -255,7 +255,7 @@ def coarsen_restarts_via_hybrid_method(
 
     coarsened = {}
 
-    coarsened["fv_core.res"] = _coarse_grain_fv_core_via_hybrid_method(
+    coarsened["fv_core.res"] = _coarse_grain_fv_core_via_blended_method(
         restarts["fv_core.res"],
         restarts["fv_core.res"].delp,
         grid_spec.area.rename(
@@ -280,7 +280,7 @@ def coarsen_restarts_via_hybrid_method(
         coarsening_factor,
     )
 
-    coarsened["fv_tracer.res"] = _coarse_grain_fv_tracer_via_hybrid_method(
+    coarsened["fv_tracer.res"] = _coarse_grain_fv_tracer_via_blended_method(
         restarts["fv_tracer.res"],
         restarts["fv_core.res"].delp.rename({FV_CORE_Y_CENTER: FV_TRACER_Y_CENTER}),
         grid_spec.area.rename(
@@ -635,7 +635,7 @@ def _3d_fv_core_names_agrid(ds):
     return names
 
 
-def _coarse_grain_fv_core_via_hybrid_method(
+def _coarse_grain_fv_core_via_blended_method(
     ds,
     delp,
     area,
@@ -645,7 +645,7 @@ def _coarse_grain_fv_core_via_hybrid_method(
     coarsen_agrid_winds=False,
     mass_weighted=True,
 ):
-    """Coarse grain a set of fv_core restart files via the hybrid pressure-level
+    """Coarse grain a set of fv_core restart files via the blended pressure-level
     / model-level approach.
 
     Parameters
@@ -700,10 +700,10 @@ def _coarse_grain_fv_core_via_hybrid_method(
     return xr.merge([fields_2d_agrid, fields_3d_agrid, u, v])
 
 
-def _coarse_grain_fv_tracer_via_hybrid_method(
+def _coarse_grain_fv_tracer_via_blended_method(
     ds, delp, area, coarsening_factor, mass_weighted=True
 ):
-    """Coarse grain a set of fv_tracer restart files via the hybrid
+    """Coarse grain a set of fv_tracer restart files via the blended
     pressure-level / model-level approach.
 
     Parameters

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -536,7 +536,12 @@ def compute_blending_weights(blending_pressure, ps_coarse, pfull_coarse):
 
 
 def _compute_blending_weights_agrid(
-    delp, area, coarsening_factor, x_dim=FV_CORE_X_CENTER, y_dim=FV_CORE_Y_CENTER
+    delp,
+    area,
+    coarsening_factor,
+    x_dim=FV_CORE_X_CENTER,
+    y_dim=FV_CORE_Y_CENTER,
+    toa_pressure=300,
 ):
     """Compute the blending weights on the A-grid.
 
@@ -560,9 +565,15 @@ def _compute_blending_weights_agrid(
     delp_coarse = weighted_block_average(
         delp, area, coarsening_factor, x_dim=x_dim, y_dim=y_dim
     )
-    pfull_coarse = pressure_at_midpoint_log(delp_coarse, dim=RESTART_Z_CENTER)
-    ps = surface_pressure_from_delp(delp, vertical_dim=RESTART_Z_CENTER)
-    ps_coarse = surface_pressure_from_delp(delp_coarse, vertical_dim=RESTART_Z_CENTER)
+    pfull_coarse = pressure_at_midpoint_log(
+        delp_coarse, toa_pressure=toa_pressure, dim=RESTART_Z_CENTER
+    )
+    ps = surface_pressure_from_delp(
+        delp, p_toa=toa_pressure, vertical_dim=RESTART_Z_CENTER
+    )
+    ps_coarse = surface_pressure_from_delp(
+        delp_coarse, p_toa=toa_pressure, vertical_dim=RESTART_Z_CENTER
+    )
     blending_pressure = SIGMA_BLEND * block_coarsen(
         ps, coarsening_factor, x_dim=x_dim, y_dim=y_dim, method="min"
     )
@@ -570,7 +581,7 @@ def _compute_blending_weights_agrid(
 
 
 def _compute_blending_weights_dgrid(
-    delp, length, coarsening_factor, edge, x_dim, y_dim
+    delp, length, coarsening_factor, edge, x_dim, y_dim, toa_pressure=300
 ):
     """This follows the approach Chris describes in Section 7 of `this document
     <https://drive.google.com/file/d/1FyLTnR1C5_Ab5Tdbbuhtxm52VC-NroJG/view>`_,
@@ -594,10 +605,14 @@ def _compute_blending_weights_dgrid(
     delp_edge_coarse = edge_weighted_block_average(
         delp_edge, length, coarsening_factor, x_dim=x_dim, y_dim=y_dim, edge=edge
     )
-    pfull_coarse = pressure_at_midpoint_log(delp_edge_coarse, dim=RESTART_Z_CENTER)
-    ps = surface_pressure_from_delp(delp_edge, vertical_dim=RESTART_Z_CENTER)
+    pfull_coarse = pressure_at_midpoint_log(
+        delp_edge_coarse, toa_pressure=toa_pressure, dim=RESTART_Z_CENTER
+    )
+    ps = surface_pressure_from_delp(
+        delp_edge, p_toa=toa_pressure, vertical_dim=RESTART_Z_CENTER
+    )
     ps_coarse = surface_pressure_from_delp(
-        delp_edge_coarse, vertical_dim=RESTART_Z_CENTER
+        delp_edge_coarse, p_toa=toa_pressure, vertical_dim=RESTART_Z_CENTER
     )
     blending_pressure = SIGMA_BLEND * block_edge_coarsen(
         ps, coarsening_factor, edge=edge, x_dim=x_dim, y_dim=y_dim, method="min"


### PR DESCRIPTION
This PR adds a Python implementation of the blended coarse-graining method outlined in [this document](https://drive.google.com/file/d/1FyLTnR1C5_Ab5Tdbbuhtxm52VC-NroJG/view) by Chris.  This is useful as a way to check the fortran implementation, and if we ever want to use this approach offline.

Added public API:
- `vcm.cubedsphere.coarse_restarts.coarsen_restarts_via_blended_method`
- `vcm.cubedsphere.coarsen.block_edge_coarsen`

These two notebooks show that the implied blending factor-- something you can back out once you have the hybrid coarsened, pressure-level coarsened, and model-level coarsened datasets--for some arbitrary columns looks as we would expect it to:
- [Mass-weighted for most 3D variables (our original default)](https://github.com/ai2cm/explore/blob/master/spencerc/2022-10-31-hybrid-coarsening-verification/2022-10-31-mass-weighted-hybrid-coarsening-test.ipynb)
- [Area-weighted for all 3D variables (newly enabled)](https://github.com/ai2cm/explore/blob/master/spencerc/2022-10-31-hybrid-coarsening-verification/2022-10-31-area-weighted-hybrid-coarsening-test.ipynb)

The pressure-level and model-level components themselves were validated in earlier PRs.  The main new aspects in this PR are the blending, and the option to weight strictly by area.

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/5b194e5d-8ac1-4c15-b0cb-78266ec61e4e/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)
