### PR TITLE
Avoid using `module load python/3.9` on Gaea

### DIFF
--- a/.environment-scripts/gaea/activate_conda_environment.sh
+++ b/.environment-scripts/gaea/activate_conda_environment.sh
@@ -3,7 +3,8 @@ set -e
 
 CONDA_ENV=$1
 
-module load python/3.9
-eval "$(conda shell.bash hook)"
+CONDA_PATH=/ncrc/sw/gaea-cle7/python/3.9/anaconda-base
+CONDA_SETUP=“$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)”
+eval “$CONDA_SETUP”
 echo "Activating conda environment: $CONDA_ENV"
 conda activate $CONDA_ENV

--- a/.environment-scripts/gaea/install_base_software.sh
+++ b/.environment-scripts/gaea/install_base_software.sh
@@ -4,8 +4,9 @@ set -e
 INSTALL_PREFIX=$1
 CONDA_ENV=$2
 
-module load python/3.9
-eval "$(conda shell.bash hook)"
+CONDA_PATH=/ncrc/sw/gaea-cle7/python/3.9/anaconda-base
+CONDA_SETUP=“$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)”
+eval “$CONDA_SETUP”
 
 CONDA_PREFIX=$INSTALL_PREFIX/conda
 conda config --add pkgs_dirs $CONDA_PREFIX/pkgs


### PR DESCRIPTION
This PR reverts back to using a hard-coding approach to use the conda installation on Gaea.  While it would be ideal if we could use the `module load` approach, that introduces conflicting software into various paths.  An alternative solution would be to install conda ourselves.

Closes #2074

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/5f27b1d7-34dd-462b-94a1-d763d254c58e/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)