### PR TITLE
Radiation: ccnorm and cloud random overlap options

### DIFF
--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -188,6 +188,8 @@ class RadiationConfig:
             ico2flg=physics_namelist["ico2"],
             iaerflg=physics_namelist["iaer"],
             ialbflg=physics_namelist["ialb"],
+            iovrsw=physics_namelist["iovr_sw"],
+            iovrlw=physics_namelist["iovr_lw"],
             isubcsw=physics_namelist["isubc_sw"],
             isubclw=physics_namelist["isubc_lw"],
             gfs_physics_control=gfs_physics_control,

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -4,29 +4,6 @@ import dataclasses
 LOOKUP_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/lookupdata/lookup.tar.gz"  # noqa: E501
 FORCING_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/data.tar.gz"  # noqa: 501
 
-PHYSICS_NAMELIST_TO_GFS_CONTROL = {
-    "imp_physics": "imp_physics",
-    "ncld": "ncld",
-    "ncnd": "ncld",
-    "fhswr": "fhswr",
-    "fhlwr": "fhlwr",
-    "swhtr": "swhtr",
-    "lwhtr": "lwhtr",
-}
-
-PHYSICS_NAMELIST_TO_RAD_CONFIG = {
-    "iems": "iemsflg",
-    "isol": "isolar",
-    "ico2": "ico2flg",
-    "iaer": "iaerflg",
-    "ialb": "ialbflg",
-    "iovr_sw": "iovrsw",
-    "iovr_lw": "iovrlw",
-    "isubc_sw": "isubcsw",
-    "isubc_lw": "isubclw",
-    "ccnorm": "lcnorm",
-}
-
 
 @dataclasses.dataclass
 class GFSPhysicsControl:
@@ -118,6 +95,25 @@ class GFSPhysicsControl:
     lssav: bool = True
     nsswr: Optional[int] = None
     nslwr: Optional[int] = None
+
+    @classmethod
+    def from_physics_namelist(cls, physics_namelist: Mapping[Hashable, Any]):
+
+        PHYSICS_NAMELIST_TO_GFS_CONTROL = {
+            "imp_physics": "imp_physics",
+            "ncld": "ncld",
+            "ncnd": "ncld",
+            "fhswr": "fhswr",
+            "fhlwr": "fhlwr",
+            "swhtr": "swhtr",
+            "lwhtr": "lwhtr",
+        }
+
+        return cls(
+            **_namelist_to_config_args(
+                physics_namelist, PHYSICS_NAMELIST_TO_GFS_CONTROL
+            )
+        )
 
 
 @dataclasses.dataclass
@@ -215,11 +211,20 @@ class RadiationConfig:
         identical. Remaining values from RadiationConfig defaults.
         """
 
-        gfs_physics_control = GFSPhysicsControl(
-            **_namelist_to_config_args(
-                physics_namelist, PHYSICS_NAMELIST_TO_GFS_CONTROL
-            )
-        )
+        gfs_physics_control = GFSPhysicsControl.from_physics_namelist(physics_namelist)
+
+        PHYSICS_NAMELIST_TO_RAD_CONFIG = {
+            "iems": "iemsflg",
+            "isol": "isolar",
+            "ico2": "ico2flg",
+            "iaer": "iaerflg",
+            "ialb": "ialbflg",
+            "iovr_sw": "iovrsw",
+            "iovr_lw": "iovrlw",
+            "isubc_sw": "isubcsw",
+            "isubc_lw": "isubclw",
+            "ccnorm": "lcnorm",
+        }
 
         return cls(
             **dict(

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -4,6 +4,28 @@ import dataclasses
 LOOKUP_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/lookupdata/lookup.tar.gz"  # noqa: E501
 FORCING_DATA_PATH = "gs://vcm-fv3gfs-serialized-regression-data/physics/forcing/data.tar.gz"  # noqa: 501
 
+PHYSICS_NAMELIST_TO_GFS_CONTROL = {
+    "imp_physics": "imp_physics",
+    "ncld": "ncld",
+    "ncnd": "ncld",
+    "fhswr": "fhswr",
+    "fhlwr": "fhlwr",
+    "swhtr": "swhtr",
+    "lwhtr": "lwhtr",
+}
+
+PHYSICS_NAMELIST_TO_RAD_CONFIG = {
+    "iemsflg": "iems",
+    "isolar": "isol",
+    "ico2flg": "ico2",
+    "iaerflg": "iaer",
+    "ialbflg": "ialb",
+    "iovrsw": "iovr_sw",
+    "iovrlw": "iovr_lw",
+    "isubcsw": "isubc_sw",
+    "isubclw": "isubc_lw",
+}
+
 
 @dataclasses.dataclass
 class GFSPhysicsControl:
@@ -173,24 +195,26 @@ class RadiationConfig:
         """
 
         gfs_physics_control = GFSPhysicsControl(
-            imp_physics=physics_namelist["imp_physics"],
-            ncld=physics_namelist["ncld"],
-            ncnd=physics_namelist["ncld"],
-            fhswr=physics_namelist["fhswr"],
-            fhlwr=physics_namelist["fhlwr"],
-            swhtr=physics_namelist["swhtr"],
-            lwhtr=physics_namelist["lwhtr"],
+            **_namelist_to_config_args(
+                physics_namelist, PHYSICS_NAMELIST_TO_GFS_CONTROL
+            )
         )
 
         return cls(
-            iemsflg=physics_namelist["iems"],
-            isolar=physics_namelist["isol"],
-            ico2flg=physics_namelist["ico2"],
-            iaerflg=physics_namelist["iaer"],
-            ialbflg=physics_namelist["ialb"],
-            iovrsw=physics_namelist["iovr_sw"],
-            iovrlw=physics_namelist["iovr_lw"],
-            isubcsw=physics_namelist["isubc_sw"],
-            isubclw=physics_namelist["isubc_lw"],
-            gfs_physics_control=gfs_physics_control,
+            **dict(
+                **_namelist_to_config_args(
+                    physics_namelist, PHYSICS_NAMELIST_TO_RAD_CONFIG
+                ),
+                gfs_physics_control=gfs_physics_control
+            )
         )
+
+
+def _namelist_to_config_args(
+    namelist: Mapping[Hashable, Any], arg_mapping: Mapping[str, str]
+) -> Mapping[str, Any]:
+    config_args = {}
+    for namelist_entry, config_arg in arg_mapping.items():
+        if namelist_entry in namelist:
+            config_args[config_arg] = namelist[namelist_entry]
+    return config_args

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -24,6 +24,7 @@ PHYSICS_NAMELIST_TO_RAD_CONFIG = {
     "iovr_lw": "iovrlw",
     "isubc_sw": "isubcsw",
     "isubc_lw": "isubclw",
+    "ccnorm": "lcnorm",
 }
 
 

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -150,16 +150,36 @@ class RadiationConfig:
         ico2flg: CO2 data source control flag. In physics namelist as 'ico2'.
         iaerflg: Volcanic aerosols. In physics namelist as 'iaer'.
         ialbflg: Surface albedo control flag. In physics namelist as 'ialb'.
-        icldflg
-        ivflip: Vertical index direction control flag.
-        iovrsw: Cloud overlapping control flag for SW.
-        iovrlw: Cloud overlapping control flag for LW.
+        icldflg:
+        ivflip: Vertical index direction control flag for radiation calculations.
+            0: Top of model to surface
+            1: Surface to top of model
+        iovrsw: Cloud overlapping control flag for shortwave radiation. In physics
+            namelist as 'iovr_sw'.
+            0: random overlapping clouds
+            1: maximum/random overlapping clouds
+            2: maximum overlap cloud (not implemented in port)
+            3: decorrelation-length overlap clouds (not implemented in port)
+        iovrlw: Cloud overlapping control flag for longwave radiation. In physics
+            namelist as 'iovr_lw'.
+            0: random overlapping clouds
+            1: maximum/random overlapping clouds
+            2: maximum overlap cloud (not implemented in port)
+            3: decorrelation-length overlap clouds (not implemented in port)
         isubcsw: Sub-column cloud approx flag in SW radiation. In physics
             namelist as 'isubc_sw'.
+            0: no sub-column cloud treatment, use grid-mean cloud quantities
+            1: MCICA sub-column, prescribed random numbers
+            2: MCICA sub-column, providing optional seed for random numbers
         isubclw: Sub-column cloud approx flag in LW radiation. In physics
             namelist as 'isubc_lw'.
+            0: no sub-column cloud treatment, use grid-mean cloud quantities
+            1: MCICA sub-column, prescribed random numbers
+            2: MCICA sub-column, providing optional seed for random numbers
         lcrick: Control flag for eliminating CRICK.
-        lcnorm: Control flag for in-cld condensate.
+        lcnorm: Control flag for in-cloud condensate. In namelist as `ccnorm`.
+            False: Grid-mean condensate
+            True: Normalize grid-mean condensate by cloud fraction
         lnoprec: Precip effect on radiation flag (ferrier microphysics).
         iswcliq: Optical property for liquid clouds for SW.
         gfs_physics_control: GFSPhysicsControl data class

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -15,15 +15,15 @@ PHYSICS_NAMELIST_TO_GFS_CONTROL = {
 }
 
 PHYSICS_NAMELIST_TO_RAD_CONFIG = {
-    "iemsflg": "iems",
-    "isolar": "isol",
-    "ico2flg": "ico2",
-    "iaerflg": "iaer",
-    "ialbflg": "ialb",
-    "iovrsw": "iovr_sw",
-    "iovrlw": "iovr_lw",
-    "isubcsw": "isubc_sw",
-    "isubclw": "isubc_lw",
+    "iems": "iemsflg",
+    "isol": "isolar",
+    "ico2": "ico2flg",
+    "iaer": "iaerflg",
+    "ialb": "ialbflg",
+    "iovr_sw": "iovrsw",
+    "iovr_lw": "iovrlw",
+    "isubc_sw": "isubcsw",
+    "isubc_lw": "isubclw",
 }
 
 

--- a/external/radiation/radiation/radiation_clouds.py
+++ b/external/radiation/radiation/radiation_clouds.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .phys_const import con_ttp, con_pi, con_g, con_rd, con_thgni
-from .radphysparam import lcrick, lcnorm
+from .radphysparam import lcrick
 
 
 class CloudClass:
@@ -20,10 +20,13 @@ class CloudClass:
     cldssa_def = 0.99
     cldasy_def = 0.84
 
-    def __init__(self, si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw):
+    def __init__(
+        self, si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw, lcnorm
+    ):
 
         self.iovr = max(iovrsw, iovrlw)
         self.ivflip = ivflip
+        self.lcnorm = lcnorm
 
         if rank == 0:
             print(self.VTAGCLD)  # print out version tag
@@ -334,7 +337,7 @@ class CloudClass:
                     crp[i, k] = 0.0
                     csp[i, k] = 0.0
 
-        if lcnorm:
+        if self.lcnorm:
             for k in range(NLAY):
                 for i in range(IX):
                     if cldtot[i, k] >= self.climit:
@@ -625,7 +628,7 @@ class CloudClass:
                     crp[i, k] = 0.0
                     csp[i, k] = 0.0
 
-        if lcnorm:
+        if self.lcnorm:
             for k in range(nlay):
                 for i in range(ix):
                     if cldtot[i, k] >= self.climit:
@@ -862,7 +865,7 @@ class CloudClass:
                     crp[i, k] = 0.0
                     csp[i, k] = 0.0
 
-        if lcnorm:
+        if self.lcnorm:
             for k in range(NLAY):
                 for i in range(IX):
                     if cldtot[i, k] >= self.climit:
@@ -1143,7 +1146,7 @@ class CloudClass:
                     crp[i, k] = 0.0
                     csp[i, k] = 0.0
 
-        if lcnorm:
+        if self.lcnorm:
             for k in range(NLAY):
                 for i in range(IX):
                     if cldtot[i, k] >= self.climit:
@@ -1352,7 +1355,7 @@ class CloudClass:
                     crp[i, k] = 0.0
                     csp[i, k] = 0.0
 
-        if lcnorm:
+        if self.lcnorm:
             for k in range(NLAY):
                 for i in range(IX):
                     if cldtot[i, k] >= self.climit:

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -171,7 +171,7 @@ class RadiationDriver:
         self.sfc = SurfaceClass(rank, ialbflg, iemsflg, semis_file, semis_data)
         #  --- ...  cloud initialization routine
         self.cld = CloudClass(
-            si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw
+            si, NLAY, imp_physics, rank, ivflip, icldflg, iovrsw, iovrlw, lcnorm
         )
         #  --- ...  lw radiation initialization routine
         self.rlw = RadLWClass(rank, iovrlw, isubclw)

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -103,6 +103,13 @@ class RadiationDriver:
                 print("Data usage is limited by initial condition!")
                 print("No volcanic aerosols")
 
+            if (iovrsw not in [0, 1]) or (iovrlw not in [0, 1]):
+                raise ValueError(
+                    "Only implemented overlap options in Python port of radiation "
+                    "scheme are 0 (random overlap) and 1 (maximum-random overlap)."
+                    f" Got iovrsw={iovrsw}, iovrlw={iovrlw}."
+                )
+
             if isubclw == 0:
                 print(
                     f"- ISUBCLW={isubclw}, No McICA, use grid ",

--- a/external/radiation/radiation/radlw/radlw_main.py
+++ b/external/radiation/radiation/radlw/radlw_main.py
@@ -63,7 +63,7 @@ def mcica_subcol(iovrlw, cldf, nlay, dz, de_lgth, iplon, rand2d):
     rand2d = rand2d[iplon, :]
     # random or max-random overlap
     cdfunc = np.reshape(rand2d, (ngptlw, nlay))
-    print("Creating random numbers for LW random overlap.")
+
     # ===> ...  begin here
     #
     #  --- ...  advance randum number generator by ipseed values
@@ -86,7 +86,6 @@ def mcica_subcol(iovrlw, cldf, nlay, dz, de_lgth, iplon, rand2d):
                     cdfunc[n, k] = cdfunc[n, k1]
                 else:
                     cdfunc[n, k] = cdfunc[n, k] * tem1
-        print("Modifying random numbers for LW max-random overlap.")
 
     #  --- ...  generate subcolumns for homogeneous clouds
     tem1 = 1.0 - cldf

--- a/external/radiation/radiation/radlw/radlw_main.py
+++ b/external/radiation/radiation/radlw/radlw_main.py
@@ -63,6 +63,7 @@ def mcica_subcol(iovrlw, cldf, nlay, dz, de_lgth, iplon, rand2d):
     rand2d = rand2d[iplon, :]
     # random or max-random overlap
     cdfunc = np.reshape(rand2d, (ngptlw, nlay))
+    print("Creating random numbers for LW random overlap.")
     # ===> ...  begin here
     #
     #  --- ...  advance randum number generator by ipseed values
@@ -85,6 +86,8 @@ def mcica_subcol(iovrlw, cldf, nlay, dz, de_lgth, iplon, rand2d):
                     cdfunc[n, k] = cdfunc[n, k1]
                 else:
                     cdfunc[n, k] = cdfunc[n, k] * tem1
+        print("Modifying random numbers for LW max-random overlap.")
+
     #  --- ...  generate subcolumns for homogeneous clouds
     tem1 = 1.0 - cldf
     lcloudy = cdfunc >= tem1

--- a/external/radiation/radiation/radlw/radlw_main.py
+++ b/external/radiation/radiation/radlw/radlw_main.py
@@ -61,13 +61,14 @@ def mcica_subcol(iovrlw, cldf, nlay, dz, de_lgth, iplon, rand2d):
     #  =====================    end of definitions    ====================  !
 
     rand2d = rand2d[iplon, :]
+    # random or max-random overlap
     cdfunc = np.reshape(rand2d, (ngptlw, nlay))
     # ===> ...  begin here
     #
     #  --- ...  advance randum number generator by ipseed values
 
     #  --- ...  sub-column set up according to overlapping assumption
-    # it is only implemented for iovrlw == 1
+
     if iovrlw == 1:  # max-ran overlap
         #  ---  first pick a random number for bottom (or top) layer.
         #       then walk up the column: (aer's code)

--- a/external/radiation/radiation/radphysparam.py
+++ b/external/radiation/radiation/radphysparam.py
@@ -209,8 +209,8 @@ isubclw = 0
 
 # eliminating CRICK control flag
 lcrick = False
-# in-cld condensate control flag
-lcnorm = False
+# in-cld condensate control flag (for Python port: read from namelist instead)
+# lcnorm = False
 # precip effect on radiation flag (Ferrier microphysics)
 lnoprec = False
 # shallow convetion flag

--- a/external/radiation/radiation/radsw/radsw_main.py
+++ b/external/radiation/radiation/radsw/radsw_main.py
@@ -762,13 +762,15 @@ def mcica_subcol(iovrsw, cldf, nlay, dz, de_lgth, ipt, rand2d):
     cdfunc = np.zeros((nlay, ngptsw))
     #  --- ...  sub-column set up according to overlapping assumption
 
-    if iovrsw == 1:  # max-ran overlap
+    if iovrsw < 2:  # random or max-random overlap
 
         k1 = 0
         for n in range(ngptsw):
             for k in range(nlay):
                 cdfunc[k, n] = rand2d[k1]
                 k1 = k1 + 1
+
+    if iovrsw == 1:  # max-ran overlap
 
         #  ---  first pick a random number for bottom/top layer.
         #       then walk up the column: (aer's code)

--- a/external/radiation/radiation/radsw/radsw_main.py
+++ b/external/radiation/radiation/radsw/radsw_main.py
@@ -770,6 +770,8 @@ def mcica_subcol(iovrsw, cldf, nlay, dz, de_lgth, ipt, rand2d):
                 cdfunc[k, n] = rand2d[k1]
                 k1 = k1 + 1
 
+        print("Creating random numbers for SW random overlap.")
+
     if iovrsw == 1:  # max-ran overlap
 
         #  ---  first pick a random number for bottom/top layer.
@@ -787,6 +789,8 @@ def mcica_subcol(iovrsw, cldf, nlay, dz, de_lgth, ipt, rand2d):
                     cdfunc[k, n] = cdfunc[k1, n]
                 else:
                     cdfunc[k, n] = cdfunc[k, n] * tem1
+
+        print("Modifying random numbers for SW max-random overlap.")
 
     #  --- ...  generate subcolumns for homogeneous clouds
 

--- a/external/radiation/radiation/radsw/radsw_main.py
+++ b/external/radiation/radiation/radsw/radsw_main.py
@@ -770,8 +770,6 @@ def mcica_subcol(iovrsw, cldf, nlay, dz, de_lgth, ipt, rand2d):
                 cdfunc[k, n] = rand2d[k1]
                 k1 = k1 + 1
 
-        print("Creating random numbers for SW random overlap.")
-
     if iovrsw == 1:  # max-ran overlap
 
         #  ---  first pick a random number for bottom/top layer.
@@ -789,8 +787,6 @@ def mcica_subcol(iovrsw, cldf, nlay, dz, de_lgth, ipt, rand2d):
                     cdfunc[k, n] = cdfunc[k1, n]
                 else:
                     cdfunc[k, n] = cdfunc[k, n] * tem1
-
-        print("Modifying random numbers for SW max-random overlap.")
 
     #  --- ...  generate subcolumns for homogeneous clouds
 

--- a/external/radiation/tests/test_config.py
+++ b/external/radiation/tests/test_config.py
@@ -1,0 +1,35 @@
+from radiation.config import RadiationConfig
+import pytest
+
+
+@pytest.mark.parametrize(
+    ["namelist", "expected_rad_config"],
+    [
+        pytest.param({}, {"iovrsw": RadiationConfig().iovrsw}, id="default_iovrsw_1"),
+        pytest.param({"iovr_sw": 0}, {"iovrsw": 0}, id="update_iovrsw"),
+    ],
+)
+def test_radiation_config_from_physics_namelist(namelist, expected_rad_config):
+    radiation_config = RadiationConfig.from_physics_namelist(namelist)
+    for k, v in expected_rad_config.items():
+        assert getattr(radiation_config, k) == v
+
+
+@pytest.mark.parametrize(
+    ["namelist", "expected_gfs_physics_control"],
+    [
+        pytest.param(
+            {},
+            {"fhswr": RadiationConfig().gfs_physics_control.fhswr},
+            id="default_fhswr_3600",
+        ),
+        pytest.param({"fhswr": 1800.0}, {"fhswr": 1800.0}, id="update_fhswr",),
+    ],
+)
+def test_gfs_physics_control_from_physics_namelist(
+    namelist, expected_gfs_physics_control
+):
+    radiation_config = RadiationConfig.from_physics_namelist(namelist)
+    gfs_physics_control = radiation_config.gfs_physics_control
+    for k, v in expected_gfs_physics_control.items():
+        assert getattr(gfs_physics_control, k) == v


### PR DESCRIPTION
Allows the radiation port to operate with cloud random overlap namelist option in addition to pre-existing maximum-random overlap option. Also allows the port to scale condensate by cloud fraction (`ccnorm=True`). As always, the radiation port's options are specified to be the same as the Fortran radiation scheme's options in prognostic runs. Also improves some of the docstrings the radiation wrapper. 

Added public API:
- radiation port can be run with GFS physics namelist options `ccnorm`: `True` and `iovr_sw`/`iovr_lw`: `0`.

- [X] Tests added

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/84e459c2-e8fb-4e16-9df2-764a959f737c/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)