### PR TITLE
Remove some fv3fit test cases, mark others as slow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,6 @@ update_submodules:
 		external/fv3gfs-fortran \
 
 
-overwrite_baseline_images:
-	pytest tests/test_diagnostics_plots.py --mpl-generate-path tests/baseline_images
-
-
 ############################################################
 # Dependency Management
 ############################################################

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,6 +11,7 @@ altair==4.1.0
 anyio==2.2.0
 apache-beam==2.37.0
 appdirs==1.4.4
+appnope==0.1.3
 argcomplete==1.12.0
 argon2-cffi==20.1.0
 asciitree==0.3.3
@@ -226,7 +227,6 @@ pympler==1.0.1
 pyparsing==2.4.7
 pyrsistent==0.14.11
 pytest-forked==1.4.0
-pytest-mpl==0.15.1
 pytest-regtest==1.4.4
 pytest-timeout==1.4.2
 pytest-xdist==1.34.0
@@ -302,7 +302,6 @@ urllib3==1.26.8
 validators==0.18.2
 virtualenv==20.0.33
 wandb==0.12.1
-watchdog==2.1.9
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==1.2.3

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -178,6 +178,7 @@ def test_cyclegan_visual(tmpdir):
     plt.show()
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("conv_type", ["conv2d", "halo_conv2d"])
 def test_cyclegan_runs_without_errors(tmpdir, conv_type: str, regtest):
     fv3fit.set_random_seed(0)

--- a/external/fv3fit/fv3fit/pytorch/recurrent/test_fmr.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/test_fmr.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 from typing import Sequence
+import pytest
 from fv3fit.pytorch.recurrent import (
     FMRHyperparameters,
     FMRNetworkConfig,
@@ -54,6 +55,7 @@ def tfdataset_to_xr_dataset(tfdataset, dims: Sequence[str]):
     return xr.Dataset(data_vars)
 
 
+@pytest.mark.slow
 def test_fmr_runs_without_errors(tmpdir):
     fv3fit.set_random_seed(0)
     # run the test in a temporary directory to delete artifacts when done

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -509,12 +509,14 @@ def cli_main(args: argparse.Namespace):
             id="random_forest",
         ),
         pytest.param(
-            "convolutional", {}, ["dQ1", "dQ2"], False, True, id="convolutional"
+            "convolutional", {}, ["dQ1", "dQ2"], False, False, id="convolutional"
         ),
         pytest.param(
-            "precipitative", {}, ["dQ1", "dQ2"], True, False, id="precipitative"
+            "precipitative", {}, ["dQ1", "dQ2"], False, False, id="precipitative"
         ),
-        pytest.param("dense", {}, ["dQ1", "dQ2"], True, False, id="dense"),
+        pytest.param("dense", {}, ["dQ1", "dQ2"], False, False, id="dense"),
+        pytest.param("dense", {}, ["dQ1", "dQ2"], True, False, id="dense-use-local"),
+        pytest.param("dense", {}, ["dQ1", "dQ2"], False, True, id="dense-use-valid"),
     ],
 )
 @pytest.mark.slow

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -497,7 +497,8 @@ def cli_main(args: argparse.Namespace):
 
 
 @pytest.mark.parametrize(
-    "model_type, hyperparameter_dict, output_variables, use_local_download_path, use_validation_data",
+    "model_type, hyperparameter_dict, output_variables, "
+    "use_local_download_path, use_validation_data",
     [
         pytest.param(
             "sklearn_random_forest",

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -497,22 +497,24 @@ def cli_main(args: argparse.Namespace):
 
 
 @pytest.mark.parametrize(
-    "model_type, hyperparameter_dict, output_variables",
+    "model_type, hyperparameter_dict, output_variables, use_local_download_path, use_validation_data",
     [
         pytest.param(
             "sklearn_random_forest",
             {"max_depth": 4, "n_estimators": 2},
             ["Qm", "Q2"],
+            False,
+            False,
             id="random_forest",
         ),
-        pytest.param("convolutional", {}, ["dQ1", "dQ2"], id="convolutional"),
-        pytest.param("precipitative", {}, ["dQ1", "dQ2"], id="precipitative"),
-        pytest.param("dense", {}, ["dQ1", "dQ2"], id="dense"),
+        pytest.param(
+            "convolutional", {}, ["dQ1", "dQ2"], False, True, id="convolutional"
+        ),
+        pytest.param(
+            "precipitative", {}, ["dQ1", "dQ2"], True, False, id="precipitative"
+        ),
+        pytest.param("dense", {}, ["dQ1", "dQ2"], True, False, id="dense"),
     ],
-)
-@pytest.mark.parametrize(
-    "use_local_download_path, use_validation_data",
-    [(False, False), (False, True), (True, False)],
 )
 @pytest.mark.slow
 def test_cli(

--- a/external/fv3fit/tests/training/test_train_novelty_detection.py
+++ b/external/fv3fit/tests/training/test_train_novelty_detection.py
@@ -43,7 +43,7 @@ def train_novelty_detector(
         cls = get_hyperparameter_class(model_type)
         hyperparameters = cls.init_testing(input_variables, output_variables)
     input_variables, _, test_dataset = get_dataset_default(sample_func)
-    train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(10)])
+    train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(2)])
     # val_tfdataset is discarded and not used for training
     val_tfdataset = tfdataset_from_batches([test_dataset])
     train = fv3fit.get_training_function(model_type)
@@ -118,24 +118,22 @@ def assert_extreme_novelties(
     assert out_dataset[NoveltyDetector._NOVELTY_OUTPUT_VAR].mean() > 0
 
 
-@pytest.mark.slow
-def test_train_novelty_default_correct_output(model_type: str, regtest):
+def test_train_novelty_default_correct_output(model_type: str):
     """
     The model has properly formatted output, including (1) thesame dimensions as the
     input (besides the vertical dimension), (2) the correct data variable, and
     (3) outputs in the correct [0, 1] range.
     """
-    n_sample, n_tile, nx, ny, n_feature = 10, 6, 12, 12, 2
+    n_sample, n_tile, nx, ny, n_feature = 2, 2, 6, 6, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
     assert_correct_output(model_type, sample_func)
 
 
-@pytest.mark.slow
-def test_train_novelty_default_extreme_novelties(model_type: str, regtest):
+def test_train_novelty_default_extreme_novelties(model_type: str):
     """
     When testing coordinates are scaled by a very large amount, nearly every sample is
     deemed a novelty.
     """
-    n_sample, n_tile, nx, ny, n_feature = 10, 6, 12, 12, 2
+    n_sample, n_tile, nx, ny, n_feature = 2, 2, 6, 6, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_tile, nx, ny, n_feature))
     assert_extreme_novelties(model_type, sample_func)

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -55,4 +55,3 @@ jupyterlab
 
 # fv3fit testing tools
 hypothesis
-pytest-mpl


### PR DESCRIPTION
The fv3fit unit tests are slow (roughly 10 minutes). This PR makes a small attempt to ease the test burden. 

- It removes some particular parameter combinations for the `test_cli` test (saved 2 minutes on my Mac)
- uses smaller dataset sizes for novelty detectors tests (about 20x speedup for module, saving 30-40s)
- marks a couple slow (cyclegan/fmr) tests as slow.
- deletes an unused requirement (`pytest-mpl`).

Requirement changes:
- Removed `pytest-mpl` from `pip-requirements.txt`
- [x] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [x] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

Improves situation described in #2057 

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/82db1038-f843-4339-9d51-b4632823e35e/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)