### PR TITLE
Add reload_path option to CycleGANNetworkConfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
           - post_process_run
           - fv3net
           - fv3fit
+          - fv3fit_torch
           - dataflow
           - artifacts
     machine:
@@ -286,6 +287,11 @@ workflows:
       - build_default:
           name: "build/push fv3fit image"
           image: fv3fit
+          requires:
+            - pytest
+      - build_default:
+          name: "build/push fv3fit_torch image"
+          image: fv3fit_torch
           requires:
             - pytest
       # manually trigger on PRs

--- a/external/fv3fit/fv3fit/pytorch/recurrent/train_fmr.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/train_fmr.py
@@ -106,9 +106,6 @@ class FMRNetworkConfig:
         state_variables: Sequence[str],
         scalers: Mapping[str, StandardScaler],
     ) -> "FMRTrainer":
-        if self.reload_path is not None:
-            fmr_reload = FullModelReplacement.load(self.reload_path)
-            scalers = fmr_reload.scalers
         if self.convolution_type == "conv2d":
             convolution = single_tile_convolution
         elif self.convolution_type == "halo_conv2d":
@@ -127,6 +124,9 @@ class FMRNetworkConfig:
         )
         init_weights(generator)
         init_weights(discriminator)
+        if self.reload_path is not None:
+            fmr_reload = FullModelReplacement.load(self.reload_path)
+            scalers = fmr_reload.scalers
         fmr = FullModelReplacement(
             model=FMRModule(generator=generator, discriminator=discriminator),
             scalers=scalers,

--- a/projects/cyclegan/0K_to_8K/run_local.sh
+++ b/projects/cyclegan/0K_to_8K/run_local.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python3 -m fv3fit.train training.yaml train-data.yaml output --validation-data-config validation-data.yaml --no-wandb

--- a/projects/cyclegan/0K_to_8K/train-data.yaml
+++ b/projects/cyclegan/0K_to_8K/train-data.yaml
@@ -1,6 +1,6 @@
 batch_size: 500
 domain_configs:
-  - data_path: gs://vcm-ml-experiments/spencerc/2021-05-24/n2f-25km-baseline-unperturbed/fv3gfs_run/atmos_dt_atmos.zarr
+  - data_path: gs://vcm-ml-experiments/mcgibbon/2022-11-09/n2f-25km-0K-merged.zarr
     unstacked_dims:
       - time
       - tile
@@ -11,7 +11,7 @@ domain_configs:
     default_variable_config:
       times: window
     n_windows: 2000  # 5808
-  - data_path: gs://vcm-ml-experiments/spencerc/2021-08-11/n2f-25km-baseline-plus-8k/fv3gfs_run/atmos_dt_atmos.zarr
+  - data_path: gs://vcm-ml-experiments/mcgibbon/2022-11-09/n2f-25km-8K-merged.zarr
     unstacked_dims:
       - time
       - tile

--- a/projects/cyclegan/0K_to_8K/training.yaml
+++ b/projects/cyclegan/0K_to_8K/training.yaml
@@ -36,6 +36,7 @@ hyperparameters:
       cycle_weight: 10.0
       generator_weight: 1.0
       discriminator_weight: 1.0
+      reload_path: gs://vcm-ml-experiments/cyclegan/2022-11-10/cyclegan_0K_to_8K-trial-0/
     training:
       n_epoch: 50
       in_memory: true

--- a/projects/cyclegan/0K_to_8K/training.yaml
+++ b/projects/cyclegan/0K_to_8K/training.yaml
@@ -1,9 +1,10 @@
 model_type: cyclegan
 cache:
-  in_memory: true
+  in_memory: false
 hyperparameters:
     state_variables:
       - h500
+      - PRATEsfc
     normalization_fit_samples: 50_000
     network:
       convolution_type: halo_conv2d
@@ -31,12 +32,12 @@ hyperparameters:
         loss_type: mae
       gan_loss:
         loss_type: mse
-      identity_weight: 0.5
+      identity_weight: 0.1
       cycle_weight: 10.0
       generator_weight: 1.0
       discriminator_weight: 1.0
     training:
-      n_epoch: 100
+      n_epoch: 50
       in_memory: true
       shuffle_buffer_size: 1000
       samples_per_batch: 1

--- a/projects/cyclegan/0K_to_8K/validation-data.yaml
+++ b/projects/cyclegan/0K_to_8K/validation-data.yaml
@@ -1,6 +1,6 @@
 batch_size: 500
 domain_configs:
-  - data_path: gs://vcm-ml-experiments/spencerc/2021-05-24/n2f-25km-baseline-unperturbed/fv3gfs_run/atmos_dt_atmos.zarr
+  - data_path: gs://vcm-ml-experiments/mcgibbon/2022-11-09/n2f-25km-0K-merged.zarr
     unstacked_dims:
       - time
       - tile
@@ -11,7 +11,7 @@ domain_configs:
     default_variable_config:
       times: window
     n_windows: 50  # 5808
-  - data_path: gs://vcm-ml-experiments/spencerc/2021-08-11/n2f-25km-baseline-plus-8k/fv3gfs_run/atmos_dt_atmos.zarr
+  - data_path: gs://vcm-ml-experiments/mcgibbon/2022-11-09/n2f-25km-8K-merged.zarr
     unstacked_dims:
       - time
       - tile

--- a/projects/cyclegan/kustomization.yaml
+++ b/projects/cyclegan/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 kind: Kustomization
 images:
 - name: us.gcr.io/vcm-ml/fv3net
-  newTag: &tag 25a31af18771a11e7de671ba000c630f0b668a7e
+  newTag: &tag 567111db8a8a386ea661478790c18a9917c4436b
 - name: us.gcr.io/vcm-ml/post_process_run
   newTag: *tag
 - name: us.gcr.io/vcm-ml/prognostic_run

--- a/projects/cyclegan/prepare_datasets.py
+++ b/projects/cyclegan/prepare_datasets.py
@@ -1,0 +1,18 @@
+import xarray as xr
+from datetime import datetime
+
+if __name__ == "__main__":
+    paths = {
+        "neg4K": "gs://vcm-ml-experiments/spencerc/2021-06-14/n2f-25km-baseline-minus-4k/fv3gfs_run/",  # noqa: E501
+        "0K": "gs://vcm-ml-experiments/spencerc/2021-05-24/n2f-25km-baseline-unperturbed/fv3gfs_run/",  # noqa: E501
+        "4K": "gs://vcm-ml-experiments/spencerc/2021-05-24/n2f-25km-baseline-plus-4k/fv3gfs_run/",  # noqa: E501
+        "8K": "gs://vcm-ml-experiments/spencerc/2021-08-11/n2f-25km-baseline-plus-8k/fv3gfs_run/",  # noqa: E501
+    }
+    date_string = datetime.now().strftime("%Y-%m-%d")
+    for name, path in paths.items():
+        ds_atmos = xr.open_zarr(path + "atmos_dt_atmos.zarr")
+        ds_sfc = xr.open_zarr(path + "sfc_dt_atmos.zarr")
+        ds = xr.merge([ds_atmos, ds_sfc])
+        out_path = f"gs://vcm-ml-experiments/mcgibbon/{date_string}/n2f-25km-{name}-merged.zarr"  # noqa: E501
+        print(f"writing zarr to {out_path}")
+        ds.to_zarr(out_path, consolidated=True)


### PR DESCRIPTION
This PR adds the ability to continue training CycleGAN from a previously saved model.

Added public API:
- added reload_path option to CycleGANNetworkConfig

Significant internal changes:
- Updated CycleGAN project files
- fv3fit_torch image is now automatically built on CircleCI

- [ ] Tests added 

Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/98db66e2-7874-403b-84c9-995bd3228d52/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)