### PR TITLE
Flake8 in pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,15 @@
 exclude: "external/gcsfs/"
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v2.3.0
     hooks:
     - id: check-added-large-files
-      args: [--enforce-all, --maxkb=250]
+      args: [--maxkb=250]
       exclude: "\
       workflows/fine_res_budget/tests/diag.json|\
       external/vcm/tests/test_data/test_data.tar"
     - id: trailing-whitespace
       exclude: "external/radiation"
--   repo: https://github.com/psf/black
-    rev: 19.10b0
-    hooks:
-    - id: black
-      additional_dependencies: ["click==8.0.4"]
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
-    hooks:
     - id: flake8
       name: flake8
       language_version: python3
@@ -28,6 +20,11 @@ repos:
       files: "__init__.py"
       # ignore unused import error in __init__.py files
       args: ["--ignore=F401,E203", --config, setup.cfg]
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      additional_dependencies: ["click==8.0.4"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.770
     hooks:

--- a/external/radiation/radiation/config.py
+++ b/external/radiation/radiation/config.py
@@ -207,8 +207,8 @@ class RadiationConfig:
     def from_physics_namelist(
         cls, physics_namelist: Mapping[Hashable, Any]
     ) -> "RadiationConfig":
-        """Generate RadiationConfig from fv3gfs physics namelist to ensure common keys are
-        identical. Remaining values from RadiationConfig defaults.
+        """Generate RadiationConfig from fv3gfs physics namelist to ensure common keys
+        are identical. Remaining values from RadiationConfig defaults.
         """
 
         gfs_physics_control = GFSPhysicsControl.from_physics_namelist(physics_namelist)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,5 @@ replace = {new_version}
 
 [flake8]
 exclude = docs
-ignore = E203,W293,W503
+ignore = E203,W293,W503,F541,E402
 max-line-length = 88

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -20,6 +20,8 @@ HISTOGRAM_BINS = {
 # argument typehint for diags in save_prognostic_run_diags but used
 # by multiple modules split out to group operations and simplify
 # the diagnostic script
+
+
 @dataclass
 class DiagArg:
     prediction: xr.Dataset

--- a/workflows/post_process_run/fv3post/post_process.py
+++ b/workflows/post_process_run/fv3post/post_process.py
@@ -23,8 +23,8 @@ TIME_AVERAGE_DT = "average_DT"
 
 
 def drop_redundant_time_avg_vars(ds):
-    """Multiple time average information variables inserted by fortran have tile dims are
-    redundant. Keep just average_DT with tile dim dropped."""
+    """Multiple time average information variables inserted by fortran have tile dims
+    are redundant. Keep just average_DT with tile dim dropped."""
     if TIME_AVERAGE_DT in ds:
         ds[TIME_AVERAGE_DT] = ds[TIME_AVERAGE_DT].mean("tile")
     for var in ds:

--- a/workflows/prognostic_c48_run/runtime/diagnostics/fortran.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/fortran.py
@@ -78,7 +78,8 @@ class FortranTimeConfig:
 
 @dataclasses.dataclass
 class FortranFileConfig:
-    """Configurations for Fortran diagnostics defined in diag_table to be converted to zarr
+    """Configurations for Fortran diagnostics defined in diag_table to be converted to
+        zarr
 
     Attributes:
         name: filename of the diagnostic. Must include .zarr suffix.


### PR DESCRIPTION
Moves flake8 in our pre-commit environment to pre-commit-hooks, because the current standalone flake8 in pre-commit is no longer working (see [error](https://app.circleci.com/pipelines/github/ai2cm/fv3net/13716/workflows/4ae37957-092d-48a7-8a60-e16ed178e905/jobs/126935?invite=true#step-103-8)). 

Significant internal changes:
- flake8 invoked via pre-commit-hooks, with a slightly different version requiring different configuration


Coverage reports (updated automatically):
- test_unit: [82%](https://output.circle-artifacts.com/output/job/1ff92846-e8d2-41d3-8d2a-548bc081a574/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)