### PR TITLE
Add dask-distributed and zarrdump to fv3net env

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -48,13 +48,14 @@ crcmod==1.7
 cycler==0.10.0
 cython==0.29.27
 dacite==1.6.0
-dask==2.22.0
+dask==2022.11.1
 decorator==4.4.2
 defusedxml==0.6.0
 deprecation==2.1.0
 dgl==0.9.0
 dill==0.3.1.1
 distlib==0.3.1
+distributed==2022.11.1
 docker-pycreds==0.4.0
 docker==5.0.3
 docopt==0.6.2
@@ -109,6 +110,7 @@ guppy3==3.1.2
 h5netcdf==0.12.0
 h5py==3.6.0
 hdfs==2.6.0
+heapdict==1.0.1
 holoviews==1.14.8
 httplib2==0.19.1
 hypothesis==6.17.4
@@ -146,7 +148,7 @@ lark==1.1.1
 libclang==13.0.0
 libcst==0.4.1
 llvmlite==0.39.0
-locket==0.2.0
+locket==1.0.0
 m2r2==0.3.3
 markdown==3.3.6
 markupsafe==1.1.1
@@ -270,6 +272,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sqlalchemy==1.4.31
 streamlit==1.7.0
 subprocess32==3.5.4
+tblib==1.7.0
 tenacity==5.1.5
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
@@ -316,6 +319,8 @@ xpartition==0.2.0
 yarl==1.6.3
 yq==2.11.0
 zarr==2.13.2
+zarrdump==0.4.1
+zict==2.2.0
 zipp==3.7.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/external/synth/setup.py
+++ b/external/synth/setup.py
@@ -16,7 +16,7 @@ setup(
     },
     entry_points={"console_scripts": ["synth-save-schema=synth.clis:save_schema"]},
     install_requires=[
-        "dask==2.*,>=2.15.0",
+        "dask>=2.15.0",
         "fsspec>=0.7.3",
         "toolz==0.*,>=0.10.0",
         "xarray==0.*,>=0.15.1",

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -52,6 +52,8 @@ tox
 pre-commit
 ipython>=7.29.0
 jupyterlab
+zarrdump
+dask[distributed]
 
 # fv3fit testing tools
 hypothesis


### PR DESCRIPTION
`dask-distributed` and `zarrdump` are useful tools; the former especially for data analysis in notebooks. This PR makes these tools part of the standard fv3net env, which should improve reproducibility of notebooks and reduce the need to manually install these tools.

Requirement changes:
- `zarrdump` and `dask[distributed]` added to `pip-requirements.txt`
- [x] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [x] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/06238daf-4214-40ce-b103-219e03b504c2/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)