### PR TITLE
Update fv3gfs-fortran submodule

### DIFF
--- a/projects/microphysics/configs/combined-base.yaml
+++ b/projects/microphysics/configs/combined-base.yaml
@@ -256,7 +256,7 @@ namelist:
     imp_physics: 99
     ncld: 1
     ldiag3d: true
-    emulate_gscond_only: true
+    emulate_gscond_only: false
     emulate_zc_microphysics: true
 zhao_carr_emulation:
   gscond:

--- a/projects/microphysics/configs/gscond-and-precpd.yaml
+++ b/projects/microphysics/configs/gscond-and-precpd.yaml
@@ -262,7 +262,7 @@ config:
       imp_physics: 99
       ncld: 1
       ldiag3d: true
-      emulate_gscond_only: true
+      emulate_gscond_only: false
       emulate_zc_microphysics: true
       save_zc_microphysics: true
   zhao_carr_emulation:

--- a/projects/microphysics/configs/gscond-only.yaml
+++ b/projects/microphysics/configs/gscond-only.yaml
@@ -264,7 +264,7 @@ config:
       ncld: 1
       ldiag3d: true
       emulate_gscond_only: true
-      save_zc_microphysics: true
+      save_zc_microphysics: false
   zhao_carr_emulation:
     gscond:
       classifier_path: gs://vcm-ml-experiments/microphysics-emulation/2022-06-09/gscond-classifier-v1/model.tf


### PR DESCRIPTION
Update the fv3gfs-fortran to use the recent fixes to emulation diagnostics in the prognostic run image.