### PR TITLE
Open models on all ranks from the locally downloaded paths

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -362,7 +362,7 @@ class TimeLoop(
             local_model_paths = self.comm.bcast(local_model_paths, root=0)
             setattr(ml_config, "model", local_model_paths)
             self._log_info("Model Downloaded From Remote")
-            model = open_model(ml_config)
+            model = open_model(local_model_paths, ml_config)  # type: ignore
             MPI.COMM_WORLD.barrier()
         self._log_info("Model Loaded")
         return model

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -179,10 +179,13 @@ class MultiModelAdapter:
         return ds
 
 
-def open_model(config: MachineLearningConfig) -> MultiModelAdapter:
-    model_paths = config.model
+def open_model(
+    local_model_paths: Sequence[str], config: MachineLearningConfig
+) -> MultiModelAdapter:
+    # Uses the paths for locally downloaded models instead opening from remote
+    # locations in ML config
     models = []
-    for path in model_paths:
+    for path in local_model_paths:
         model = cast(fv3fit.Predictor, fv3fit.load(path))
         rename_in = config.input_standard_names
         rename_out = config.output_standard_names


### PR DESCRIPTION
Previously, the prognostic run downloaded the ML models locally but still referenced the remote paths from the config in the `open_model` function, so all ranks were still downloading the model fro GCS. This PR adds a `local_model_paths` arg to that function, which is passed to `fv3fit.load` so that the locally downloaded models are loaded.

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/04955d01-19cb-498a-94ef-cf1def0298ab\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)