### PR TITLE
Fix CI kubectl auth mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       CLUSTER_NAME: ml-cluster-dev
+      USE_GKE_GCLOUD_AUTH_PLUGIN: True
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The kubectl-gcloud authentication mechanism is switching over soon.  The google/cloud-sdk image we're currently using is on  v1.25 where you have to specify the flag to use the new auth plugin.  This adjustment should get us through the transition until everything is v1.26 or newer.

https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/2f76f137-c5f0-44b4-8849-7eb2d868646f\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)