### PR TITLE
Refactor momentum tendency update to use new A-grid to D-grid wind transform in wrapper

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -154,7 +154,7 @@ def add_tendency(state: Any, tendencies: State, dt: float) -> Tuple[State, State
         filled_fractions = {}
 
         for name, tendency in tendencies.items():
-            filled, filled_fraction = fillna_tendency(tendency[name])
+            filled, filled_fraction = fillna_tendency(tendency)
             filled_tendencies[name] = filled
             filled_fractions[f"{name}_filled_frac"] = filled_fraction
 
@@ -544,7 +544,6 @@ class TimeLoop(
 
         Mostly used for updating the eastward and northward winds.
         """
-        pass
         # self._log_debug(f"Apply postphysics tendencies to physics state")
         # tendency = {k: v for k, v in self._tendencies.items() if k in ["dQu", "dQv"]}
 
@@ -657,7 +656,7 @@ class TimeLoop(
                 self._step_pre_radiation_physics,
                 self._step_radiation_physics,
                 self._step_post_radiation_physics,
-                self._apply_postphysics_to_physics_state,
+                # self._apply_postphysics_to_physics_state,
                 self.monitor(
                     "applied_physics",
                     self.emulate_or_prescribe_tendency(

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -123,22 +123,16 @@ def compute_total_dgrid_wind_tendencies(state, tendencies):
     # tendencies are provided, we don't need to bother passing zeros through
     # to the transformation function.  We don't need to bother adding zeros
     # if no D-grid wind tendencies are provided either.
-    dQx_wind = tendencies.get(
-        "dQx_wind", xr.zeros_like(state["x_wind"]).assign_attrs(units="m/s/s")
-    )
-    dQy_wind = tendencies.get(
-        "dQy_wind", xr.zeros_like(state["y_wind"]).assign_attrs(units="m/s/s")
-    )
-    dQu = tendencies.get(
-        "dQu", xr.zeros_like(state["eastward_wind"]).assign_attrs(units="m/s/s")
-    )
-    dQv = tendencies.get(
-        "dQv", xr.zeros_like(state["northward_wind"]).assign_attrs(units="m/s/s")
-    )
+    dQx_wind = tendencies.get("dQx_wind", xr.zeros_like(state["x_wind"]))
+    dQy_wind = tendencies.get("dQy_wind", xr.zeros_like(state["y_wind"]))
+    dQu = tendencies.get("dQu", xr.zeros_like(state["eastward_wind"]))
+    dQv = tendencies.get("dQv", xr.zeros_like(state["northward_wind"]))
     (
         dQx_wind_from_dQu_and_dQv,
         dQy_wind_from_dQu_and_dQv,
-    ) = transform_agrid_winds_to_dgrid_winds(dQu, dQv)
+    ) = transform_agrid_winds_to_dgrid_winds(
+        dQu.assign_attrs(units="m/s/s"), dQv.assign_attrs(units="m/s/s")
+    )
     return dQx_wind + dQx_wind_from_dQu_and_dQv, dQy_wind + dQy_wind_from_dQu_and_dQv
 
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -110,8 +110,8 @@ def fillna_tendency(tendency: xr.DataArray) -> Tuple[xr.DataArray, xr.DataArray]
 def transform_agrid_winds_to_dgrid_winds(
     ua: xr.DataArray, va: xr.DataArray
 ) -> Tuple[xr.DataArray, xr.DataArray]:
-    ua_quantity = pace.util.Quantity.from_data_array(ua.assign_attrs(units="m/s"))
-    va_quantity = pace.util.Quantity.from_data_array(va.assign_attrs(units="m/s"))
+    ua_quantity = pace.util.Quantity.from_data_array(ua)
+    va_quantity = pace.util.Quantity.from_data_array(va)
     x_wind, y_wind = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(
         ua_quantity, va_quantity
     )
@@ -539,31 +539,6 @@ class TimeLoop(
 
         return diagnostics
 
-    def _apply_postphysics_to_physics_state(self) -> Diagnostics:
-        """Apply computed tendencies and state updates to the physics state
-
-        Mostly used for updating the eastward and northward winds.
-        """
-        # self._log_debug(f"Apply postphysics tendencies to physics state")
-        # tendency = {k: v for k, v in self._tendencies.items() if k in ["dQu", "dQv"]}
-
-        # diagnostics: Diagnostics = {}
-
-        # if self._postphysics_stepper is not None:
-        #     diagnostics = self._postphysics_stepper.get_momentum_diagnostics(
-        #         self._state, tendency
-        #     )
-        #     if self._postphysics_only_diagnostic_ml:
-        #         rename_diagnostics(diagnostics)
-        #     else:
-        #         updated_state, tendency_filled_frac = add_tendency(
-        #             self._state, tendency, dt=self._timestep
-        #         )
-        #         self._state.update_mass_conserving(updated_state)
-        #         diagnostics.update(tendency_filled_frac)
-
-        # return diagnostics
-
     def _compute_postphysics(self) -> Diagnostics:
         self._log_info("Computing Postphysics Updates")
 
@@ -656,7 +631,6 @@ class TimeLoop(
                 self._step_pre_radiation_physics,
                 self._step_radiation_physics,
                 self._step_post_radiation_physics,
-                # self._apply_postphysics_to_physics_state,
                 self.monitor(
                     "applied_physics",
                     self.emulate_or_prescribe_tendency(

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -112,7 +112,7 @@ def transform_agrid_winds_to_dgrid_winds(
 ) -> Tuple[xr.DataArray, xr.DataArray]:
     ua_quantity = pace.util.Quantity.from_data_array(ua.assign_attrs(units="m/s"))
     va_quantity = pace.util.Quantity.from_data_array(va.assign_attrs(units="m/s"))
-    x_wind, y_wind = fv3gfs.wrapper.transform_agrid_winds_dgrid_winds(
+    x_wind, y_wind = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(
         ua_quantity, va_quantity
     )
     return x_wind.data_array, y_wind.data_array

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -110,8 +110,8 @@ def fillna_tendency(tendency: xr.DataArray) -> Tuple[xr.DataArray, xr.DataArray]
 def transform_agrid_winds_to_dgrid_winds(
     ua: xr.DataArray, va: xr.DataArray
 ) -> Tuple[xr.DataArray, xr.DataArray]:
-    ua_quantity = pace.util.Quantity.from_data_array(ua)
-    va_quantity = pace.util.Quantity.from_data_array(va)
+    ua_quantity = pace.util.Quantity.from_data_array(ua.assign_attrs(units="m/s"))
+    va_quantity = pace.util.Quantity.from_data_array(va.assign_attrs(units="m/s"))
     x_wind, y_wind = fv3gfs.wrapper.transform_agrid_winds_dgrid_winds(
         ua_quantity, va_quantity
     )

--- a/workflows/prognostic_c48_run/runtime/names.py
+++ b/workflows/prognostic_c48_run/runtime/names.py
@@ -38,6 +38,9 @@ PREPHYSICS_OVERRIDES = [
     "ocean_surface_temperature",
     "surface_temperature",
 ]
+A_GRID_WIND_TENDENCIES = {"dQu", "dQv"}
+D_GRID_WIND_TENDENCIES = {"dQx_wind", "dQy_wind"}
+WIND_TENDENCIES = A_GRID_WIND_TENDENCIES | D_GRID_WIND_TENDENCIES
 
 
 def is_state_update_variable(key, state: State):

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -310,6 +310,8 @@ class PureMLStepper:
 
     def get_diagnostics(self, state, tendency):
         diags = compute_diagnostics(state, tendency, self.label, self.hydrostatic)
+        momentum_diags = compute_ml_momentum_diagnostics(state, tendency)
+        diags.update(momentum_diags)
         return diags, diags[f"net_moistening_due_to_{self.label}"]
 
     def get_momentum_diagnostics(self, state, tendency):


### PR DESCRIPTION
This PR refactors the code used to apply tendency updates to the A-grid winds in the prognostic run.  Beyond being somewhat convoluted, the previous approach had two primary drawbacks:
- It required delaying applying wind updates by a timestep.
- It required updating the `"eastward_wind_after_physics"` and `"northward_wind_after_physics"` variables from the wrapper, which use the opposite vertical dimension orientation convention to variables in the dynamical core and diagnostics. The code was previously not accounting for this and was thus applying the wind corrections upside down.

Significant internal changes:
- Removes the `_apply_postphysics_to_physics_state` step in the prognostic run time loop, which is no longer needed.

- [ ] Tests added

Coverage reports (updated automatically):
