### PR TITLE
Add time start and end indices to zarr loading for fv3fit

### DIFF
--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -115,6 +115,10 @@ class WindowedZarrLoader(TFDatasetLoader):
         n_windows: number of windows to create per epoch, defaults to the number
             of windows needed to fully cover the dataset with overlapping
             start and end times.
+        time_start_index: index of the first time step of the raw dataset to use,
+            defaults to 0
+        time_end_index: index of the last time step of the raw dataset to use,
+            defaults to the last time step in the dataset
     """
 
     data_path: str
@@ -127,6 +131,8 @@ class WindowedZarrLoader(TFDatasetLoader):
     batch_size: int = 1
     time_stride: int = 1
     n_windows: Optional[int] = None
+    time_start_index: int = 0
+    time_end_index: Optional[int] = None
 
     def open_tfdataset(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -141,6 +147,7 @@ class WindowedZarrLoader(TFDatasetLoader):
                 first dimension is the batch dimension
         """
         ds = open_zarr_using_filecache(self.data_path)
+        ds = ds.isel(time=slice(self.time_start_index, self.time_end_index))
         tfdataset = self._convert_to_tfdataset(ds, variable_names)
         # if local_download_path is given, cache on disk
         if local_download_path is not None:

--- a/external/fv3fit/tests/data/test_windowed_zarr.py
+++ b/external/fv3fit/tests/data/test_windowed_zarr.py
@@ -138,9 +138,14 @@ def test_loader_handles_time_range():
         dataset = loader.open_tfdataset(
             local_download_path=None, variable_names=variable_names
         )
-        item = next(iter(dataset))
+        # result is a dictionary of Tensor
+        item_tensors = next(iter(dataset))
+        # retrieve numpy array
+        item = item_tensors["a"].numpy()
         # remove inserted batch dimension when comparing
-        np.testing.assert_array_equal(item["a"].numpy()[0, :], ds["a"][5:15].values)
+        item = item[0, :]
+        expected = ds["a"].isel(time=slice(5, 15)).values
+        np.testing.assert_array_equal(item, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently the WIndowedZarrMonitor does not allow subsetting along the time axis, a feature which is useful for separating a single dataset into training, validation, and testing periods. This PR adds that feature.

Refactored public API:
- `fv3fit.WindowedZarrMonitor` now accepts `time_start_index` and `time_end_index` configuration values

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/06cb7ec0-00b8-4ec4-92f5-7448b57508c3/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)