### PR TITLE
Combine reservoir models

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -21,9 +21,6 @@ class ReservoirHyperparameters:
         W_res has shape state_size x state_size
     adjacency_matrix_sparsity: Fraction of elements in adjacency matrix
         W_res that are zero
-    output_size: Optional: size of output vector. Can be smaller than input
-        dimension if predicting on subdomains with overlapping
-        input regions. Defaults to same as input_size
     spectral_radius: Largest absolute value eigenvalue of W_res.
         Larger values increase the memory of the reservoir.
     seed: Random seed for sampling
@@ -49,8 +46,10 @@ class ReadoutHyperparameters:
     """
     linear_regressor_kwargs: kwargs to provide when initializing the
         sklearn Ridge regressor for ReservoirComputingReadout
-    square_half_hidden_state: if True, square even elements of state vector
-        as described in in Wikner+ 2020 (https://doi.org/10.1063/5.0005541)
+    square_half_hidden_state: if True, square even terms in the reservoir
+        state before it is used as input to the regressor's .fit and
+        .predict methods. This option was found to be important for skillful
+        predictions in Wikner+2020 (https://doi.org/10.1063/5.0005541)
     """
 
     linear_regressor_kwargs: dict

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -17,7 +17,6 @@ class SubdomainConfig:
 class ReservoirHyperparameters:
     """Hyperparameters for reservoir
 
-    input_size: Size of input vector
     state_size: Size of hidden state vector,
         W_res has shape state_size x state_size
     adjacency_matrix_sparsity: Fraction of elements in adjacency matrix
@@ -35,32 +34,21 @@ class ReservoirHyperparameters:
         where all elements are sampled from random uniform distribution
         [-1, 1]. Changing this affects relative weighting of reservoir memory
         versus the most recent state.
-    ncols_state: If state is 2D (each column is a separate subdomain which uses
-        the same W_in and W_res weights) then use this to initialize the state
-        with the corret shape.
-
     """
 
-    input_size: int
     state_size: int
     adjacency_matrix_sparsity: float
     spectral_radius: float
-    output_size: Optional[int] = None
     seed: int = 0
     input_coupling_sparsity: float = 0.0
     input_coupling_scaling: float = 1.0
-    ncols_state: int = 1
-
-    def __post_init__(self):
-        if not self.output_size:
-            self.output_size = self.input_size
 
 
 @dataclass
 class ReadoutHyperparameters:
     """
-    linear_regressor_kwargs: kwargs to provide when initializing the linear
-        regressor for ReservoirComputingReadout
+    linear_regressor_kwargs: kwargs to provide when initializing the
+        sklearn Ridge regressor for ReservoirComputingReadout
     square_half_hidden_state: if True, square even elements of state vector
         as described in in Wikner+ 2020 (https://doi.org/10.1063/5.0005541)
     """

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -35,6 +35,10 @@ class ReservoirHyperparameters:
         where all elements are sampled from random uniform distribution
         [-1, 1]. Changing this affects relative weighting of reservoir memory
         versus the most recent state.
+    ncols_state: If state is 2D (each column is a separate subdomain which uses
+        the same W_in and W_res weights) then use this to initialize the state
+        with the corret shape.
+
     """
 
     input_size: int
@@ -45,6 +49,7 @@ class ReservoirHyperparameters:
     seed: int = 0
     input_coupling_sparsity: float = 0.0
     input_coupling_scaling: float = 1.0
+    ncols_state: int = 1
 
     def __post_init__(self):
         if not self.output_size:

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -24,7 +24,7 @@ class ImperfectModel(abc.ABC):
 
 
 class ReservoirComputingModel:
-    _METADATA_NAME = "metadata.bin"
+    _RESERVOIR_SUBDIR = "reservoir"
 
     def __init__(
         self, reservoir: Reservoir, readout: ReservoirComputingReadout,
@@ -44,19 +44,18 @@ class ReservoirComputingModel:
             path: a URL pointing to a directory
         """
         self.readout.dump(path)
-        self.reservoir.dump(path)
+        self.reservoir.dump(f"{path}/{self._RESERVOIR_SUBDIR}")
 
     @classmethod
     def load(cls, path: str) -> "ReservoirComputingModel":
         """Load a model from a remote path"""
         readout = ReservoirComputingReadout.load(path)
-        reservoir = Reservoir.load(path)
+        reservoir = Reservoir.load(f"{path}/{cls._RESERVOIR_SUBDIR}")
         return cls(reservoir=reservoir, readout=readout,)
 
 
 class HybridReservoirComputingModel:
-    _READOUT_NAME = "readout.bin"
-    _METADATA_NAME = "metadata.bin"
+    _RESERVOIR_SUBDIR = "reservoir"
 
     def __init__(
         self, reservoir: Reservoir, readout: ReservoirComputingReadout,
@@ -78,12 +77,12 @@ class HybridReservoirComputingModel:
             path: a URL pointing to a directory
         """
         self.readout.dump(path)
-        self.reservoir.dump(path)
+        self.reservoir.dump(f"{path}/{self._RESERVOIR_SUBDIR}")
 
     @classmethod
     def load(cls, path):
         readout = ReservoirComputingReadout.load(path)
-        reservoir = Reservoir.load(path)
+        reservoir = Reservoir.load(f"{path}/{cls._RESERVOIR_SUBDIR}")
         return cls(reservoir=reservoir, readout=readout,)
 
 

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -29,7 +29,7 @@ class ImperfectModel(abc.ABC):
 
 
 class ReservoirComputingModel:
-    _READOUT_NAME = "readout.pkl"
+    _READOUT_NAME = "readout.bin"
     _METADATA_NAME = "metadata.bin"
 
     def __init__(
@@ -85,7 +85,7 @@ class ReservoirComputingModel:
 
 
 class HybridReservoirComputingModel:
-    _READOUT_NAME = "readout.pkl"
+    _READOUT_NAME = "readout.bin"
     _METADATA_NAME = "metadata.bin"
 
     def __init__(

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -10,7 +10,7 @@ import yaml
 
 from .readout import ReservoirComputingReadout
 from .reservoir import Reservoir
-from .config import ReservoirHyperparameters, SubdomainConfig
+from .config import ReservoirHyperparameters, SubdomainConfig, ReadoutHyperparameters
 from .domain import PeriodicDomain, Subdomain
 
 
@@ -69,7 +69,12 @@ class ReservoirComputingModel:
 
         f = io.BytesIO(mapper[cls._READOUT_NAME])
         readout_components = joblib.load(f)
-        readout = ReservoirComputingReadout(**readout_components)
+        readout_hyperparameters = dacite.from_dict(
+            ReadoutHyperparameters, readout_components.pop("hyperparameters")
+        )
+        readout = ReservoirComputingReadout(
+            hyperparameters=readout_hyperparameters, **readout_components
+        )
         metadata = yaml.safe_load(mapper[cls._METADATA_NAME])
 
         reservoir_hyperparameters = dacite.from_dict(
@@ -120,7 +125,13 @@ class HybridReservoirComputingModel:
 
         f_readout = io.BytesIO(mapper[cls._READOUT_NAME])
         readout_components = joblib.load(f_readout)
-        readout = ReservoirComputingReadout(**readout_components)
+        readout_hyperparameters = dacite.from_dict(
+            ReadoutHyperparameters, readout_components.pop("hyperparameters")
+        )
+        readout = ReservoirComputingReadout(
+            hyperparameters=readout_hyperparameters, **readout_components
+        )
+
         metadata = yaml.safe_load(mapper[cls._METADATA_NAME])
 
         reservoir_hyperparameters = dacite.from_dict(

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -60,8 +60,9 @@ class ReservoirComputingModel:
         mapper[self._READOUT_NAME] = self.readout.dumps()
         metadata = {
             "reservoir_hyperparameters": dataclasses.asdict(
-                self.reservoir.hyperparameters
-            )
+                self.reservoir.hyperparameters,
+            ),
+            "input_size": self.reservoir.input_size,
         }
         with fs.open(f"{path}/{self._INPUT_WEIGHTS_NAME}", "wb") as f:
             scipy.sparse.save_npz(f, self.reservoir.W_in),
@@ -93,7 +94,10 @@ class ReservoirComputingModel:
             reservoir_W_res = scipy.sparse.load_npz(f)
         return cls(
             reservoir=Reservoir(
-                reservoir_hyperparameters, W_in=reservoir_W_in, W_res=reservoir_W_res
+                reservoir_hyperparameters,
+                W_in=reservoir_W_in,
+                W_res=reservoir_W_res,
+                input_size=metadata["input_size"],
             ),
             readout=readout,
         )
@@ -130,7 +134,8 @@ class HybridReservoirComputingModel:
         metadata = {
             "reservoir_hyperparameters": dataclasses.asdict(
                 self.reservoir.hyperparameters
-            )
+            ),
+            "input_size": self.reservoir.input_size,
         }
         mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
 
@@ -153,7 +158,12 @@ class HybridReservoirComputingModel:
             ReservoirHyperparameters, metadata["reservoir_hyperparameters"]
         )
 
-        return cls(reservoir=Reservoir(reservoir_hyperparameters), readout=readout,)
+        return cls(
+            reservoir=Reservoir(
+                reservoir_hyperparameters, input_size=metadata["input_size"]
+            ),
+            readout=readout,
+        )
 
 
 class DomainPredictor:

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -5,6 +5,7 @@ import fsspec
 import io
 import joblib
 import numpy as np
+import scipy.sparse
 from typing import Sequence
 import yaml
 
@@ -31,6 +32,8 @@ class ImperfectModel(abc.ABC):
 class ReservoirComputingModel:
     _READOUT_NAME = "readout.bin"
     _METADATA_NAME = "metadata.bin"
+    _INPUT_WEIGHTS_NAME = "reservoir_W_in.npz"
+    _RESERVOIR_WEIGHTS_NAME = "reservoir_W_res.npz"
 
     def __init__(
         self, reservoir: Reservoir, readout: ReservoirComputingReadout,
@@ -60,13 +63,17 @@ class ReservoirComputingModel:
                 self.reservoir.hyperparameters
             )
         }
+        with fs.open(f"{path}/{self._INPUT_WEIGHTS_NAME}", "wb") as f:
+            scipy.sparse.save_npz(f, self.reservoir.W_in),
+        with fs.open(f"{path}/{self._RESERVOIR_WEIGHTS_NAME}", "wb") as f:
+            scipy.sparse.save_npz(f, self.reservoir.W_res),
         mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
 
     @classmethod
     def load(cls, path: str) -> "ReservoirComputingModel":
         """Load a model from a remote path"""
         mapper = fsspec.get_mapper(path)
-
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
         f = io.BytesIO(mapper[cls._READOUT_NAME])
         readout_components = joblib.load(f)
         readout_hyperparameters = dacite.from_dict(
@@ -80,8 +87,16 @@ class ReservoirComputingModel:
         reservoir_hyperparameters = dacite.from_dict(
             ReservoirHyperparameters, metadata["reservoir_hyperparameters"]
         )
-
-        return cls(reservoir=Reservoir(reservoir_hyperparameters), readout=readout,)
+        with fs.open(f"{path}/{cls._INPUT_WEIGHTS_NAME}", "rb") as f:
+            reservoir_W_in = scipy.sparse.load_npz(f)
+        with fs.open(f"{path}/{cls._RESERVOIR_WEIGHTS_NAME}", "rb") as f:
+            reservoir_W_res = scipy.sparse.load_npz(f)
+        return cls(
+            reservoir=Reservoir(
+                reservoir_hyperparameters, W_in=reservoir_W_in, W_res=reservoir_W_res
+            ),
+            readout=readout,
+        )
 
 
 class HybridReservoirComputingModel:

--- a/external/fv3fit/fv3fit/reservoir/readout.py
+++ b/external/fv3fit/fv3fit/reservoir/readout.py
@@ -53,11 +53,11 @@ def _sort_subdirs_numerically(subdirs: Sequence[str]) -> Sequence[str]:
 class ReservoirComputingReadout:
     """Readout layer of the reservoir computing model
 
-    linear_regressor: a sklearn Ridge regressor
-    square_half_hidden_state: if True, square even terms in the reservoir
-        state before it is used as input to the regressor's .fit and
-        .predict methods. This option was found to be important for skillful
-        predictions in Wikner+2020 (https://doi.org/10.1063/5.0005541)
+    hyperparameters: hyperparameters describing the readout
+    coefficients: if provided from an already-fit readout,
+        use as the linear regression coefficients
+    intercepts: if provided from an already-fit readout,
+        use as the linear regression intercepts
     """
 
     _READOUT_NAME = "readout.bin"
@@ -167,14 +167,20 @@ class CombinedReservoirComputingReadout:
 
     @classmethod
     def load(cls, path: str) -> "CombinedReservoirComputingReadout":
-        """Load a model from a remote directory. Each path in paths
+        """Load a model from a remote directory. Each subdir in path
         refers to the full reservoir model directory containing the saved
-        readout to load.
-
-        Assumes readout subdirs are numbered in the order that they should
+        readout to load within a subdir named "readout". ex.
+        | path
+        | -- model_0
+        |    -- readout.bin
+        |    -- reservoir
+        | -- model_1
+        |    -- readout.bin
+              ...
+        Assumes model subdirs are numbered in the order that they should
         be used in the combined readout.
 
-        path: directory containing subdirectories for each readout
+        path: directory containing model subdirectories for each readout
         """
         fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
         subdirs = _sort_subdirs_numerically(fs.ls(path))

--- a/external/fv3fit/fv3fit/reservoir/readout.py
+++ b/external/fv3fit/fv3fit/reservoir/readout.py
@@ -88,7 +88,7 @@ class CombinedReservoirComputingReadout:
         Wikner+2020 (https://doi.org/10.1063/5.0005541)
     """
 
-    _READOUT_NAME = "readout.pkl"
+    _READOUT_NAME = "readout.bin"
 
     def __init__(self, readouts: Sequence[ReservoirComputingReadout]):
         self._combine_readouts(readouts)
@@ -116,15 +116,14 @@ class CombinedReservoirComputingReadout:
     def predict(self, input: np.ndarray):
         if self.square_half_hidden_state:
             input = square_even_terms(input, axis=0)
-        print(self.coefficients.shape, input.shape, self.intercepts.shape)
-        print(self.coefficients.todense())
-        print(np.dot(self.coefficients, input))
-        print(self.coefficients * input)
         return self.coefficients * input + self.intercepts
 
     @classmethod
     def load(cls, paths: Sequence[str]) -> "CombinedReservoirComputingReadout":
-        """Load a model from a remote path"""
+        """Load a model from a remote directory. Each path in paths
+        refers to the full reservoir model directory containing the saved
+        readout to load.
+        """
         readouts = []
         for path in paths:
             mapper = fsspec.get_mapper(path)

--- a/external/fv3fit/fv3fit/reservoir/readout.py
+++ b/external/fv3fit/fv3fit/reservoir/readout.py
@@ -4,6 +4,7 @@ import fsspec
 import io
 import joblib
 import numpy as np
+import re
 import scipy.sparse
 from sklearn.linear_model import Ridge
 from typing import Sequence, Optional
@@ -22,6 +23,31 @@ def _square_evens(v: np.ndarray) -> np.ndarray:
 
 def square_even_terms(v: np.ndarray, axis=1) -> np.ndarray:
     return np.apply_along_axis(func1d=_square_evens, axis=axis, arr=v)
+
+
+def _extract_int_from_subdir(s):
+    nums = re.findall(r"\d+", s.rstrip("/").split("/")[-1])
+    if len(nums) == 1:
+        return int(nums[0])
+    else:
+        raise ValueError(
+            "Ordering of readout subdirectories should be indicated "
+            "by a single numeric tag or suffix. ex. 'subdir_0' or '0'."
+            f"Subdir {s} violates this naming rule."
+        )
+
+
+def _sort_subdirs_numerically(subdirs: Sequence[str]) -> Sequence[str]:
+    """
+    Sort a list of subdirs by their numeric tags.
+    ex. "subdir_0", "subdir_1"
+    """
+    nums = [_extract_int_from_subdir(s) for s in subdirs]
+    if len(subdirs) != len(np.unique(nums)):
+        raise ValueError(
+            "Multiple readout subdirectories have the same " "numbering label."
+        )
+    return [subdir for _, subdir in sorted(zip(nums, subdirs))]
 
 
 class ReservoirComputingReadout:
@@ -140,14 +166,25 @@ class CombinedReservoirComputingReadout:
         return self.coefficients * input + self.intercepts
 
     @classmethod
-    def load(cls, paths: Sequence[str]) -> "CombinedReservoirComputingReadout":
+    def load(cls, path: str) -> "CombinedReservoirComputingReadout":
         """Load a model from a remote directory. Each path in paths
         refers to the full reservoir model directory containing the saved
         readout to load.
+
+        Assumes readout subdirs are numbered in the order that they should
+        be used in the combined readout.
+
+        path: directory containing subdirectories for each readout
         """
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
+        subdirs = _sort_subdirs_numerically(fs.ls(path))
+        if "gs" in fs.protocol:
+            subdirs = [f"gs://{path}" for path in subdirs]
+
         readouts = []
-        for path in paths:
-            mapper = fsspec.get_mapper(path)
+
+        for subdir in subdirs:
+            mapper = fsspec.get_mapper(subdir)
 
             f = io.BytesIO(mapper[cls._READOUT_NAME])
             readout_components = joblib.load(f)

--- a/external/fv3fit/fv3fit/reservoir/readout.py
+++ b/external/fv3fit/fv3fit/reservoir/readout.py
@@ -68,7 +68,6 @@ class ReservoirComputingReadout:
             "hyperparameters": dataclasses.asdict(self.hyperparameters),
             "coefficients": self.coefficients,
             "intercepts": self.intercepts,
-            "square_half_hidden_state": self.square_half_hidden_state,
         }
         f = io.BytesIO()
         joblib.dump(components, f)

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
 import scipy
+from typing import Optional
 
 from .config import ReservoirHyperparameters
 
@@ -25,12 +26,16 @@ def _random_uniform_sparse_matrix(m, n, sparsity, min=0, max=1):
 
 class Reservoir:
     def __init__(
-        self, hyperparameters: ReservoirHyperparameters,
+        self,
+        hyperparameters: ReservoirHyperparameters,
+        W_in: Optional[scipy.sparse.coo_matrix] = None,
+        W_res: Optional[scipy.sparse.coo_matrix] = None,
     ):
         self.hyperparameters = hyperparameters
+
         np.random.seed(self.hyperparameters.seed)
-        self.W_in = self._generate_W_in()
-        self.W_res = self._generate_W_res()
+        self.W_in = W_in if W_in is not None else self._generate_W_in()
+        self.W_res = W_res if W_res is not None else self._generate_W_res()
         self.state_after_reset = (
             np.zeros(
                 (self.hyperparameters.state_size, self.hyperparameters.ncols_state)

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -72,7 +72,7 @@ class Reservoir:
         self.state = np.zeros(self.hyperparameters.state_size)
 
     def increment_state(self, input):
-        self.state = np.tanh(self.W_in * input + self.W_res * self.state)
+        self.state = np.tanh(self.W_in @ input + self.W_res @ self.state)
 
     def reset_state(self):
         logger.info("Resetting reservoir state.")

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -28,32 +28,57 @@ class Reservoir:
     def __init__(
         self,
         hyperparameters: ReservoirHyperparameters,
+        input_size: int,
         W_in: Optional[scipy.sparse.coo_matrix] = None,
         W_res: Optional[scipy.sparse.coo_matrix] = None,
     ):
+        """
+
+        Args:
+            hyperparameters: information for generating reservoir matrices
+            input_size: length of input vector features
+            W_in: Weights for input matrix. If None, this matrix will be generated
+                upon initialization.
+            W_res: Weights for reservoir matrix. If None, this matrix will be
+                generated upon initialiation.
+        """
         self.hyperparameters = hyperparameters
+        self.input_size = input_size
 
         np.random.seed(self.hyperparameters.seed)
         self.W_in = W_in if W_in is not None else self._generate_W_in()
         self.W_res = W_res if W_res is not None else self._generate_W_res()
-        self.state_after_reset = (
-            np.zeros(
-                (self.hyperparameters.state_size, self.hyperparameters.ncols_state)
+
+    def __getattr__(self, attr):
+        if attr == "state":
+            raise AttributeError(
+                "Reservoir.state is not set yet."
+                "To initialize, first use Reservoir.reset_state"
             )
-            if self.hyperparameters.ncols_state > 1
-            else np.zeros(self.hyperparameters.state_size)
+        raise AttributeError(
+            f"{self.__class__.__name__} object has no attribute {attr}."
         )
-        self.state = self.state_after_reset
 
     def increment_state(self, input):
         self.state = np.tanh(self.W_in @ input + self.W_res @ self.state)
 
-    def reset_state(self):
+    def reset_state(self, input_shape: tuple):
         logger.info("Resetting reservoir state.")
-        self.state = self.state_after_reset
+        if len(input_shape) > 1:
+            # Input is a 2d matrix with each colum as a separate subdomain
+            ncols_inputs = input_shape[1]
+            state_after_reset = np.zeros(
+                (self.hyperparameters.state_size, ncols_inputs)
+            )
+        elif len(input_shape) == 1:
+            # Input is a 1d vector
+            state_after_reset = np.zeros(self.hyperparameters.state_size)
+        else:
+            raise ValueError("Input shape tuple must describe either a 1D or 2D array.")
+        self.state = state_after_reset
 
     def synchronize(self, synchronization_time_series):
-        self.reset_state()
+        self.reset_state(input_shape=synchronization_time_series[0].shape)
         for input in synchronization_time_series:
             self.increment_state(input)
 
@@ -61,7 +86,7 @@ class Reservoir:
         W_in_cols = []
         # Generate by column to ensure same number of connections per input element,
         # as described in Wikner+ 2020 (https://doi.org/10.1063/5.0005541)
-        for k in range(self.hyperparameters.input_size):
+        for k in range(self.input_size):
             W_in_cols.append(
                 _random_uniform_sparse_matrix(
                     m=self.hyperparameters.state_size,

--- a/external/fv3fit/tests/reservoir/test_readout.py
+++ b/external/fv3fit/tests/reservoir/test_readout.py
@@ -7,6 +7,7 @@ from fv3fit.reservoir.readout import (
     ReservoirComputingReadout,
     CombinedReservoirComputingReadout,
     square_even_terms,
+    _sort_subdirs_numerically,
 )
 
 
@@ -111,6 +112,23 @@ def test_combined_readout_inconsistent_hyperparameters():
         CombinedReservoirComputingReadout(readouts=[readout_1, readout_2])
 
 
+def test__sort_subdirs_numerically():
+    subdirs = [
+        "subdir_0",
+        "subdir_1",
+        "subdir_10",
+        "subdir_11",
+        "subdir_2",
+    ]
+    assert _sort_subdirs_numerically(subdirs) == [
+        "subdir_0",
+        "subdir_1",
+        "subdir_2",
+        "subdir_10",
+        "subdir_11",
+    ]
+
+
 def test_combined_load(tmpdir):
     readouts, readout_paths = [], []
     coef_shape = (2, 2)
@@ -127,7 +145,7 @@ def test_combined_load(tmpdir):
         readout.dump(output_path)
         readouts.append(readout)
         readout_paths.append(output_path)
-    combined_readout = CombinedReservoirComputingReadout.load(readout_paths)
+    combined_readout = CombinedReservoirComputingReadout.load(str(tmpdir))
     np.testing.assert_array_almost_equal(
         scipy.linalg.block_diag(*[r.coefficients for r in readouts]),
         combined_readout.coefficients.todense(),

--- a/external/fv3fit/tests/reservoir/test_readout.py
+++ b/external/fv3fit/tests/reservoir/test_readout.py
@@ -1,7 +1,6 @@
 import numpy as np
 import scipy.linalg
 import pytest
-import os
 
 from fv3fit.reservoir.config import ReadoutHyperparameters
 from fv3fit.reservoir.readout import (
@@ -118,7 +117,6 @@ def test_combined_load(tmpdir):
     output_size = 2
     for i in range(3):
         output_path = f"{str(tmpdir)}/readout_{i}"
-        os.mkdir(output_path)
         readout = ReservoirComputingReadout(
             hyperparameters=ReadoutHyperparameters(
                 linear_regressor_kwargs={}, square_half_hidden_state=True
@@ -126,8 +124,7 @@ def test_combined_load(tmpdir):
             coefficients=np.ones(coef_shape) * i,
             intercepts=np.zeros(output_size),
         )
-        with open(f"{output_path}/readout.bin", "wb") as f:
-            f.write(readout.dumps())
+        readout.dump(output_path)
         readouts.append(readout)
         readout_paths.append(output_path)
     combined_readout = CombinedReservoirComputingReadout.load(readout_paths)

--- a/external/fv3fit/tests/reservoir/test_readout.py
+++ b/external/fv3fit/tests/reservoir/test_readout.py
@@ -62,21 +62,23 @@ def test_reservoir_computing_readout_fit():
 
 
 def test_combined_readout():
+    np.random.seed(0)
+
     state_size = 3
     output_size = 2
     readout_1 = ReservoirComputingReadout(
         hyperparameters=ReadoutHyperparameters(
             linear_regressor_kwargs={}, square_half_hidden_state=False
         ),
-        coefficients=np.ones(shape=(output_size, state_size)),
-        intercepts=np.zeros(output_size),
+        coefficients=np.random.rand(output_size, state_size),
+        intercepts=np.random.rand(output_size),
     )
     readout_2 = ReservoirComputingReadout(
         hyperparameters=ReadoutHyperparameters(
             linear_regressor_kwargs={}, square_half_hidden_state=False
         ),
-        coefficients=2.0 * np.ones(shape=(output_size, state_size)),
-        intercepts=np.zeros(output_size),
+        coefficients=np.random.rand(output_size, state_size),
+        intercepts=np.random.rand(output_size),
     )
     input = np.array([1, 1, 1])
     output_1 = readout_1.predict(input)
@@ -130,6 +132,7 @@ def test__sort_subdirs_numerically():
 
 
 def test_combined_load(tmpdir):
+    np.random.seed(0)
     readouts, readout_paths = [], []
     coef_shape = (2, 2)
     output_size = 2
@@ -139,8 +142,8 @@ def test_combined_load(tmpdir):
             hyperparameters=ReadoutHyperparameters(
                 linear_regressor_kwargs={}, square_half_hidden_state=True
             ),
-            coefficients=np.ones(coef_shape) * i,
-            intercepts=np.zeros(output_size),
+            coefficients=np.random.rand(*coef_shape),
+            intercepts=np.random.rand(output_size),
         )
         readout.dump(output_path)
         readouts.append(readout)

--- a/external/fv3fit/tests/reservoir/test_reservoir.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir.py
@@ -96,3 +96,31 @@ def test_increment_state():
     np.testing.assert_array_almost_equal(
         reservoir.state, np.tanh(np.array([elem, elem, elem]))
     )
+
+
+def test_increment_state_2d_input():
+    input_matrix_columns = 4
+    state_size = 3
+    hyperparameters = ReservoirHyperparameters(
+        input_size=2,
+        state_size=state_size,
+        adjacency_matrix_sparsity=0.0,
+        input_coupling_sparsity=0,
+        spectral_radius=1.0,
+        ncols_state=input_matrix_columns,
+    )
+    reservoir = Reservoir(hyperparameters)
+
+    reservoir.W_in = sparse.coo_matrix(np.ones(reservoir.W_in.shape))
+    reservoir.W_res = sparse.identity(hyperparameters.state_size)
+
+    reservoir.reset_state()
+    # Test matrix multiplication with W_in and W_res when input has
+    # multiple columns for different subdomains
+    input = np.array([[0.5 * i, 0.5 * i] for i in range(input_matrix_columns)]).T
+
+    reservoir.increment_state(input)
+    assert reservoir.state.shape == (state_size, input_matrix_columns)
+
+    reservoir.increment_state(input)
+    assert reservoir.state.shape == (state_size, input_matrix_columns)

--- a/external/fv3fit/tests/reservoir/test_reservoir.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir.py
@@ -7,15 +7,13 @@ from fv3fit.reservoir import Reservoir, ReservoirHyperparameters
 def test_matrices_and_state_correct_dims():
     N_input, N_res = 10, 100
     hyperparameters = ReservoirHyperparameters(
-        input_size=N_input,
-        state_size=N_res,
-        adjacency_matrix_sparsity=0.05,
-        spectral_radius=0.2,
+        state_size=N_res, adjacency_matrix_sparsity=0.05, spectral_radius=0.2,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=N_input)
     assert reservoir.W_in.shape == (N_res, N_input)
     assert (reservoir.W_in * np.ones(N_input)).shape == (N_res,)
     assert reservoir.W_res.shape == (N_res, N_res)
+    reservoir.reset_state(input_shape=(N_input,))
     reservoir.increment_state(np.ones(N_input))
     assert reservoir.state.shape == (N_res,)
 
@@ -24,12 +22,11 @@ def test_matrices_and_state_correct_dims():
 def test_Wres_sparsity(adjacency_matrix_sparsity):
     N_input, N_res = 10, 100
     hyperparameters = ReservoirHyperparameters(
-        input_size=N_input,
         state_size=N_res,
         adjacency_matrix_sparsity=adjacency_matrix_sparsity,
         spectral_radius=0.2,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=N_input)
     assert (
         reservoir.W_res.count_nonzero() == (1 - adjacency_matrix_sparsity) * N_res ** 2
     )
@@ -38,12 +35,9 @@ def test_Wres_sparsity(adjacency_matrix_sparsity):
 def test_spectral_radius():
     radius = 0.6
     hyperparameters = ReservoirHyperparameters(
-        input_size=10,
-        state_size=100,
-        adjacency_matrix_sparsity=0.8,
-        spectral_radius=radius,
+        state_size=100, adjacency_matrix_sparsity=0.8, spectral_radius=radius,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=10)
     np.testing.assert_almost_equal(
         sparse.linalg.eigs(
             reservoir.W_res, return_eigenvectors=False, k=1, which="LM"
@@ -55,16 +49,14 @@ def test_spectral_radius():
 def test_Win_equal_connections_per_input():
     input_coupling_sparsity = 0.2
     hyperparameters = ReservoirHyperparameters(
-        input_size=100,
         state_size=1000,
         adjacency_matrix_sparsity=0.8,
         spectral_radius=0.6,
         input_coupling_sparsity=input_coupling_sparsity,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=100)
     nonzero_per_col = [
-        reservoir.W_in.getcol(i).count_nonzero()
-        for i in range(hyperparameters.input_size)
+        reservoir.W_in.getcol(i).count_nonzero() for i in range(reservoir.input_size)
     ]
     assert np.unique(nonzero_per_col).item() == 800
     assert len(np.unique(nonzero_per_col)) == 1
@@ -72,19 +64,18 @@ def test_Win_equal_connections_per_input():
 
 def test_increment_state():
     hyperparameters = ReservoirHyperparameters(
-        input_size=2,
         state_size=3,
         adjacency_matrix_sparsity=0.0,
         input_coupling_sparsity=0,
         spectral_radius=1.0,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=2)
 
     reservoir.W_in = sparse.coo_matrix(np.ones(reservoir.W_in.shape))
     reservoir.W_res = sparse.identity(hyperparameters.state_size)
 
-    reservoir.reset_state()
     input = np.array([0.5, 0.5])
+    reservoir.reset_state(input_shape=input.shape)
 
     reservoir.increment_state(input)
     np.testing.assert_array_almost_equal(
@@ -102,22 +93,20 @@ def test_increment_state_2d_input():
     input_matrix_columns = 4
     state_size = 3
     hyperparameters = ReservoirHyperparameters(
-        input_size=2,
         state_size=state_size,
         adjacency_matrix_sparsity=0.0,
         input_coupling_sparsity=0,
         spectral_radius=1.0,
-        ncols_state=input_matrix_columns,
     )
-    reservoir = Reservoir(hyperparameters)
+    reservoir = Reservoir(hyperparameters, input_size=2)
 
     reservoir.W_in = sparse.coo_matrix(np.ones(reservoir.W_in.shape))
     reservoir.W_res = sparse.identity(hyperparameters.state_size)
 
-    reservoir.reset_state()
     # Test matrix multiplication with W_in and W_res when input has
     # multiple columns for different subdomains
     input = np.array([[0.5 * i, 0.5 * i] for i in range(input_matrix_columns)]).T
+    reservoir.reset_state(input_shape=input.shape)
 
     reservoir.increment_state(input)
     assert reservoir.state.shape == (state_size, input_matrix_columns)

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -42,8 +42,8 @@ def _sparse_allclose(A, B, atol=1e-8):
 
 
 def test_dump_load_preserves_matrices(tmpdir):
-    input_size = 3  # 10
-    state_size = 5  # 150
+    input_size = 10
+    state_size = 150
     hyperparameters = ReservoirHyperparameters(
         input_size=input_size,
         state_size=state_size,
@@ -169,7 +169,6 @@ def test_hybrid_prediction_after_load(tmpdir):
     )
     reservoir = Reservoir(hyperparameters)
 
-    # readout = MultiOutputMeanRegressor(n_outputs=input_size)
     readout = generic_readout()
     readout.fit(np.random.rand(1, state_size + input_size), np.ones((1, input_size)))
 

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy import sparse
 
-from sklearn.dummy import DummyRegressor
 from fv3fit.reservoir import (
     ReservoirComputingModel,
     ReservoirComputingReadout,
@@ -11,7 +10,14 @@ from fv3fit.reservoir import (
     ReservoirOnlyDomainPredictor,
     HybridDomainPredictor,
 )
-from fv3fit.reservoir.config import SubdomainConfig
+from fv3fit.reservoir.config import SubdomainConfig, ReadoutHyperparameters
+
+
+def generic_readout(**readout_kwargs):
+    readout_hyperparameters = ReadoutHyperparameters(
+        linear_regressor_kwargs={}, square_half_hidden_state=False
+    )
+    return ReservoirComputingReadout(readout_hyperparameters, **readout_kwargs)
 
 
 class MultiOutputMeanRegressor:
@@ -35,18 +41,20 @@ def _sparse_allclose(A, B, atol=1e-8):
         return np.allclose(v1, v2, atol=atol)
 
 
-def test_dump_load_preserves_reservoir(tmpdir):
+def test_dump_load_preserves_matrices(tmpdir):
+    input_size = 3  # 10
+    state_size = 5  # 150
     hyperparameters = ReservoirHyperparameters(
-        input_size=10,
-        state_size=150,
+        input_size=input_size,
+        state_size=state_size,
         adjacency_matrix_sparsity=0.0,
         spectral_radius=1.0,
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters)
-    readout = ReservoirComputingReadout(
-        linear_regressor=DummyRegressor(strategy="constant", constant=-1.0),
-        square_half_hidden_state=False,
+    readout = generic_readout(
+        coefficients=np.random.rand(input_size, state_size),
+        intercepts=np.random.rand(input_size),
     )
     predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
     output_path = f"{str(tmpdir)}/predictor"
@@ -55,6 +63,12 @@ def test_dump_load_preserves_reservoir(tmpdir):
     loaded_predictor = ReservoirComputingModel.load(output_path)
     assert _sparse_allclose(loaded_predictor.reservoir.W_in, predictor.reservoir.W_in)
     assert _sparse_allclose(loaded_predictor.reservoir.W_res, predictor.reservoir.W_res)
+    np.testing.assert_array_almost_equal(
+        loaded_predictor.readout.coefficients, predictor.readout.coefficients
+    )
+    np.testing.assert_array_almost_equal(
+        loaded_predictor.readout.intercepts, predictor.readout.intercepts
+    )
 
 
 def test_prediction_shape():
@@ -67,11 +81,9 @@ def test_prediction_shape():
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters)
-    lr = DummyRegressor(strategy="constant", constant=np.ones(input_size))
-    lr.fit(reservoir.state.reshape(1, -1), np.ones((1, input_size)))
-    readout = ReservoirComputingReadout(
-        linear_regressor=lr, square_half_hidden_state=True,
-    )
+
+    readout = generic_readout()
+    readout.fit(reservoir.state.reshape(1, -1), np.ones((1, input_size)))
     predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
     # ReservoirComputingModel.predict reshapes the prediction to remove
     # the first dim of length 1 (sklearn regressors predict 2D arrays)
@@ -80,9 +92,10 @@ def test_prediction_shape():
 
 def test_ReservoirComputingModel_state_increment():
     input_size = 2
+    state_size = 3
     hyperparameters = ReservoirHyperparameters(
-        input_size=2,
-        state_size=3,
+        input_size=input_size,
+        state_size=state_size,
         adjacency_matrix_sparsity=0.0,
         spectral_radius=1.0,
         input_coupling_sparsity=0,
@@ -91,10 +104,7 @@ def test_ReservoirComputingModel_state_increment():
     reservoir.W_in = sparse.coo_matrix(np.ones(reservoir.W_in.shape))
     reservoir.W_res = sparse.coo_matrix(np.ones(reservoir.W_res.shape))
 
-    readout = ReservoirComputingReadout(
-        linear_regressor=MultiOutputMeanRegressor(n_outputs=input_size),
-        square_half_hidden_state=False,
-    )
+    readout = MultiOutputMeanRegressor(n_outputs=input_size)
     predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
 
     predictor.reservoir.reset_state()
@@ -107,18 +117,17 @@ def test_ReservoirComputingModel_state_increment():
 
 def test_prediction_after_load(tmpdir):
     input_size = 15
+    state_size = 1000
     hyperparameters = ReservoirHyperparameters(
         input_size=input_size,
-        state_size=1000,
+        state_size=state_size,
         adjacency_matrix_sparsity=0.9,
         spectral_radius=1.0,
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters)
-    readout = ReservoirComputingReadout(
-        linear_regressor=MultiOutputMeanRegressor(n_outputs=input_size),
-        square_half_hidden_state=True,
-    )
+    readout = generic_readout()
+    readout.fit(np.random.rand(1, state_size), np.ones((1, input_size)))
     predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout,)
     predictor.reservoir.reset_state()
 
@@ -150,18 +159,20 @@ class MockImperfectModel:
 def test_hybrid_prediction_after_load(tmpdir):
     imperfect_model = MockImperfectModel(offset=0.1)
     input_size = 15
+    state_size = 1000
     hyperparameters = ReservoirHyperparameters(
         input_size=input_size,
-        state_size=1000,
+        state_size=state_size,
         adjacency_matrix_sparsity=0.9,
         spectral_radius=1.0,
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters)
-    readout = ReservoirComputingReadout(
-        linear_regressor=MultiOutputMeanRegressor(n_outputs=input_size),
-        square_half_hidden_state=True,
-    )
+
+    # readout = MultiOutputMeanRegressor(n_outputs=input_size)
+    readout = generic_readout()
+    readout.fit(np.random.rand(1, state_size + input_size), np.ones((1, input_size)))
+
     hybrid_predictor = HybridReservoirComputingModel(
         reservoir=reservoir, readout=readout,
     )
@@ -206,10 +217,7 @@ def test_hybrid_gives_different_results():
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters)
-    readout = ReservoirComputingReadout(
-        linear_regressor=MultiOutputMeanRegressor(n_outputs=input_size),
-        square_half_hidden_state=True,
-    )
+    readout = MultiOutputMeanRegressor(n_outputs=input_size)
     predictor = ReservoirComputingModel(reservoir=reservoir, readout=readout)
     hybrid_predictor = HybridReservoirComputingModel(
         reservoir=reservoir, readout=readout,
@@ -256,10 +264,7 @@ def create_domain_predictor(
     subdomain_predictors = []
     for i in range(n_subdomains):
         reservoir = Reservoir(hyperparameters)
-        readout = ReservoirComputingReadout(
-            linear_regressor=MultiOutputMeanRegressor(n_outputs=subdomain_size),
-            square_half_hidden_state=False,
-        )
+        readout = MultiOutputMeanRegressor(n_outputs=subdomain_size)
         if type == "reservoir_only":
             subdomain_predictors.append(
                 ReservoirComputingModel(reservoir=reservoir, readout=readout,)


### PR DESCRIPTION
This PR makes some changes to the existing `Reservoir` and `ReservoirComputingReadout` classes to allow for easier prediction over multiple subdomains in a single call. 

- `Reservoir.increment_state` can operate on a matrix where the each column is the input from a separate subdomain. This saves iterations if we are to use the same reservoir weights across multiple subdomains. Previously, reservoir state updates only worked if the input and reservoir states were 1d arrays.
- `ReservoirComputingReadout` is refactored to save the linear regression coefficients and intercepts as attributes, rather than an sklearn regressor object. This makes combining multiple readouts more straightforward. Instead of being initialized with an sklearn regressor object, the class is initialized with the `ReadoutHyperparameters` and the sklearn regressor is created and fit when `.fit` is called. The class can be initialized with previously-fit values for these, by default they are None and updated when `ReservoirComputingReadout.fit` is called. An exception is raised if `.fit` is called but these attributes are not None.

This also adds a `CombinedReservoirComputingReadout` class that combines multiple trained readouts into a single readout. Let's say there's N subdomains, each with a reservoir state vector of length s. Unlike the method of combining reservoir prediction across subdomains, each subdomain is assumed to use a different readout, so the input to the combined readout `.predict` is a 1D array of length N x s. The coefficient matrices of N individual readouts are combined into a block diagonal matrix. The intercepts are concatenated into a 1D array of length N x s.



- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/8a6fd204-026b-44c7-8cce-01f6d30b9890/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)