### PR TITLE
Make unstacked_dims property default to ("z",)

### DIFF
--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -52,8 +52,8 @@ class BatchesFromMapperConfig(BatchesLoader):
         needs_grid: Add grid information into batched datasets. [Warning] requires
             remote GCS access
         in_memory: if True, load data eagerly and keep it in memory
-        unstacked_dims: if given, produce stacked and shuffled batches retaining
-            these dimensions as unstacked (non-sample) dimensions
+        unstacked_dims: Produce stacked and shuffled batches retaining
+            these dimensions as unstacked (non-sample) dimensions. Defaults to ("z",).
         subsample_ratio: the fraction of data to retain in each batch, selected
             at random along the sample dimension.
         drop_nans: if True, drop samples with NaN values from the data, and raise an
@@ -73,7 +73,7 @@ class BatchesFromMapperConfig(BatchesLoader):
     res: str = "c48"
     needs_grid: bool = True
     in_memory: bool = False
-    unstacked_dims: Optional[Sequence[str]] = None
+    unstacked_dims: Optional[Sequence[str]] = ("z",)
     subsample_ratio: float = 1.0
     drop_nans: bool = False
     shuffle_timesteps: bool = True

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -299,6 +299,12 @@ def main(args):
         as_dict = yaml.safe_load(f)
     config = loaders.BatchesLoader.from_dict(as_dict)
 
+    if not (config.unstacked_dims is None):
+        logger.warn(
+            "The unstacked_dims property of data configuration is being set to None."
+        )
+        config.unstacked_dims = None
+
     if args.evaluation_grid is None:
         evaluation_grid = load_grid_info(EVALUATION_RESOLUTION)
     else:


### PR DESCRIPTION
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
