### PR TITLE
Allow offline diags to work for 2D only outputs

### DIFF
--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -23,6 +23,7 @@ spec:
           - name: test_data_config
           - name: offline-diags-output
           - name: report-output
+          - {name: offline-diags-flags, value: " "}
           - {name: no-wandb, value: "false"}
           - {name: wandb-project, value: "argo-default"}
           - {name: wandb-tags, value: ""}
@@ -69,7 +70,8 @@ spec:
             python -m fv3net.diagnostics.offline.compute \
               {{inputs.parameters.ml-model}} \
               test_data.yaml \
-              {{inputs.parameters.offline-diags-output}}
+              {{inputs.parameters.offline-diags-output}} \
+              {{inputs.parameters.offline-diags-flags}}
 
             cat << EOF > training.yaml
             {{inputs.parameters.training_config}}

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -34,6 +34,7 @@ spec:
       - {name: memory-training, value: 6Gi}
       - {name: memory-offline-diags, value: 10Gi}
       - {name: training-flags, value: " "}
+      - {name: offline-diags-flags, value: " "}
       - {name: online-diags-flags, value: " "}
       - {name: do-prognostic-run, value: "true"}
       - {name: no-wandb, value: "false"}
@@ -115,6 +116,8 @@ spec:
                 value: "{{inputs.parameters.tag}},{{inputs.parameters.wandb-tags}}"
               - name: wandb-group
                 value: "{{inputs.parameters.wandb-group}}"
+              - name: offline-diags-flags
+                value: "{{inputs.parameters.offline-diags-flags}}"
       - name: insert-model-urls
         when: "{{inputs.parameters.do-prognostic-run}} == true"
         dependencies: [resolve-output-url]


### PR DESCRIPTION
[This issue ](https://github.com/ai2cm/fv3net/issues/2136)describes a problem where the offline diags require `pressure_thickness_of_atmospheric_layer` variable to be loaded even if the model is only predicting 2D outputs and doesn't use this information for diagnostics.

This PR adds an optional flag `--outputs-2d-only` that can be set to allow the diagnostics to proceed without loading this variable. It also adds `offline-diags-flags` as an optional argo parameter for `offline-diags` and `train-diags-prog` templates so this flag and `n-jobs` can be set for argo jobs.



Resolves #<2136> [JIRA-TAG]

Coverage reports (updated automatically):
