### PR TITLE
Delete slack notification for e2e CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.0
-  slack: circleci/slack@3.4.2
   gh: circleci/github-cli@2.1.0
   jq: circleci/jq@2.2.0
 jobs:
@@ -200,10 +199,7 @@ jobs:
       - run:
           name: Firewall rule deletion
           when: always
-          command: gcloud compute firewall-rules delete $firewall_name
-      - slack/status:
-          fail_only: true
-          mentions: "channel"
+          command: gcloud compute firewall-rules delete $firewall_name\
 
   validate_radiation_port:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
       - run:
           name: Firewall rule deletion
           when: always
-          command: gcloud compute firewall-rules delete $firewall_name\
+          command: gcloud compute firewall-rules delete $firewall_name
 
   validate_radiation_port:
     machine:


### PR DESCRIPTION
This is failing (https://app.circleci.com/pipelines/github/ai2cm/fv3net/13854/workflows/a36517d6-e74b-4691-97ea-bb5f8392afe7/jobs/128649) and the feature was not being used by anyone AFAIK. Deleting for simplicity.

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/e2f11dff-6f93-44bd-8f48-b467ca323e62\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)