### PR TITLE
Combine optimizer settings for cyclegan

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
@@ -33,10 +33,8 @@ class CycleGANNetworkConfig:
     Configuration for building and training a CycleGAN network.
 
     Attributes:
-        generator_optimizer: configuration for the optimizer used to train the
-            generator
-        discriminator_optimizer: configuration for the optimizer used to train the
-            discriminator
+        optimizer: configuration for the optimizer used to train the
+            generator and discriminator
         generator: configuration for building the generator network
         discriminator: configuration for building the discriminator network
         identity_loss: loss function used to make the generator which outputs
@@ -53,10 +51,7 @@ class CycleGANNetworkConfig:
         discriminator_weight: weight of the discriminator gan loss
     """
 
-    generator_optimizer: OptimizerConfig = dataclasses.field(
-        default_factory=lambda: OptimizerConfig("Adam")
-    )
-    discriminator_optimizer: OptimizerConfig = dataclasses.field(
+    optimizer: OptimizerConfig = dataclasses.field(
         default_factory=lambda: OptimizerConfig("Adam")
     )
     generator: "GeneratorConfig" = dataclasses.field(
@@ -92,12 +87,12 @@ class CycleGANNetworkConfig:
         )
         discriminator_a = self.discriminator.build(n_state, convolution=convolution)
         discriminator_b = self.discriminator.build(n_state, convolution=convolution)
-        optimizer_generator = self.generator_optimizer.instance(
+        optimizer_generator = self.optimizer.instance(
             itertools.chain(
                 generator_a_to_b.parameters(), generator_b_to_a.parameters()
             )
         )
-        optimizer_discriminator = self.discriminator_optimizer.instance(
+        optimizer_discriminator = self.optimizer.instance(
             itertools.chain(discriminator_a.parameters(), discriminator_b.parameters())
         )
         model = CycleGANModule(

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -197,13 +197,8 @@ def test_cyclegan_runs_without_errors(tmpdir, conv_type: str, regtest):
             generator=fv3fit.pytorch.GeneratorConfig(
                 n_convolutions=2, n_resnet=5, max_filters=128, kernel_size=3
             ),
-            generator_optimizer=fv3fit.pytorch.OptimizerConfig(
-                name="Adam", kwargs={"lr": 0.001}
-            ),
+            optimizer=fv3fit.pytorch.OptimizerConfig(name="Adam", kwargs={"lr": 0.001}),
             discriminator=fv3fit.pytorch.DiscriminatorConfig(kernel_size=3),
-            discriminator_optimizer=fv3fit.pytorch.OptimizerConfig(
-                name="Adam", kwargs={"lr": 0.001}
-            ),
             convolution_type=conv_type,
             identity_weight=0.01,
             cycle_weight=10.0,

--- a/projects/cyclegan/c48_to_c384/training.yaml
+++ b/projects/cyclegan/c48_to_c384/training.yaml
@@ -7,14 +7,10 @@ hyperparameters:
     normalization_fit_samples: 50_000
     network:
       convolution_type: halo_conv2d
-      generator_optimizer:
+      optimizer:
         name: Adam
         kwargs:
-          lr: 0.0002
-      discriminator_optimizer:
-        name: Adam
-        kwargs:
-          lr: 0.0002
+          lr: 1.0e-3
       generator:
         n_convolutions: 2
         n_resnet: 6


### PR DESCRIPTION
Currently the CycleGAN network configuration has separate configurations for the generator and discriminator optimizers. This is an issue when running hyperparameter sweeps, as there is no way to link the learning rate of these two optimizers when performing sweeps.

This PR merges the configuration for the two optimizers, which will allow hyperparameter sweeps. The relative learning rates of these two models can still be modified by setting different scale factors on the generator and discriminator loss functions.

Refactored public API:
- CycleGANNetworkConfig now has one `optimizer` setting instead of separate `discriminator_optimizer` and `generator_optimizer` settings

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/c4ef5656-3ffa-40d1-8307-85ee0aaff222/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)