### PR TITLE
Add option to save CycleGAN checkpoint models

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
@@ -51,6 +51,8 @@ class CycleGANNetworkConfig:
         cycle_weight: weight of the cycle loss
         generator_weight: weight of the generator's gan loss
         discriminator_weight: weight of the discriminator gan loss
+        reload_path: path to a directory containing a saved CycleGAN model to use
+            as a starting point for training
     """
 
     generator_optimizer: OptimizerConfig = dataclasses.field(

--- a/external/fv3fit/fv3fit/pytorch/predict.py
+++ b/external/fv3fit/fv3fit/pytorch/predict.py
@@ -279,7 +279,7 @@ def _load_pytorch(cls: Type[_PytorchDumpable], path: str):
         model = torch.load(f, map_location=DEVICE)
     with fs.open(os.path.join(path, cls._SCALERS_FILENAME), "rb") as f:
         scalers = load_mapping(StandardScaler, f)
-    with open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
+    with fs.open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
         config = yaml.load(f, Loader=yaml.Loader)
     obj = cls(model=model, scalers=scalers, **config)
     return obj
@@ -289,7 +289,7 @@ def _dump_pytorch(obj: _PytorchDumpable, path: str) -> None:
     fs = vcm.get_fs(path)
     model_filename = os.path.join(path, obj._MODEL_FILENAME)
     with fs.open(model_filename, "wb") as f:
-        torch.save(obj.model, model_filename)
+        torch.save(obj.model, f)
     with fs.open(os.path.join(path, obj._SCALERS_FILENAME), "wb") as f:
         dump_mapping(obj.scalers, f)
     with fs.open(os.path.join(path, obj._CONFIG_FILENAME), "w") as f:


### PR DESCRIPTION
This PR cleans up the CycleGAN training code and makes two improvements, adding a checkpointing option and fixing cloud dumping.

Refactored public API:
- `checkpoint_path` option has been added to CycleGANTrainingConfig, if given models will be dumped to labelled subdirectories under that path every epoch
- Fixed bug where CycleGAN models would not be able to save to remote paths (e.g. on gcsfs)

Significant internal changes:
- CycleGAN's fit_loop routines have been merged into one, making it easier to modify

- [ ] Tests added

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/6e4facf8-fb47-4fca-bf38-b242cca7e027/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)