### PR TITLE
Add argo configuration to perform pytorch wandb sweeps

### DIFF
--- a/projects/cyclegan/c48_to_c384/run_sweep.sh
+++ b/projects/cyclegan/c48_to_c384/run_sweep.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Manually run the 'wandb sweep ...' command first to get the sweep ID, then paste into argo submit parameter field
+# wandb sweep --entity ai2cm --project cyclegan-tuning sweep.yaml
+# wandb sweep --entity annakwa --project test-pire-dense-model-tuning sweep.yaml
+
+NAME=sweep-cyclegan-$(openssl rand --hex 6)
+
+argo submit --from workflowtemplate/wandb-sweep-torch-v1 \
+    -p sweep_id="ai2cm/cyclegan-tuning/g9wo6d38" \
+    -p training_config="$(< training.yaml)" \
+    -p training_data_config="$(< train-data.yaml)" \
+    -p validation_data_config="$(< validation-data.yaml)" \
+    -p max_runs="20" \
+    --name $NAME
+
+echo "argo get $NAME"

--- a/projects/cyclegan/c48_to_c384/sweep.yaml
+++ b/projects/cyclegan/c48_to_c384/sweep.yaml
@@ -1,0 +1,25 @@
+entity: ai2cm
+project:  cyclegan-tuning
+name: 2023-01-04-sweep
+command:  # note yaml filenames in this command are determined by sweep workflow, and do not need to match the local filenames
+  - ${env}
+  - python3
+  - -m
+  - fv3fit.train
+  - training_config.yaml
+  - training_data.yaml
+  - trained_model
+  - --validation-data-config
+  - validation_data.yaml
+method: random
+early_terminate:
+  type: hyperband
+  min_iter: 10
+metric:
+  goal: minimize
+  name: val_regularization_loss
+parameters:
+  network.optimizer.kwargs.lr:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.001

--- a/workflows/argo/kustomization.yaml
+++ b/workflows/argo/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - train-diags-prog.yaml
 - cubed-to-latlon.yaml
 - resolve-output-url.yaml
+- wandb-sweep.yaml
 configurations:
 - image-transformerconfig.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/workflows/argo/wandb-sweep.yaml
+++ b/workflows/argo/wandb-sweep.yaml
@@ -1,0 +1,85 @@
+# vim: set sts=2 ts=2 tw=2 sw=2 :
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: wandb-sweep-torch-v1
+spec:
+  entrypoint: wandb-sweep-torch-v1
+  volumes:
+    - name: workdir
+      emptyVol: {}
+    - name: gcp-key-secret
+      secret:
+        defaultMode: 420
+        secretName: gcp-key
+  templates:
+    - name: wandb-sweep-torch-v1
+      inputs:
+        parameters:
+          - name: sweep_id
+          - name: training_config
+          - name: training_data_config
+          - name: validation_data_config
+          - {name: max_runs, value: 50}
+          - {name: cpu, value: 6000m}
+          - {name: memory, value: 24Gi}
+          - {name: wandb-project, value: "argo-default"}
+          - {name: wandb-tags, value: " "}
+          - {name: wandb-run-group, value: " "}
+      container:
+        image: us.gcr.io/vcm-ml/fv3fit_torch
+        command: ["bash", "-c", "-x"]
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/gcp-credentials/key.json
+          - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+            value: /secret/gcp-credentials/key.json
+          - name: WANDB_ENTITY
+            value: ai2cm
+          - name: WANDB_PROJECT
+            value: "{{inputs.parameters.wandb-project}}"
+          - name: WANDB_RUN_GROUP
+            value: "{{inputs.parameters.wandb-run-group}}"
+        envFrom:
+          - secretRef:
+              name: wandb-service-token
+        volumeMounts:
+          - mountPath: /secret/gcp-credentials
+            name: gcp-key-secret
+        args:
+          - |
+            cat <<EOF >training_config.yaml
+            {{inputs.parameters.training_config}}
+            EOF
+            cat <<EOF >training_data.yaml
+            {{inputs.parameters.training_data_config}}
+            EOF
+            cat <<EOF >validation_data.yaml
+            {{inputs.parameters.validation_data_config}}
+            EOF
+            echo "Training Configuration:"
+            cat training_config.yaml
+            echo "Training Data Configuration:"
+            cat training_data.yaml
+            echo "Validation Data Configuration:"
+            cat validation_data.yaml
+            wandb agent --count {{inputs.parameters.max_runs}} {{inputs.parameters.sweep_id}}
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "gpu-sim-pool"
+        effect: "NoSchedule"
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      podSpecPatch: |
+        containers:
+          - name: main
+            resources:
+              limits:
+                cpu: "{{inputs.parameters.cpu}}"
+                memory: "{{inputs.parameters.memory}}"
+                nvidia.com/gpu: 1
+              requests:
+                cpu: "{{inputs.parameters.cpu}}"
+                memory: "{{inputs.parameters.memory}}"


### PR DESCRIPTION
This PR adds an argo template to perform Weights and Biases (wandb) hyperparameter sweeps with pytorch models.

Added public API:
- added wandb-sweep-torch-v1 argo template

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/cd4b7273-c053-4fa8-a814-66b59b342d39/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)