### PR TITLE
Add postphysics bias correction prescriber option

### DIFF
--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -50,6 +50,8 @@ class UserConfig:
         nudging: nudge2fine configuration. Cannot be used if any scikit_learn model
             urls are specified.
         tendency_prescriber: configuration for overriding physics tendencies.
+        bias_correction: configuration for using bias correction tendencies
+            from a dataset.
     """
 
     diagnostics: List[DiagnosticFileConfig] = dataclasses.field(default_factory=list)
@@ -62,6 +64,7 @@ class UserConfig:
     tendency_prescriber: Optional[TendencyPrescriberConfig] = None
     online_emulator: Optional[runtime.transformers.fv3fit.Config] = None
     radiation_scheme: Optional[RadiationStepperConfig] = None
+    bias_correction: Optional[PrescriberConfig] = None
 
     @property
     def diagnostic_variables(self) -> Iterable[str]:

--- a/workflows/prognostic_c48_run/runtime/factories.py
+++ b/workflows/prognostic_c48_run/runtime/factories.py
@@ -154,7 +154,12 @@ def get_prescriber(
         config.reference_initial_time,
         config.reference_frequency_seconds,
     )
-    return Prescriber(communicator, time_lookup_function, config.variables)
+    return Prescriber(
+        communicator=communicator,
+        time_lookup_function=time_lookup_function,
+        variables=config.variables,
+        tendency_variables=config.tendency_variables,
+    )
 
 
 def get_radiation_stepper(

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -407,6 +407,11 @@ class TimeLoop(
         elif config.nudging:
             self._log_info("Using NudgingStepper for postphysics updates")
             stepper = PureNudger(config.nudging, self._get_communicator(), hydrostatic)
+        elif config.bias_correction:
+            self._log_info("Using bias correction for postphysics updates")
+            stepper = runtime.factories.get_prescriber(
+                config.bias_correction, self._get_communicator()
+            )
         else:
             self._log_info("Performing baseline simulation")
             stepper = None

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -357,7 +357,10 @@ class TimeLoop(
         if isinstance(stepper_config, MachineLearningConfig):
             model = self._open_model(stepper_config)
             stepper: Union[PureMLStepper, Prescriber] = PureMLStepper(
-                model, self._timestep, hydrostatic
+                model=model,
+                timestep=self._timestep,
+                hydrostatic=hydrostatic,
+                communicator=self._get_communicator(),
             )
             self._log_info(f"Using PureMLStepper at {step}.")
         else:

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -357,10 +357,7 @@ class TimeLoop(
         if isinstance(stepper_config, MachineLearningConfig):
             model = self._open_model(stepper_config)
             stepper: Union[PureMLStepper, Prescriber] = PureMLStepper(
-                model=model,
-                timestep=self._timestep,
-                hydrostatic=hydrostatic,
-                communicator=self._get_communicator(),
+                model=model, timestep=self._timestep, hydrostatic=hydrostatic,
             )
             self._log_info(f"Using PureMLStepper at {step}.")
         else:

--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -232,9 +232,18 @@ def to_fv3config(dict_: dict,) -> dict:
     """
     user_config = HighLevelConfig.from_dict(dict_)
 
-    if user_config.nudging and user_config.scikit_learn:
+    n_postphysics_configs = sum(
+        c is not None
+        for c in [
+            user_config.nudging,
+            user_config.scikit_learn,
+            user_config.bias_correction,
+        ]
+    )
+    if n_postphysics_configs > 1:
         raise NotImplementedError(
-            "Nudging and machine learning cannot currently be run at the same time."
+            "Only one of (bias correction, nudging, or machine learning) "
+            "postphysics updates can be run at the same time."
         )
 
     return user_config.to_fv3config()

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -11,7 +11,6 @@ from runtime.diagnostics import compute_diagnostics, compute_ml_momentum_diagnos
 from runtime.names import DELP, SPHUM, is_state_update_variable, is_tendency_variable
 from runtime.types import Diagnostics, State
 import vcm
-import pace.util
 
 
 __all__ = ["MachineLearningConfig", "PureMLStepper", "open_model"]
@@ -204,10 +203,9 @@ def download_model(config: MachineLearningConfig, path: str) -> Sequence[str]:
     return local_model_paths
 
 
-def predict(model: MultiModelAdapter, state: State, rank: int) -> State:
-    """Given ML model, state, rank, return prediction"""
+def predict(model: MultiModelAdapter, state: State) -> State:
+    """Given ML model and state, return prediction"""
     state_loaded = {key: state[key] for key in model.input_variables}
-    state_loaded["rank"] = xr.DataArray(rank, name="rank")
     ds = xr.Dataset(state_loaded)  # type: ignore
     output = model.predict(ds)
     return {key: cast(xr.DataArray, output[key]) for key in output.data_vars}
@@ -222,7 +220,6 @@ class PureMLStepper:
         model: MultiModelAdapter,
         timestep: float,
         hydrostatic: bool,
-        communicator: pace.util.CubedSphereCommunicator,
         mse_conserving_limiter: bool = True,
     ):
         """A stepper for predicting machine learning tendencies and state updates.
@@ -231,26 +228,20 @@ class PureMLStepper:
             model: the machine learning model.
             timestep: physics timestep in seconds.
             hydrostatic: whether simulation is hydrostatic. For net heating diagnostic.
-            communicator: pace.util.CubedSphereCommunicator
             mse_conserving_limiter (optional): whether to use MSE-conserving humidity
                 limiter. Defaults to True.
-
-
         """
         self.model = model
         self.timestep = timestep
         self.hydrostatic = hydrostatic
         self.mse_conserving_limiter = mse_conserving_limiter
-        self.communicator = communicator
 
     def __call__(self, time, state):
 
         diagnostics: Diagnostics = {}
         delp = state[DELP]
 
-        prediction: State = predict(
-            model=self.model, state=state, rank=self.communicator.rank
-        )
+        prediction: State = predict(self.model, state)
 
         tendency, state_updates = {}, {}
         for key, value in prediction.items():

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -24,6 +24,8 @@ class PrescriberConfig:
             defaults to True
         reference_initial_time: if time interpolating, time of first point in dataset
         reference_frequency_seconds: time frequency of dataset
+        tendency_variables: optional mapping of tendency variable names in the dataset
+            to the state variables they update
 
     Example::
 
@@ -42,6 +44,7 @@ class PrescriberConfig:
     consolidated: bool = True
     reference_initial_time: Optional[str] = None
     reference_frequency_seconds: float = 900
+    tendency_variables: Optional[Mapping[str, str]] = None
 
 
 class Prescriber:
@@ -53,6 +56,7 @@ class Prescriber:
         communicator: pace.util.CubedSphereCommunicator,
         time_lookup_function: Callable[[cftime.DatetimeJulian], State],
         variables: Mapping[str, str],
+        tendency_variables: Optional[Mapping[str, str]],
     ):
         """Create a Prescriber object
 
@@ -62,14 +66,18 @@ class Prescriber:
                 containing data arrays to be prescribed
             variables: a mapping from variable names returned by the
                 `time_lookup_function` to the standard names to be prescribed
+            tendency_variables: mapping from tendency variable names returned by the
+                `time_lookup_function` to the standard tendency names used to update
+                the state
         """
         self._communicator = communicator
         self._time_lookup_function = time_lookup_function
         self._variables = variables
+        self._tendency_variables = tendency_variables or {}
 
     def _open_prescribed_timestep(self, time: cftime.DatetimeJulian) -> xr.Dataset:
         ds = scatter_within_tile(time, self._time_lookup_function, self._communicator)
-        return ds.rename(self._variables)
+        return ds.rename(**self._variables, **self._tendency_variables)
 
     def __call__(self, time, state):
         diagnostics: Diagnostics = {}
@@ -77,7 +85,7 @@ class Prescriber:
         prescribed_timestep: xr.Dataset = self._open_prescribed_timestep(time)
         state_updates: State = {}
 
-        for name in prescribed_timestep.data_vars:
+        for name in self._variables.values():
             if name == MASK:
                 state_updates[name] = prescribed_timestep[name].round()
 
@@ -93,7 +101,11 @@ class Prescriber:
                 state_updates[name] = prescribed_timestep[name]
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]
+
         tendency: Tendencies = {}
+        for name in self._tendency_variables.values():
+            tendency[name] = prescribed_timestep[name]
+
         return tendency, diagnostics, state_updates
 
     def get_diagnostics(self, state, tendency) -> Tuple[Diagnostics, xr.DataArray]:

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -83,7 +83,11 @@ class Prescriber:
         diagnostics: Diagnostics = {}
 
         prescribed_timestep: xr.Dataset = self._open_prescribed_timestep(time)
+        tendency: Tendencies = {}
         state_updates: State = {}
+
+        for name in self._tendency_variables.values():
+            tendency[name] = prescribed_timestep[name]
 
         for name in self._variables.values():
             if name == MASK:
@@ -101,10 +105,6 @@ class Prescriber:
                 state_updates[name] = prescribed_timestep[name]
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]
-
-        tendency: Tendencies = {}
-        for name in self._tendency_variables.values():
-            tendency[name] = prescribed_timestep[name]
 
         return tendency, diagnostics, state_updates
 

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -1,3 +1,4 @@
+bias_correction: null
 data_table: default
 diag_table:
   base_time: 2000-01-01 00:00:00
@@ -442,7 +443,6 @@ zhao_carr_emulation:
     cloud_squash: null
     enforce_conservative: false
     enforce_conservative_phase_dependent: false
-    enforce_strict_precpd_conservative: false
     gscond_cloud_conservative: false
     mask_emulator_levels: {}
     mask_gscond_identical_cloud: false
@@ -455,7 +455,6 @@ zhao_carr_emulation:
       period: 21600
     path: gs://vcm-ml-experiments/microphysics-emulation/2022-03-02/limit-tests-limiter-all-loss-rnn-7ef273/model.tf
     ranges: {}
-    simple_precip_conservative: false
     tensor_transform: []
   storage:
     output_freq_sec: 3600

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[emulator].out
@@ -443,6 +443,7 @@ zhao_carr_emulation:
     cloud_squash: null
     enforce_conservative: false
     enforce_conservative_phase_dependent: false
+    enforce_strict_precpd_conservative: false
     gscond_cloud_conservative: false
     mask_emulator_levels: {}
     mask_gscond_identical_cloud: false
@@ -455,6 +456,7 @@ zhao_carr_emulation:
       period: 21600
     path: gs://vcm-ml-experiments/microphysics-emulation/2022-03-02/limit-tests-limiter-all-loss-rnn-7ef273/model.tf
     ranges: {}
+    simple_precip_conservative: false
     tensor_transform: []
   storage:
     output_freq_sec: 3600

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[fine-res-ml].out
@@ -1,3 +1,4 @@
+bias_correction: null
 data_table: default
 diag_table:
   base_time: 2000-01-01 00:00:00

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[ml].out
@@ -1,3 +1,4 @@
+bias_correction: null
 data_table: default
 diag_table:
   base_time: 2000-01-01 00:00:00

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2f].out
@@ -1,3 +1,4 @@
+bias_correction: null
 data_table: default
 diag_table:
   base_time: 2000-01-01 00:00:00

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2o].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[n2o].out
@@ -1,3 +1,4 @@
+bias_correction: null
 data_table: default
 diag_table:
   base_time: 2000-01-01 00:00:00

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -89,3 +89,13 @@ def test_config_high_level_duration_respects_namelist():
     config = HighLevelConfig(namelist={"coupler_nml": {"seconds": 7}})
     out = config.to_fv3config()
     assert out["namelist"]["coupler_nml"]["seconds"] == 7
+
+
+def test_error_on_multiple_postphysics():
+
+    dict_ = {
+        "nudging": {"restarts_path": "/path/", "timescale_hours": {"T": 1}},
+        "scikit_learn": {"model": ["/path/"]},
+    }
+    with pytest.raises(NotImplementedError):
+        prepare_config.to_fv3config(dict_)


### PR DESCRIPTION
Currently the prognostic run `Prescriber` option only is available for state updates in the prephysics stepper. 

This PR adds 
- a`bias_correction` top level configuration field, which uses the same config as other prescribers and will be used as a postphysics stepper. I'm open to alternate naming suggestions.
- an optional field `PrescriberConfig.tendency_variables` which is a mapping of tendency field names in the prescriber dataset to the tendency name conventions used in the prog run (e.g. "dQ1"). If this field exists, the `Prescriber` will return these tendencies (as opposed to always returning empty tendencies before)

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/ba68c227-0050-434c-bb03-2bd2a4b97719\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)