### PR TITLE
Experiment/renaming predictor adapter

### DIFF
--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -37,6 +37,13 @@ class RenamedModel(Predictor):
         output = self.model.predict(X)
         return output.rename(self.renaming)
 
+    def dump(self, path):
+        raise NotImplementedError(
+            "no dump method yet for this class, you can define one manually "
+            "using instructions at "
+            "http://vulcanclimatemodeling.com/docs/fv3fit/composite-models.html"
+        )
+
 
 @io.register("derived_model")
 class DerivedModel(Predictor):


### PR DESCRIPTION
Experiment branch for simple model renaming adapter. Needs this feature at the model loading level so that novelty detector model can work on a renaming of `tapered_dQx -> dQx`


(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/ai2cm/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/5de706b0-019d-4add-97bc-d2cf8f5a4e10/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)