### PR TITLE
Tapering wrapper

### DIFF
--- a/external/fv3fit/docs/composite-models.rst
+++ b/external/fv3fit/docs/composite-models.rst
@@ -38,3 +38,17 @@ Models augmented with out-of-sample detection can be defined with a config file 
     base_model_path: gs://vcm-ml-experiments/2021-01-26-c3072-nn/l2/tq-seed-0/trained_model
     novelty_detector_path: # path to a min-max or OCSVM novelty detector
     cutoff: 0 # can be omitted and use the default value for a given predictor instead.
+
+
+Tapered models
+--------------------
+A tapering transform can be applied to an existing saved model:
+.. code-block:: yaml
+    model: gs://vcm-ml-experiments/some_path
+    tapering:
+        dQ1:
+            cutoff: 25
+            rate: 5
+        dQ2:
+            cutoff: 25
+            rate: 5

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -9,7 +9,7 @@ from typing import (
 # TODO: move all keras configs under fv3fit.keras
 import tensorflow as tf
 import xarray as xr
-from vcm.calc.calc import vertical_tapering_scale_factors
+import vcm
 
 
 @dataclasses.dataclass
@@ -18,10 +18,10 @@ class TaperConfig:
     rate: float
     taper_dim: str = "z"
 
-    def apply(self, data: xr.DataArray):
+    def apply(self, data: xr.DataArray) -> xr.DataArray:
         n_levels = len(data[self.taper_dim])
         scaling = xr.DataArray(
-            vertical_tapering_scale_factors(
+            vcm.vertical_tapering_scale_factors(
                 n_levels=n_levels, cutoff=self.cutoff, rate=self.rate
             ),
             dims=[self.taper_dim],

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -8,6 +8,25 @@ from typing import (
 
 # TODO: move all keras configs under fv3fit.keras
 import tensorflow as tf
+import xarray as xr
+from vcm.calc.calc import vertical_tapering_scale_factors
+
+
+@dataclasses.dataclass
+class TaperConfig:
+    cutoff: int
+    rate: float
+    taper_dim: str = "z"
+
+    def apply(self, data: xr.DataArray):
+        n_levels = len(data[self.taper_dim])
+        scaling = xr.DataArray(
+            vertical_tapering_scale_factors(
+                n_levels=n_levels, cutoff=self.cutoff, rate=self.rate
+            ),
+            dims=[self.taper_dim],
+        )
+        return scaling * data
 
 
 @dataclasses.dataclass

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -47,7 +47,7 @@ class TaperedModel(Predictor):
         return cls(model, tapering)
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
-        """Predict an output xarray dataset and rename outputs"""
+        """Predict an output xarray dataset and taper outputs"""
         output = self.model.predict(X)
         for taper_variable, taper_config in self.tapering.items():
             output[taper_variable] = taper_config.apply(output[taper_variable])

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Callable, Iterable, Optional, Set, Hashable, Sequence, cast
+from typing import Callable, Iterable, Optional, Set, Hashable, Sequence, cast, Mapping
 import dacite
 import fsspec
 import yaml
@@ -10,9 +10,55 @@ import vcm
 
 from fv3fit._shared.novelty_detector import NoveltyDetector
 from fv3fit._shared.taper_function import get_taper_function, taper_mask
+from fv3fit._shared.config import TaperConfig
 
 from . import io
 from .predictor import Predictor
+
+
+@io.register("tapered_model")
+class TaperedModel(Predictor):
+    _CONFIG_FILENAME = "tapered_model.yaml"
+
+    def __init__(self, model, tapering: Mapping[str, TaperConfig]):
+        for taper_var in tapering:
+            if taper_var not in model.output_variables:
+                raise KeyError(
+                    f"Tapered variable {taper_var} not in model output variables."
+                )
+        self.model = model
+        self.tapering = tapering
+
+        super().__init__(
+            input_variables=tuple(sorted(model.input_variables)),
+            output_variables=tuple(sorted(model.output_variables)),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "TaperedModel":
+        """Load a serialized model from a directory."""
+        with fsspec.open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
+            config = yaml.safe_load(f)
+        model = cast(Predictor, io.load(config["model"]))
+        tapering = {
+            taper_variable: dacite.from_dict(TaperConfig, taper_config)
+            for taper_variable, taper_config in config["tapering"].items()
+        }
+        return cls(model, tapering)
+
+    def predict(self, X: xr.Dataset) -> xr.Dataset:
+        """Predict an output xarray dataset and rename outputs"""
+        output = self.model.predict(X)
+        for taper_variable, taper_config in self.tapering.items():
+            output[taper_variable] = taper_config.apply(output[taper_variable])
+        return output
+
+    def dump(self, path):
+        raise NotImplementedError(
+            "no dump method yet for this class, you can define one manually "
+            "using instructions at "
+            "http://vulcanclimatemodeling.com/docs/fv3fit/composite-models.html"
+        )
 
 
 @io.register("derived_model")

--- a/external/fv3fit/tests/test_tapered_model.py
+++ b/external/fv3fit/tests/test_tapered_model.py
@@ -1,0 +1,70 @@
+import numpy as np
+import os
+import xarray as xr
+import yaml
+
+from fv3fit._shared.config import TaperConfig
+from fv3fit._shared.models import TaperedModel
+
+from fv3fit.testing import ConstantOutputPredictor
+
+
+class ConstantPredictor:
+    def __init__(self, input_variables, output_variables):
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+
+    def predict(self, X):
+        da = xr.ones_like(X[self.input_variables[0]])
+        return xr.Dataset({v: da for v in self.output_variables})
+
+
+def test_TaperedModel():
+    model = ConstantOutputPredictor(
+        input_variables=["in0", "in1"], output_variables=["out0", "out1"]
+    )
+    model.set_outputs(out1=np.ones(10), out0=np.ones(10))
+    taper_config0 = TaperConfig(cutoff=3, rate=5.0, taper_dim="z")
+    taper_config1 = TaperConfig(cutoff=6, rate=3.0, taper_dim="z")
+    tapered_model = TaperedModel(model, {"out0": taper_config0, "out1": taper_config1})
+    da = xr.DataArray(data=np.ones((5, 10)), dims=["x", "z"])
+    X = xr.Dataset({"in0": da, "in1": da})
+
+    tapered_prediction = tapered_model.predict(X)
+    np.testing.assert_array_equal(
+        tapered_prediction["out0"].values, taper_config0.apply(model.predict(X)["out0"])
+    )
+    np.testing.assert_array_equal(
+        tapered_prediction["out1"].values, taper_config1.apply(model.predict(X)["out1"])
+    )
+
+
+def test_TaperedModel_load(tmpdir):
+
+    model = ConstantOutputPredictor(
+        input_variables=["in0", "in1"], output_variables=["out0", "out1"]
+    )
+    model.set_outputs(out1=np.ones(10), out0=np.ones(10))
+
+    base_model_output_path = f"{str(tmpdir)}/predictor"
+    os.mkdir(base_model_output_path)
+    model.dump(base_model_output_path)
+    config = {
+        "tapering": {
+            "out0": {"cutoff": 3, "rate": 5},
+            "out1": {"cutoff": 2, "rate": 6},
+        },
+        "model": base_model_output_path,
+    }
+    output_path = f"{str(tmpdir)}/tapered_model"
+    os.mkdir(output_path)
+    with open(f"{output_path}/tapered_model.yaml", "w") as f:
+        yaml.dump(config, f)
+    with open(f"{output_path}/name", "w") as f:
+        print("tapered_model", file=f)
+
+    tapered_model = TaperedModel.load(output_path)
+    da = xr.DataArray(data=np.ones((5, 10)), dims=["x", "z"])
+    X = xr.Dataset({"in0": da, "in1": da})
+    tapered_prediction = tapered_model.predict(X)
+    assert np.mean(tapered_prediction["out0"]) < 1.0

--- a/external/fv3fit/tests/test_tapered_model.py
+++ b/external/fv3fit/tests/test_tapered_model.py
@@ -9,16 +9,6 @@ from fv3fit._shared.models import TaperedModel
 from fv3fit.testing import ConstantOutputPredictor
 
 
-class ConstantPredictor:
-    def __init__(self, input_variables, output_variables):
-        self.input_variables = input_variables
-        self.output_variables = output_variables
-
-    def predict(self, X):
-        da = xr.ones_like(X[self.input_variables[0]])
-        return xr.Dataset({v: da for v in self.output_variables})
-
-
 def test_TaperedModel():
     model = ConstantOutputPredictor(
         input_variables=["in0", "in1"], output_variables=["out0", "out1"]

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -17,7 +17,7 @@ from .convenience import (
     shift_timestamp,
     round_time,
 )
-from .calc.calc import local_time, weighted_average
+from .calc.calc import local_time, weighted_average, vertical_tapering_scale_factors
 from .calc._zenith_angle import cos_zenith_angle
 from .calc.metrics import (
     r2_score,


### PR DESCRIPTION
This PR adds a wrapper for a `TaperedModel`  that can be applied to an existing saved model.
The new model type is manually created via a yaml configuration in a similar manner as the `EnsembleModel`, see added documentation.


- [x] Tests added


Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/c4715f3e-b5f6-4b8f-b3f1-822268339d6b\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)