### PR TITLE
Postphysics prescriber fix

### DIFF
--- a/workflows/prognostic_c48_run/runtime/factories.py
+++ b/workflows/prognostic_c48_run/runtime/factories.py
@@ -150,7 +150,7 @@ def get_prescriber(
         mapper = {}
     time_lookup_function = _get_time_lookup_function(
         mapper,
-        list(config.variables),
+        list(config.variables) + list(config.tendency_variables or []),
         config.reference_initial_time,
         config.reference_frequency_seconds,
     )

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -106,7 +106,7 @@ class Prescriber:
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]
         for name, update in tendency.items():
-            diagnostics[f"{name}_prescribed"] = update
+            diagnostics[f"{name}_prescribed_tendency"] = update
         return tendency, diagnostics, state_updates
 
     def get_diagnostics(self, state, tendency) -> Tuple[Diagnostics, xr.DataArray]:

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -105,7 +105,8 @@ class Prescriber:
                 state_updates[name] = prescribed_timestep[name]
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]
-
+        for name, update in tendency.items():
+            diagnostics[f"{name}_prescribed"] = update
         return tendency, diagnostics, state_updates
 
     def get_diagnostics(self, state, tendency) -> Tuple[Diagnostics, xr.DataArray]:

--- a/workflows/prognostic_c48_run/tests/test_prescriber.py
+++ b/workflows/prognostic_c48_run/tests/test_prescriber.py
@@ -125,16 +125,6 @@ def prescriber_output(external_dataset_path, layout):
     return state_updates_list, tendencies_list
 
 
-def get_expected_prescribed_tendency(layout):
-    vars_ = {
-        "renamed_bias_correction": BIAS_CORRECTION,
-    }
-    sizes = {"y": NXY // layout[0], "x": NXY // layout[1]}
-    ds = get_dataset(vars_, sizes, TIME_COORD)
-    ds = ds.sel(time=TIME_COORD[0], tile=0).drop_vars(["tile", "time"])
-    return {name: ds[name] for name in ds.data_vars}
-
-
 def get_expected_update_dataset(layout, updates):
     sizes = {"y": NXY // layout[0], "x": NXY // layout[1]}
     ds = get_dataset(updates, sizes, TIME_COORD)


### PR DESCRIPTION
I had to fix the prescribed tendency option to add the tendency variables to the list to load in the time lookup function.
I also added the prescribed tendencies to the diagnostics as `{tendency variable}_prescribed`.

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/0d2cc5f3-16ed-4485-8cf0-5b9de36ca489\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)