### PR TITLE
Add C12 grid data to the catalog

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -337,6 +337,50 @@ sources:
         access: read_only
       urlpath: "gs://vcm-ml-intermediate/2020-03-27-T85-GFS-nudging-data-as-zarr/nudging_data_mean_1M.zarr"
 
+  grid/c12:
+    description: Lat, lon, and area of C12 data
+    driver: zarr
+    metadata:
+      grid: c12
+      variables:
+        - area
+        - lat
+        - latb
+        - lon
+        - lonb
+    args:
+      urlpath: "gs://vcm-ml-intermediate/latLonArea/c12/c12.zarr/"
+      consolidated: true
+
+  landseamask/c12:
+    description: land_sea_mask of C12 data
+    driver: zarr
+    metadata:
+      grid: c12
+      variables:
+        - land_sea_mask
+    args:
+      urlpath: "gs://vcm-ml-intermediate/latLonArea/c12/land_sea_mask.zarr/"
+      consolidated: true
+
+  wind_rotation/c12:
+    description: Rotation matrix components transforming x/y components to lat/lon
+    driver: zarr
+    metadata:
+      grid: c12
+      variables:
+        - eastward_wind_u_coeff
+        - eastward_wind_v_coeff
+        - northward_wind_u_coeff
+        - northward_wind_v_coeff
+        - x_unit_vector
+        - y_unit_vector
+        - lat_unit_vector
+        - lon_unit_vector
+    args:
+      urlpath: "gs://vcm-ml-intermediate/latLonArea/c12/wind_rotation_matrix_correct_factor.zarr/"
+      consolidated: true
+
   grid/c48:
     description: Lat, lon, and area of C48 data
     driver: zarr


### PR DESCRIPTION
This PR adds catalog entries for C12 grid data I added to Google Cloud.  This will be useful for running extremely coarse-resolution experiments for testing.

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/9bb10303-0ce9-4ab5-9165-e3ddf56dbc22/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)