### PR TITLE
Always obtain offline diagnostics grid information from catalog

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -843,7 +843,7 @@ sources:
     args:
       storage_options:
         access: read_only
-      urlpath: "gs://vcm-ml-code-testing-data/c8-grids-regression-testing/grid.zarr/"
+      urlpath: "gs://vcm-ml-code-testing-data/c8-grids-regression-testing/grid-updated.zarr/"
       consolidated: true
 
   wind_rotation/c8_random_values:

--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -830,7 +830,11 @@ sources:
 
   # Regression testing data. Do not use for analysis, values are randomized.
   grid/c8_random_values:
-    description: FOR REGRESSION TESTING ONLY. Lat, lon, and area of C48 data
+    description: FOR REGRESSION TESTING ONLY. Lat, lon, and area of C48 data.  Updated on 2023-02-01 to
+      be consistent with the grid_spec.json schema in synth fv3net/external/synth/synth/_dataset_fixtures/grid_schema.json
+      with the land_sea_mask variable dropped.  This schema generates grid data with semi-realistic values, which are
+      required for the offline diagnostics compute integration test to pass (credit Brian Henn).  Previously this catalog
+      entry referred to gs://vcm-ml-code-testing-data/c8-grids-regression-testing/grid.zarr.
     driver: zarr
     metadata:
       grid: c8
@@ -843,7 +847,7 @@ sources:
     args:
       storage_options:
         access: read_only
-      urlpath: "gs://vcm-ml-code-testing-data/c8-grids-regression-testing/grid-updated.zarr/"
+      urlpath: "gs://vcm-ml-code-testing-data/c8-grids-regression-testing/2023-02-01-grid.zarr/"
       consolidated: true
 
   wind_rotation/c8_random_values:

--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -23,6 +23,7 @@ spec:
           - name: test_data_config
           - name: offline-diags-output
           - name: report-output
+          - {name: compute-flags, value: " "}
           - {name: no-wandb, value: "false"}
           - {name: wandb-project, value: "argo-default"}
           - {name: wandb-tags, value: ""}
@@ -69,7 +70,8 @@ spec:
             python -m fv3net.diagnostics.offline.compute \
               {{inputs.parameters.ml-model}} \
               test_data.yaml \
-              {{inputs.parameters.offline-diags-output}}
+              {{inputs.parameters.offline-diags-output}} \
+              {{inputs.parameters.compute-flags}}
 
             cat << EOF > training.yaml
             {{inputs.parameters.training_config}}

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -90,13 +90,13 @@ def _get_parser() -> argparse.ArgumentParser:
         default=EVALUATION_RESOLUTION,
         help=(
             f"Optional arguent that sets the grid resolution at which the diagnostics"
-            f"will be computed. If not provided, evaluation grid resolution will "
-            f"be {EVALUATION_RESOLUTION}. If validation data resolution is higher "
-            f"than the evaluation grid resolution by an integer multiple, the "
-            f"validation data will be coarsened to the evaluation grid resolution. "
-            f"Otherwise the evaluation grid resolution must match the validation "
-            f"data resolution. Grid and land mask entries must be present in the"
-            f"vcm catalog at the evaluation resolution."
+            f"will be computed (e.g. 'c12'). If not provided, evaluation grid "
+            f"resolution will be {EVALUATION_RESOLUTION}. If validation data "
+            f"resolution is higher than the evaluation grid resolution by an "
+            f"integer multiple, the validation data will be coarsened to the "
+            f"evaluation grid resolution. Otherwise the evaluation grid resolution "
+            f"must match the validation data resolution. Grid and land mask entries "
+            f"must be present in the vcm catalog at the evaluation resolution."
         ),
     )
     parser.add_argument(

--- a/workflows/diagnostics/tests/offline/test_compute.py
+++ b/workflows/diagnostics/tests/offline/test_compute.py
@@ -4,11 +4,6 @@ import tempfile
 import os
 import loaders
 import synth
-from synth import (  # noqa: F401
-    grid_dataset,
-    grid_dataset_path,
-    dataset_fixtures_dir,
-)
 
 import fv3fit
 from fv3net.diagnostics.offline._helpers import DATASET_DIM_NAME
@@ -39,7 +34,7 @@ def data_path(tmpdir, request):
     return str(tmpdir)
 
 
-def test_offline_diags_integration(data_path, grid_dataset_path):  # noqa: F811
+def test_offline_diags_integration(data_path):  # noqa: F811
     """
     Test the bash endpoint for computing offline diagnostics
     """
@@ -71,7 +66,7 @@ def test_offline_diags_integration(data_path, grid_dataset_path):  # noqa: F811
                 data_config_filename,
                 os.path.join(tmpdir, "offline_diags"),
                 "--evaluation-grid",
-                grid_dataset_path,
+                "c8_random_values",
                 "--n-jobs",
                 "1",
             ]


### PR DESCRIPTION
It is currently not possible to pass flags to the compute step in the offline diagnostics workflow.  This PR adds an option to do that.  The motivation for me adding this is to enable producing an offline report using C12 test data via the `--evaluation-grid` flag.

Refactored public API:

- The `evaluation-grid` flag associated with setting the evaluation grid resolution of the offline diagnostics workflow no longer accepts a path to a netCDF file.  It instead takes in a resolution string that can be used to read in grid information from the catalog, e.g. `"c12"`.  This makes it more consistent with other workflows (e.g. [in data loading for ML training](https://github.com/ai2cm/fv3net/blob/46afd21253778b4be32c2333c3f53311177ccbe6/external/loaders/loaders/batches/_batch.py#L73)) and more convenient (one no longer needs to construct a specific grid file or look up a path to a previous one to use an evaluation grid other than the default).

Coverage reports (updated automatically):
- test_unit: [60%](https://output.circle-artifacts.com/output/job/37b83e4e-f466-4829-aff7-caab15b63ff2/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)