### PR TITLE
Add combined output model

### DIFF
--- a/external/fv3fit/docs/composite-models.rst
+++ b/external/fv3fit/docs/composite-models.rst
@@ -52,3 +52,15 @@ A tapering transform can be applied to an existing saved model:
         dQ2:
             cutoff: 25
             rate: 5
+
+
+
+Combined models
+----------------
+Combines multiple models with nonoverlapping output variables into a single model.
+Similar functionality is also in the prognostic run's MultipleModelAdapter, but sometimes it
+is more efficient to combine models earlier in the workflow.
+.. code-block:: yaml
+models:
+    - gs://vcm-ml-experiments/model1
+    - gs://vcm-ml-experiments/model2

--- a/external/fv3fit/tests/test_combined_output_model.py
+++ b/external/fv3fit/tests/test_combined_output_model.py
@@ -24,12 +24,15 @@ def test_CombinedOutputModel():
     X = xr.Dataset({"in0": da, "in1": da, "in2": da})
 
     combined_model = CombinedOutputModel([model0, model1])
+    assert set(combined_model.input_variables) == {"in0", "in1", "in2"}
+    assert set(combined_model.output_variables) == {"out0a", "out0b", "out1a", "out1b"}
+
     combined_prediction = combined_model.predict(X)
     np.testing.assert_array_equal(
-        combined_prediction["out0a"].values, model0.predict(X)["out0a"]
+        combined_prediction["out0a"], model0.predict(X)["out0a"]
     )
     np.testing.assert_array_equal(
-        combined_prediction["out1a"].values, model1.predict(X)["out1a"]
+        combined_prediction["out1a"], model1.predict(X)["out1a"]
     )
 
 

--- a/external/fv3fit/tests/test_combined_output_model.py
+++ b/external/fv3fit/tests/test_combined_output_model.py
@@ -1,0 +1,78 @@
+import numpy as np
+import os
+import pytest
+import xarray as xr
+import yaml
+
+
+from fv3fit._shared.models import CombinedOutputModel
+from fv3fit.testing import ConstantOutputPredictor
+
+
+def test_CombinedOutputModel():
+    model0 = ConstantOutputPredictor(
+        input_variables=["in0", "in1"], output_variables=["out0a", "out0b"]
+    )
+    model1 = ConstantOutputPredictor(
+        input_variables=["in1", "in2"], output_variables=["out1a", "out1b"]
+    )
+
+    model0.set_outputs(out0a=np.ones(10), out0b=np.ones(10))
+    model1.set_outputs(out1a=np.ones(10) * 2, out1b=np.ones(10) * 2)
+
+    da = xr.DataArray(data=np.ones((5, 10)), dims=["x", "z"])
+    X = xr.Dataset({"in0": da, "in1": da, "in2": da})
+
+    combined_model = CombinedOutputModel([model0, model1])
+    combined_prediction = combined_model.predict(X)
+    np.testing.assert_array_equal(
+        combined_prediction["out0a"].values, model0.predict(X)["out0a"]
+    )
+    np.testing.assert_array_equal(
+        combined_prediction["out1a"].values, model1.predict(X)["out1a"]
+    )
+
+
+def test_CombinedOutputModel_load(tmpdir):
+    model0 = ConstantOutputPredictor(
+        input_variables=["in0", "in1"], output_variables=["out0a", "out0b"]
+    )
+    model1 = ConstantOutputPredictor(
+        input_variables=["in1", "in2"], output_variables=["out1a", "out1b"]
+    )
+
+    model0.set_outputs(out0a=np.ones(10), out0b=np.ones(10))
+    model1.set_outputs(out1a=np.ones(10) * 2, out1b=np.ones(10) * 2)
+
+    config = {"models": []}
+
+    for i, model in enumerate([model0, model1]):
+        base_model_output_path = f"{str(tmpdir)}/predictor{i}"
+        os.mkdir(base_model_output_path)
+        model.dump(base_model_output_path)
+        config["models"].append(base_model_output_path)
+
+    output_path = f"{str(tmpdir)}/combined_output_model"
+    os.mkdir(output_path)
+    with open(f"{output_path}/combined_output_model.yaml", "w") as f:
+        yaml.dump(config, f)
+    with open(f"{output_path}/name", "w") as f:
+        print("combined_output_model", file=f)
+
+    da = xr.DataArray(data=np.ones((5, 10)), dims=["x", "z"])
+    X = xr.Dataset({"in0": da, "in1": da, "in2": da})
+
+    combined_model = CombinedOutputModel.load(output_path)
+    combined_prediction = combined_model.predict(X)
+    assert {"out0a", "out0b", "out1a", "out1b"} == set(combined_prediction.data_vars)
+
+
+def test_error_on_duplicate_outputs():
+    model0 = ConstantOutputPredictor(
+        input_variables=["in0", "in1"], output_variables=["out0a", "out0b"]
+    )
+    model1 = ConstantOutputPredictor(
+        input_variables=["in1", "in2"], output_variables=["out0a"]
+    )
+    with pytest.raises(ValueError):
+        CombinedOutputModel([model0, model1])

--- a/external/fv3fit/tests/test_combined_output_model.py
+++ b/external/fv3fit/tests/test_combined_output_model.py
@@ -28,6 +28,7 @@ def test_CombinedOutputModel():
     assert set(combined_model.output_variables) == {"out0a", "out0b", "out1a", "out1b"}
 
     combined_prediction = combined_model.predict(X)
+
     np.testing.assert_array_equal(
         combined_prediction["out0a"], model0.predict(X)["out0a"]
     )


### PR DESCRIPTION
This PR adds the `CombinedOutputModel` class, which combines multiple models with nonoverlapping output variables into a single model. It replicates functionality in the prognostic run's [`MultipleModelAdapter`](https://github.com/ai2cm/fv3net/blob/46afd21253778b4be32c2333c3f53311177ccbe6/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py#L150), but sometimes it is more efficient to combine models earlier in the workflow. e.g. using the novelty detector to wrap a `CombinedOutputModel` once instead of wrapping individual models helps to cut down on evaluation time.

- [x] Tests added

Coverage reports (updated automatically):
- test_unit: [60%](https:\/\/output.circle-artifacts.com\/output\/job\/823fa706-f586-4868-bd7a-c0cec945e495\/artifacts\/0\/tmp\/coverage\/htmlcov-test_unit\/index.html)