### PR TITLE
vcm: in-cloud <-> gridcell-mean condensate mappings

### DIFF
--- a/external/vcm/tests/test_calc_clouds.py
+++ b/external/vcm/tests/test_calc_clouds.py
@@ -1,0 +1,76 @@
+import xarray as xr
+import pytest
+from vcm import gridcell_to_incloud_condensate, incloud_to_gridcell_condensate
+
+
+def get_cloud_arrays():
+    cloud_fraction = xr.DataArray([1.0e-3, 1.0e-2, 1.0e-1], dims=["x"])
+    gridcell_mean_condensate = xr.DataArray([1.0e-3, 1.0e-3, 1.0e-3], dims=["x"])
+    incloud_condensate = xr.DataArray([1.0e-2, 1.0e-2, 1.0e-2], dims=["x"])
+    return xr.Dataset(
+        {
+            "cloud_fraction": cloud_fraction,
+            "gridcell_mean_condensate": gridcell_mean_condensate,
+            "incloud_condensate": incloud_condensate,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ["climit1", "climit2", "expected_incloud"],
+    [
+        pytest.param(1.0e-3, 5.0e-2, [1.0e-3, 2.0e-2, 1.0e-2], id="default"),
+        pytest.param(1.0e-2, 5.0e-2, [1.0e-3, 1.0e-3, 1.0e-2], id="higher_climit1"),
+        pytest.param(1.0e-3, 1.0e-2, [1.0e-3, 1.0e-1, 1.0e-2], id="lower_climit2"),
+    ],
+)
+def test_to_incloud_climits(climit1, climit2, expected_incloud):
+    cloud_ds = get_cloud_arrays()
+    incloud_condensate = gridcell_to_incloud_condensate(
+        cloud_ds["cloud_fraction"],
+        cloud_ds["gridcell_mean_condensate"],
+        climit1=climit1,
+        climit2=climit2,
+    )
+    expected_incloud = xr.DataArray(expected_incloud, dims=["x"])
+    xr.testing.assert_allclose(incloud_condensate, expected_incloud)
+
+
+@pytest.mark.parametrize(
+    ["climit1", "climit2", "expected_gridcell"],
+    [
+        pytest.param(1.0e-3, 5.0e-2, [1.0e-2, 5.0e-4, 1.0e-3], id="default"),
+        pytest.param(1.0e-2, 5.0e-2, [1.0e-2, 1.0e-2, 1.0e-3], id="higher_climit1"),
+        pytest.param(1.0e-3, 1.0e-2, [1.0e-2, 1.0e-4, 1.0e-3], id="lower_climit2"),
+    ],
+)
+def test_to_gridcell_climits(climit1, climit2, expected_gridcell):
+    cloud_ds = get_cloud_arrays()
+    gridcell_condensate = incloud_to_gridcell_condensate(
+        cloud_ds["cloud_fraction"],
+        cloud_ds["incloud_condensate"],
+        climit1=climit1,
+        climit2=climit2,
+    )
+    expected_gridcell = xr.DataArray(expected_gridcell, dims=["x"])
+    xr.testing.assert_allclose(gridcell_condensate, expected_gridcell)
+
+
+def test_condensate_roundtrip():
+    cloud_ds = get_cloud_arrays()
+    gridcell_condensate = incloud_to_gridcell_condensate(
+        cloud_ds["cloud_fraction"], cloud_ds["incloud_condensate"],
+    )
+    incloud_condensate = gridcell_to_incloud_condensate(
+        cloud_ds["cloud_fraction"], gridcell_condensate,
+    )
+    xr.testing.assert_allclose(incloud_condensate, cloud_ds["incloud_condensate"])
+    incloud_condensate = gridcell_to_incloud_condensate(
+        cloud_ds["cloud_fraction"], cloud_ds["gridcell_mean_condensate"],
+    )
+    gridcell_condensate = incloud_to_gridcell_condensate(
+        cloud_ds["cloud_fraction"], incloud_condensate,
+    )
+    xr.testing.assert_allclose(
+        gridcell_condensate, cloud_ds["gridcell_mean_condensate"]
+    )

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -60,6 +60,7 @@ from .calc.thermo.local import (
     moist_static_energy_tendency,
 )
 from .calc.histogram import histogram, histogram2d
+from .calc.clouds import gridcell_to_incloud_condensate, incloud_to_gridcell_condensate
 
 from .interpolate import (
     interpolate_to_pressure_levels,

--- a/external/vcm/vcm/calc/clouds.py
+++ b/external/vcm/vcm/calc/clouds.py
@@ -1,0 +1,66 @@
+import xarray as xr
+
+CLIMIT1: float = 1.0e-3
+CLIMIT2: float = 5.0e-2
+
+
+def gridcell_to_incloud_condensate(
+    cloud_fraction: xr.DataArray,
+    gridcell_cloud_condensate: xr.DataArray,
+    climit1: float = CLIMIT1,
+    climit2: float = CLIMIT2,
+) -> xr.DataArray:
+    """Convert gridcell-mean condensate to in-cloud condensate via cloud fraction.
+
+    Follows GFS physics condensate normalization; see
+    https://github.com/ai2cm/fv3gfs-fortran/blob/5e1553cc34727399f629b233c36f1b4e8d2d902d/FV3/gfsphysics/physics/radiation_clouds.f#L1920 # noqa: E501
+
+
+    Args:
+        cloud_fraction: array of dimensionless cloud fractions
+        gridcell_cloud_condensate: array of gridcell-mean condensate mixing ratios
+        climit1: scalar of smallest cloud fraction where in-cloud condensate will be
+            computed; where cloud fraction is smaller than this, in-cloud and gridcell-
+            mean condensate will be the same
+        climit2: scalar of minimum cloud fraction to compute in-cloud condensate; for
+            values smaller than this (but greater than `climit1`), in-cloud condensate
+            will be a factor of 1.0 / climit2 of gridcell-mean condensate
+
+    Returns:
+        Array of in-cloud condensate mixing ratios
+
+    """
+    scaling_ratio = 1.0 / cloud_fraction.where(cloud_fraction > climit2, climit2)
+    incloud_condensate = gridcell_cloud_condensate.where(
+        cloud_fraction <= climit1, gridcell_cloud_condensate * scaling_ratio
+    )
+    return incloud_condensate
+
+
+def incloud_to_gridcell_condensate(
+    cloud_fraction: xr.DataArray,
+    incloud_condensate: xr.DataArray,
+    climit1: float = CLIMIT1,
+    climit2: float = CLIMIT2,
+) -> xr.DataArray:
+    """Convert in-cloud condensate to gridcell-mean condensate via cloud fraction
+
+    Follows GFS physics condensate normalization; see
+    https://github.com/ai2cm/fv3gfs-fortran/blob/5e1553cc34727399f629b233c36f1b4e8d2d902d/FV3/gfsphysics/physics/radiation_clouds.f#L1920 # noqa: E501
+
+    Args:
+        cloud_fraction: array of dimensionless cloud fractions
+        incloud_condensate: array of in-cloud condensate mixing ratios
+        climit1: scalar of smallest cloud fraction where gridcell-mean condensate will be
+            computed; where cloud fraction is smaller than this, gridcell-mean and in-cloud
+            condensate will be the same
+        climit2: scalar of minimum cloud fraction to compute gridcell-mean condensate; for
+            values smaller than this (but greater than `climit1`), gridcell-mean condensate
+            will be a factor of climit2 of in-cloud condensate
+
+    Returns: array of gridcell-mean condensate mixing ratios"""
+    rectified_cloud_fraction = cloud_fraction.where(cloud_fraction > climit2, climit2)
+    gridcell_condensate = incloud_condensate.where(
+        cloud_fraction <= climit1, incloud_condensate * rectified_cloud_fraction
+    )
+    return gridcell_condensate

--- a/external/vcm/vcm/data_transform.py
+++ b/external/vcm/vcm/data_transform.py
@@ -36,6 +36,8 @@ TransformName = Literal[
     "implied_downward_radiative_flux_at_surface",
     "tapered_dQ1",
     "tapered_dQ2",
+    "cloud_water_mixing_ratio_from_incloud",
+    "cloud_ice_mixing_ratio_from_incloud",
 ]
 
 
@@ -293,6 +295,30 @@ def implied_surface_precipitation_rate(ds, rectify=True):
         long_name="Implied surface precipitation rate computed as E-<Q2>",
     )
     ds["implied_surface_precipitation_rate"] = implied_precip
+    return ds
+
+
+@register(["cloud_amount", "incloud_water_mixing_ratio"], ["cloud_water_mixing_ratio"])
+def cloud_water_mixing_ratio_from_incloud(ds):
+    cloud_water = vcm.incloud_to_gridcell_condensate(
+        ds["cloud_amount"], ds["incloud_water_mixing_ratio"]
+    )
+    cloud_water = cloud_water.assign_attrs(
+        long_name="cloud water mixing ratio", units="kg/kg"
+    )
+    ds["cloud_water_mixing_ratio"] = cloud_water
+    return ds
+
+
+@register(["cloud_amount", "incloud_ice_mixing_ratio"], ["cloud_ice_mixing_ratio"])
+def cloud_ice_mixing_ratio_from_incloud(ds):
+    cloud_ice = vcm.incloud_to_gridcell_condensate(
+        ds["cloud_amount"], ds["incloud_ice_mixing_ratio"]
+    )
+    cloud_ice = cloud_ice.assign_attrs(
+        long_name="cloud ice mixing ratio", units="kg/kg"
+    )
+    ds["cloud_ice_mixing_ratio"] = cloud_ice
     return ds
 
 

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -384,6 +384,7 @@ def upward_heat_flux_at_surface(self):
 @DerivedMapping.register(
     "incloud_water_mixing_ratio",
     required_inputs=["cloud_amount", "cloud_water_mixing_ratio"],
+    use_nonderived_if_exists=True,
 )
 def incloud_water_mixing_ratio(self):
     result = vcm.gridcell_to_incloud_condensate(
@@ -395,6 +396,7 @@ def incloud_water_mixing_ratio(self):
 @DerivedMapping.register(
     "incloud_ice_mixing_ratio",
     required_inputs=["cloud_amount", "cloud_ice_mixing_ratio"],
+    use_nonderived_if_exists=True,
 )
 def incloud_ice_mixing_ratio(self):
     result = vcm.gridcell_to_incloud_condensate(
@@ -408,13 +410,13 @@ def incloud_ice_mixing_ratio(self):
     required_inputs=["cloud_amount", "incloud_water_mixing_ratio"],
 )
 def gridcell_cloud_water_mixing_ratio(self):
-    if "cloud_water_mixing_ratio" not in self.keys():
-        result = vcm.incloud_to_gridcell_condensate(
-            self["cloud_amount"], self["incloud_water_mixing_ratio"]
-        )
-        return result.assign_attrs(long_name="cloud water mixing ratio", units="kg/kg")
-    else:
-        return self["cloud_water_mixing_ratio"]
+    # needs a nonstandard name to avoid circular reference
+    result = vcm.incloud_to_gridcell_condensate(
+        self["cloud_amount"], self["incloud_water_mixing_ratio"]
+    )
+    return result.assign_attrs(
+        long_name="gridcell-mean cloud water mixing ratio", units="kg/kg"
+    )
 
 
 @DerivedMapping.register(
@@ -422,10 +424,10 @@ def gridcell_cloud_water_mixing_ratio(self):
     required_inputs=["cloud_amount", "incloud_ice_mixing_ratio"],
 )
 def gridcell_cloud_ice_mixing_ratio(self):
-    if "cloud_ice_mixing_ratio" not in self.keys():
-        result = vcm.incloud_to_gridcell_condensate(
-            self["cloud_amount"], self["incloud_ice_mixing_ratio"]
-        )
-        return result.assign_attrs(long_name="cloud ice mixing ratio", units="kg/kg")
-    else:
-        return self["cloud_water_mixing_ratio"]
+    # needs a nonstandard name to avoid circular reference
+    result = vcm.incloud_to_gridcell_condensate(
+        self["cloud_amount"], self["incloud_ice_mixing_ratio"]
+    )
+    return result.assign_attrs(
+        long_name="gridcell-mean cloud ice mixing ratio", units="kg/kg"
+    )

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -384,7 +384,6 @@ def upward_heat_flux_at_surface(self):
 @DerivedMapping.register(
     "incloud_water_mixing_ratio",
     required_inputs=["cloud_amount", "cloud_water_mixing_ratio"],
-    use_nonderived_if_exists=True,
 )
 def incloud_water_mixing_ratio(self):
     result = vcm.gridcell_to_incloud_condensate(
@@ -396,38 +395,9 @@ def incloud_water_mixing_ratio(self):
 @DerivedMapping.register(
     "incloud_ice_mixing_ratio",
     required_inputs=["cloud_amount", "cloud_ice_mixing_ratio"],
-    use_nonderived_if_exists=True,
 )
 def incloud_ice_mixing_ratio(self):
     result = vcm.gridcell_to_incloud_condensate(
         self["cloud_amount"], self["cloud_ice_mixing_ratio"]
     )
     return result.assign_attrs(long_name="in-cloud ice mixing ratio", units="kg/kg")
-
-
-@DerivedMapping.register(
-    "gridcell_cloud_water_mixing_ratio",
-    required_inputs=["cloud_amount", "incloud_water_mixing_ratio"],
-)
-def gridcell_cloud_water_mixing_ratio(self):
-    # needs a nonstandard name to avoid circular reference
-    result = vcm.incloud_to_gridcell_condensate(
-        self["cloud_amount"], self["incloud_water_mixing_ratio"]
-    )
-    return result.assign_attrs(
-        long_name="gridcell-mean cloud water mixing ratio", units="kg/kg"
-    )
-
-
-@DerivedMapping.register(
-    "gridcell_cloud_ice_mixing_ratio",
-    required_inputs=["cloud_amount", "incloud_ice_mixing_ratio"],
-)
-def gridcell_cloud_ice_mixing_ratio(self):
-    # needs a nonstandard name to avoid circular reference
-    result = vcm.incloud_to_gridcell_condensate(
-        self["cloud_amount"], self["incloud_ice_mixing_ratio"]
-    )
-    return result.assign_attrs(
-        long_name="gridcell-mean cloud ice mixing ratio", units="kg/kg"
-    )

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -379,3 +379,53 @@ def upward_heat_flux_at_surface(self):
     return result.assign_attrs(
         long_name="Upward heat (sensible+radiative) flux at surface", units="W/m**2"
     )
+
+
+@DerivedMapping.register(
+    "incloud_water_mixing_ratio",
+    required_inputs=["cloud_amount", "cloud_water_mixing_ratio"],
+)
+def incloud_water_mixing_ratio(self):
+    result = vcm.gridcell_to_incloud_condensate(
+        self["cloud_amount"], self["cloud_water_mixing_ratio"]
+    )
+    return result.assign_attrs(long_name="in-cloud water mixing ratio", units="kg/kg")
+
+
+@DerivedMapping.register(
+    "incloud_ice_mixing_ratio",
+    required_inputs=["cloud_amount", "cloud_ice_mixing_ratio"],
+)
+def incloud_ice_mixing_ratio(self):
+    result = vcm.gridcell_to_incloud_condensate(
+        self["cloud_amount"], self["cloud_ice_mixing_ratio"]
+    )
+    return result.assign_attrs(long_name="in-cloud ice mixing ratio", units="kg/kg")
+
+
+@DerivedMapping.register(
+    "gridcell_cloud_water_mixing_ratio",
+    required_inputs=["cloud_amount", "incloud_water_mixing_ratio"],
+)
+def gridcell_cloud_water_mixing_ratio(self):
+    if "cloud_water_mixing_ratio" not in self.keys():
+        result = vcm.incloud_to_gridcell_condensate(
+            self["cloud_amount"], self["incloud_water_mixing_ratio"]
+        )
+        return result.assign_attrs(long_name="cloud water mixing ratio", units="kg/kg")
+    else:
+        return self["cloud_water_mixing_ratio"]
+
+
+@DerivedMapping.register(
+    "gridcell_cloud_ice_mixing_ratio",
+    required_inputs=["cloud_amount", "incloud_ice_mixing_ratio"],
+)
+def gridcell_cloud_ice_mixing_ratio(self):
+    if "cloud_ice_mixing_ratio" not in self.keys():
+        result = vcm.incloud_to_gridcell_condensate(
+            self["cloud_amount"], self["incloud_ice_mixing_ratio"]
+        )
+        return result.assign_attrs(long_name="cloud ice mixing ratio", units="kg/kg")
+    else:
+        return self["cloud_water_mixing_ratio"]


### PR DESCRIPTION
Adds functions to `vcm` to convert between in the standard grid-cell mean condensate mixing ratios and the "in-cloud" equivalent. This exactly follows the [conversion](https://github.com/ai2cm/fv3gfs-fortran/blob/3238351a062385baae73f91bc121dcd77347b442/FV3/gfsphysics/physics/radiation_clouds.f#L1920) done in the GFS radiation scheme to compute effective optical properties. Adds the conversion to "in-cloud" condensate to `DerivedMapping`, and adds the conversions back grid-cell mean as `DataTransform`s; this is because the former is an unambiguous result from standard wrapper variables, but the latter is not. The use case is training ML from standard wrapper outputs that a) predicts the "in-cloud" mixing ratio and b) produces the grid-cell mean mixing ratio as a transformed output variable, to produce ML cloud fields for the ported radiation scheme.

Added public API:
- `gridcell_to_incloud_condensate`, `incloud_to_gridcell_condensate` added to `vcm`
- `incloud_[water,ice]_mixing_ratio` added to `DerivedMapping`
- `cloud_[water,ice]_mixing_ratio_from_incloud` added as `DataTransform`s

- [X] Tests added

Coverage reports (updated automatically):
- test_unit: [61%](https://output.circle-artifacts.com/output/job/d8f7207b-6771-4a81-8efb-db185ad6601d/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)