### PR TITLE
fv3fit: remove sklearn regressor ensemble

### DIFF
--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -150,7 +150,7 @@ class SklearnWrapper(Predictor):
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
         model: sklearn.base.BaseEstimator,
-        n_jobs: int,
+        n_jobs: int = 1,
         scaler_type: str = "standard",
         scaler_kwargs: Optional[Mapping] = None,
         packer_config: PackerConfig = PackerConfig({}),

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -125,8 +125,52 @@ class RandomForest(Predictor):
     def load(cls, path: str) -> "RandomForest":
         return RandomForest.from_sklearn_wrapper(SklearnWrapper.load(path))
 
+    def _feature_importances(self) -> np.ndarray:
+        return np.array(
+            [
+                tree.feature_importances_
+                for tree in self._model_wrapper.model.estimators_
+            ]
+        )
+
+    def _mean_feature_importances(self) -> np.ndarray:
+        return self._feature_importances().mean(axis=0)
+
+    def _std_feature_importances(self) -> np.ndarray:
+        return self._feature_importances().std(axis=0)
+
     def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
-        return self._model_wrapper.input_sensitivity(stacked_sample)
+        _, input_multiindex = pack(
+            stacked_sample[self.input_variables],
+            ["sample"],
+            self._model_wrapper.packer_config,
+        )
+        feature_importances = {}
+        for (name, feature_index), mean_importance, std_importance in zip(
+            input_multiindex,
+            self._mean_feature_importances(),
+            self._std_feature_importances(),
+        ):
+            if name not in feature_importances:
+                feature_importances[name] = {
+                    "indices": [feature_index],
+                    "mean_importances": [mean_importance],
+                    "std_importances": [std_importance],
+                }
+            else:
+                feature_importances[name]["indices"].append(feature_index)
+                feature_importances[name]["mean_importances"].append(mean_importance)
+                feature_importances[name]["std_importances"].append(std_importance)
+
+        formatted_feature_importances = {
+            name: RandomForestInputSensitivity(
+                indices=info["indices"],
+                mean_importances=info["mean_importances"],
+                std_importances=info["std_importances"],
+            )
+            for name, info in feature_importances.items()
+        }
+        return InputSensitivity(rf_feature_importances=formatted_feature_importances)
 
 
 def _get_iterator_size(iterator):
@@ -325,34 +369,3 @@ class SklearnWrapper(Predictor):
         else:
             regressor = regressor_components["regressors"]
         return regressor, regressor_components["n_jobs"]
-
-    def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
-        _, input_multiindex = pack(
-            stacked_sample[self.input_variables], ["sample"], self.packer_config
-        )
-        feature_importances = {}
-        for (name, feature_index), mean_importance, std_importance in zip(
-            input_multiindex,
-            self.model.feature_importances_,
-            np.zeros_like(self.model.feature_importances_),
-        ):
-            if name not in feature_importances:
-                feature_importances[name] = {
-                    "indices": [feature_index],
-                    "mean_importances": [mean_importance],
-                    "std_importances": [std_importance],
-                }
-            else:
-                feature_importances[name]["indices"].append(feature_index)
-                feature_importances[name]["mean_importances"].append(mean_importance)
-                feature_importances[name]["std_importances"].append(std_importance)
-
-        formatted_feature_importances = {
-            name: RandomForestInputSensitivity(
-                indices=info["indices"],
-                mean_importances=info["mean_importances"],
-                std_importances=info["std_importances"],
-            )
-            for name, info in feature_importances.items()
-        }
-        return InputSensitivity(rf_feature_importances=formatted_feature_importances)

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -5,7 +5,6 @@ import io
 import dacite
 from fv3fit._shared.packer import PackingInfo, clip_sample
 import numpy as np
-from copy import copy
 import xarray as xr
 import fsspec
 import joblib
@@ -34,7 +33,7 @@ from fv3fit.typing import Batch
 from fv3fit import tfdataset
 from fv3fit.tfdataset import apply_to_mapping, ensure_nd
 
-from typing import Optional, Iterable, Sequence
+from typing import Optional, Iterable, Tuple
 import yaml
 from vcm import safe
 
@@ -74,28 +73,26 @@ class RandomForest(Predictor):
         hyperparameters: RandomForestHyperparameters,
     ):
         super().__init__(input_variables, output_variables)
-        batch_regressor = _RegressorEnsemble(
-            sklearn.ensemble.RandomForestRegressor(
-                # n_jobs != 1 is non-reproducible,
-                # None uses joblib which is reproducible
-                n_jobs=None,
-                random_state=hyperparameters.random_state,
-                n_estimators=hyperparameters.n_estimators,
-                max_depth=hyperparameters.max_depth,
-                min_samples_split=hyperparameters.min_samples_split,
-                min_samples_leaf=hyperparameters.min_samples_leaf,
-                max_features=hyperparameters.max_features,
-            ),
-            # pass n_jobs along here to use joblib
-            n_jobs=hyperparameters.n_jobs,
+        _regressor = sklearn.ensemble.RandomForestRegressor(
+            # n_jobs != 1 is non-reproducible,
+            # None uses joblib which is reproducible
+            n_jobs=None,
+            random_state=hyperparameters.random_state,
+            n_estimators=hyperparameters.n_estimators,
+            max_depth=hyperparameters.max_depth,
+            min_samples_split=hyperparameters.min_samples_split,
+            min_samples_leaf=hyperparameters.min_samples_leaf,
+            max_features=hyperparameters.max_features,
         )
         self._model_wrapper = SklearnWrapper(
             input_variables,
             output_variables,
-            model=batch_regressor,
+            model=_regressor,
             scaler_type=hyperparameters.scaler_type,
             scaler_kwargs=hyperparameters.scaler_kwargs,
             packer_config=hyperparameters.packer_config,
+            # pass n_jobs along here to use joblib
+            n_jobs=hyperparameters.n_jobs,
         )
         self.input_variables = self._model_wrapper.input_variables
         self.output_variables = self._model_wrapper.output_variables
@@ -128,84 +125,8 @@ class RandomForest(Predictor):
     def load(cls, path: str) -> "RandomForest":
         return RandomForest.from_sklearn_wrapper(SklearnWrapper.load(path))
 
-
-class _RegressorEnsemble:
-    """
-    Ensemble of RandomForestRegressor objects that are each trained on a separate
-    batch of data.
-    """
-
-    def __init__(
-        self,
-        base_regressor,
-        n_jobs,
-        regressors: Sequence[sklearn.base.BaseEstimator] = None,
-    ) -> None:
-        self.base_regressor = base_regressor
-        self.regressors = regressors or []
-        self.n_jobs = n_jobs
-
-    @property
-    def n_estimators(self):
-        return len(self.regressors)
-
-    def fit(self, features, outputs):
-        """ Adds a base regressor fit on features to the ensemble
-
-        Args:
-            features: numpy array of features
-            outputs: numpy array of targets
-
-        Returns:
-
-        """
-        new_regressor = copy(self.base_regressor)
-        # each regressor needs different randomness
-        if hasattr(new_regressor, "random_state"):
-            new_regressor.random_state += len(self.regressors)
-        # loky is the process-based backend
-        with joblib.parallel_backend("loky", n_jobs=self.n_jobs):
-            new_regressor.fit(features, outputs)
-        self.regressors.append(new_regressor)
-
-    def predict(self, features):
-        """
-        Args:
-            features: 2D numpy array of features to predict on
-
-        Returns:
-            2D numpy array of predictions with N rows corresponding to N input samples.
-            Each row is the average ensemble prediction for that sample.
-        """
-        predictions = np.array(
-            [regressor.predict(features) for regressor in self.regressors]
-        )
-        return np.mean(predictions, axis=0)
-
-    def dumps(self) -> bytes:
-        batch_regressor_components = {
-            "regressors": self.regressors,
-            "base_regressor": self.base_regressor,
-            "n_jobs": self.n_jobs,
-        }
-        f = io.BytesIO()
-        joblib.dump(batch_regressor_components, f)
-        return f.getvalue()
-
-    @classmethod
-    def loads(cls, b: bytes) -> "_RegressorEnsemble":
-        f = io.BytesIO(b)
-        batch_regressor_components = joblib.load(f)
-        regressors: Sequence[sklearn.base.BaseEstimator] = batch_regressor_components[
-            "regressors"
-        ]
-        base_regressor = batch_regressor_components["base_regressor"]
-        obj = cls(
-            base_regressor=base_regressor,
-            regressors=regressors,
-            n_jobs=batch_regressor_components.get("n_jobs", 1),
-        )
-        return obj
+    def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
+        return self._model_wrapper.input_sensitivity(stacked_sample)
 
 
 def _get_iterator_size(iterator):
@@ -228,7 +149,8 @@ class SklearnWrapper(Predictor):
         self,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
-        model: _RegressorEnsemble,
+        model: sklearn.base.BaseEstimator,
+        n_jobs: int,
         scaler_type: str = "standard",
         scaler_kwargs: Optional[Mapping] = None,
         packer_config: PackerConfig = PackerConfig({}),
@@ -245,6 +167,7 @@ class SklearnWrapper(Predictor):
         if scaler_type != "standard":
             raise NotImplementedError("only 'standard' scaler_type is implemented")
         self.model = model
+        self.n_jobs = n_jobs
         self.scaler_type = scaler_type
         self.scaler_kwargs = scaler_kwargs or {}
         self.target_scaler: Optional[scaler.NormalizeTransform] = None
@@ -284,8 +207,14 @@ class SklearnWrapper(Predictor):
             self.target_scaler = self._init_target_scaler(y)
 
         y = self.target_scaler.normalize(y)
-        self.model.fit(X, y)
+        self._fit(X, y)
         logger.info(f"Random forest done fitting.")
+        return self
+
+    def _fit(self, X: Batch, y: Batch):
+        # loky is the process-based backend
+        with joblib.parallel_backend("loky", n_jobs=self.n_jobs):
+            self.model.fit(X, y)
 
     def _predict_on_stacked_data(self, stacked_data):
         X, _ = pack(
@@ -324,7 +253,9 @@ class SklearnWrapper(Predictor):
         fs.makedirs(path, exist_ok=True)
 
         mapper = fs.get_mapper(path)
-        mapper[self._PICKLE_NAME] = self.model.dumps()
+
+        mapper[self._PICKLE_NAME] = self._dump_regressor()
+
         if self.target_scaler is not None:
             mapper[self._SCALER_NAME] = scaler.dumps(self.target_scaler).encode("UTF-8")
 
@@ -337,11 +268,21 @@ class SklearnWrapper(Predictor):
 
         mapper[self._METADATA_NAME] = yaml.safe_dump(metadata).encode("UTF-8")
 
+    def _dump_regressor(self):
+        regressor_components = {
+            "regressors": self.model,
+            "n_jobs": self.n_jobs,
+        }
+        f = io.BytesIO()
+        joblib.dump(regressor_components, f)
+        return f.getvalue()
+
     @classmethod
     def load(cls, path: str) -> "SklearnWrapper":
         """Load a model from a remote path"""
         mapper = fsspec.get_mapper(path)
-        model = _RegressorEnsemble.loads(mapper[cls._PICKLE_NAME])
+
+        regressor, n_jobs = cls._load_regressor(mapper[cls._PICKLE_NAME])
 
         scaler_str = mapper.get(cls._SCALER_NAME, b"")
         scaler_obj: Optional[scaler.NormalizeTransform]
@@ -356,32 +297,34 @@ class SklearnWrapper(Predictor):
         packer_config_dict = metadata.get("packer_config", {})
         packer_config = dacite.from_dict(PackerConfig, packer_config_dict)
 
-        obj = cls(input_variables, output_variables, model, packer_config=packer_config)
+        obj = cls(
+            input_variables,
+            output_variables,
+            regressor,
+            n_jobs,
+            packer_config=packer_config,
+        )
         obj.target_scaler = scaler_obj
         output_features_dict = metadata["output_features"]
-        if isinstance(output_features_dict, dict):
-            output_features_ = dacite.from_dict(PackingInfo, data=output_features_dict)
-        else:
-            # older model format, uses tuple instead
-            output_features_ = PackingInfo.from_tuples(output_features_dict[1])
+        output_features_ = dacite.from_dict(PackingInfo, data=output_features_dict)
         obj.output_features_ = output_features_
 
         return obj
 
-    @property
-    def feature_importances(self) -> Sequence[float]:
-        importances = []
-        for member in self.model.regressors:
-            importances.append(member.feature_importances_)
-        return importances
-
-    @property
-    def mean_importances(self) -> np.ndarray:
-        return np.array(self.feature_importances).mean(axis=0)
-
-    @property
-    def std_importances(self) -> np.ndarray:
-        return np.array(self.feature_importances).std(axis=0)
+    @staticmethod
+    def _load_regressor(b: bytes) -> Tuple[sklearn.base.BaseEstimator, int]:
+        regressor_components = joblib.load(io.BytesIO(b))
+        if isinstance(regressor_components["regressors"], list):
+            # backward compatibility for previous models saved as single batch regressor
+            if len(regressor_components["regressors"]) == 1:
+                regressor = regressor_components["regressors"][0]
+            else:
+                raise ValueError(
+                    "Cannot load older models that saved multiple batch regressors."
+                )
+        else:
+            regressor = regressor_components["regressors"]
+        return regressor, regressor_components["n_jobs"]
 
     def input_sensitivity(self, stacked_sample: xr.Dataset) -> InputSensitivity:
         _, input_multiindex = pack(
@@ -389,7 +332,9 @@ class SklearnWrapper(Predictor):
         )
         feature_importances = {}
         for (name, feature_index), mean_importance, std_importance in zip(
-            input_multiindex, self.mean_importances, self.std_importances
+            input_multiindex,
+            self.model.feature_importances_,
+            np.zeros_like(self.model.feature_importances_),
         ):
             if name not in feature_importances:
                 feature_importances[name] = {

--- a/external/fv3fit/tests/test_random_forest.py
+++ b/external/fv3fit/tests/test_random_forest.py
@@ -4,6 +4,17 @@ import numpy as np
 import xarray as xr
 import pytest
 
+n_features = 10
+
+
+def get_batches(outputs):
+    array = xr.DataArray(
+        np.reshape(np.arange(30), (3, n_features)), dims=["sample", "z"]
+    )
+    ds = xr.Dataset({key: array for key in outputs})
+    ds = ds.merge(xr.Dataset({"air_temperature": array}))
+    return [ds, ds]
+
 
 @pytest.mark.parametrize("outputs", (["Q1"], ["Q1", "Q2"]))
 def test_random_forest_predict_dim_size(outputs):
@@ -11,11 +22,29 @@ def test_random_forest_predict_dim_size(outputs):
     model = fv3fit.sklearn._random_forest.RandomForest(
         ["air_temperature"], outputs, parameters
     )
-    array = xr.DataArray(np.reshape(np.arange(30), (3, 10)), dims=["sample", "z"])
-    ds = xr.Dataset({key: array for key in outputs})
-    ds = ds.merge(xr.Dataset({"air_temperature": array}))
-    batches = [ds, ds]
-    tfdataset = tfdataset_from_batches(batches)
-    model.fit(tfdataset)
-    prediction = model.predict(ds[["air_temperature"]])
-    assert prediction.sizes["z"] == 10
+    batches = get_batches(outputs)
+    model.fit(tfdataset_from_batches(batches))
+    prediction = model.predict(batches[0][["air_temperature"]])
+    assert prediction.sizes["z"] == n_features
+
+
+@pytest.fixture(params=[1, 3])
+def fitted_random_forest(request):
+    n_estimators = request.param
+    outputs = ["dQ1"]
+    parameters = fv3fit.RandomForestHyperparameters(
+        ["air_temperature"], outputs, n_estimators=n_estimators, n_jobs=1
+    )
+    model = fv3fit.sklearn._random_forest.RandomForest(
+        ["air_temperature"], outputs, parameters
+    )
+    batches = get_batches(outputs)
+    model.fit(tfdataset_from_batches(batches))
+    return model, n_estimators
+
+
+def test_rf_feature_importances(fitted_random_forest):
+    rf, n_estimators = fitted_random_forest
+    assert rf._feature_importances().shape == (n_estimators, n_features)
+    assert rf._mean_feature_importances().shape == (n_features,)
+    assert rf._std_feature_importances().shape == (n_features,)

--- a/external/fv3fit/tests/test_sklearn_wrapper.py
+++ b/external/fv3fit/tests/test_sklearn_wrapper.py
@@ -65,9 +65,7 @@ def _get_sklearn_wrapper(scale_factor=None, dumps_returns: bytes = b"HEY!"):
     else:
         scaler = None
 
-    wrapper = SklearnWrapper(
-        input_variables=["x"], output_variables=["y"], model=model, n_jobs=1
-    )
+    wrapper = SklearnWrapper(input_variables=["x"], output_variables=["y"], model=model)
     wrapper.target_scaler = scaler
     return wrapper
 
@@ -91,9 +89,7 @@ def test_fitting_SklearnWrapper_does_not_fit_scaler():
     model = unittest.mock.Mock()
     scaler = unittest.mock.Mock()
 
-    wrapper = SklearnWrapper(
-        input_variables=["x"], output_variables=["y"], model=model, n_jobs=1
-    )
+    wrapper = SklearnWrapper(input_variables=["x"], output_variables=["y"], model=model)
     wrapper.target_scaler = scaler
 
     dims = ["sample_", "z"]
@@ -113,9 +109,7 @@ def test_SklearnWrapper_serialize_predicts_the_same(tmpdir, scale_factor):
     else:
         scaler = None
     model = LinearRegression()
-    wrapper = SklearnWrapper(
-        input_variables=["x"], output_variables=["y"], model=model, n_jobs=1
-    )
+    wrapper = SklearnWrapper(input_variables=["x"], output_variables=["y"], model=model)
     wrapper.target_scaler = scaler
 
     # setup input data
@@ -134,9 +128,7 @@ def test_SklearnWrapper_serialize_predicts_the_same(tmpdir, scale_factor):
 def fit_wrapper_with_columnar_data():
     nz = 2
     model = DummyRegressor(strategy="constant", constant=np.arange(nz))
-    wrapper = SklearnWrapper(
-        input_variables=["a"], output_variables=["b"], model=model, n_jobs=1
-    )
+    wrapper = SklearnWrapper(input_variables=["a"], output_variables=["b"], model=model)
 
     dims = ["sample", "z"]
     shape = (4, nz)
@@ -179,7 +171,6 @@ def test_SklearnWrapper_fit_predict_with_clipped_input_data():
         input_variables=["a", "b"],
         output_variables=["c"],
         model=model,
-        n_jobs=1,
         packer_config=PackerConfig({"a": SliceConfig(2, None)}),
     )
 
@@ -201,17 +192,16 @@ def test_SklearnWrapper_raises_not_implemented_error_with_clipped_output_data():
             input_variables=["a", "b"],
             output_variables=["c"],
             model=model,
-            n_jobs=1,
             packer_config=PackerConfig({"c": SliceConfig(2, None)}),
         )
 
 
 class OldSklearnWrapper(SklearnWrapper):
     def __init__(
-        self, input_variables, output_variables, model, n_jobs, n_regressors, **kwargs
+        self, input_variables, output_variables, model, n_regressors, **kwargs
     ):
         self._n_regressors = n_regressors
-        super().__init__(input_variables, output_variables, model, n_jobs, **kwargs)
+        super().__init__(input_variables, output_variables, model, **kwargs)
 
     def _dump_regressor(self):
         # how regressor ensemble was saved
@@ -229,7 +219,6 @@ def _get_old_sklearn_wrapper(n_regressors):
         input_variables=["a"],
         output_variables=["b"],
         model=model,
-        n_jobs=1,
         n_regressors=n_regressors,
     )
     # setup input data; wrappers must be fit to be dumped


### PR DESCRIPTION
Removes the fv3fit sklearn's internal `_RegressorEnsemble` class, since its random forests are no longer trained as an ensemble this way.  Backwards compatible loading of `RandomForest` models created after the change to a single sklearn ensemble regressor is allowed, but not before.

Significant internal changes:
- When training `sklearn_random_forest`,  the model wrapper now accepts a sklearn `RandomForestRegressor` as its regressor instead of the `_RegressorEnsemble`. 
- The 'input_sensitivity' method previously on the `SklearnWrapper` is now on the `RandomForest` and accesses the `RandomForestRegressor`'s ensemble sensivities, which restores the ability of the offline diags to show this for the RF.

- [X] Tests added

Coverage reports (updated automatically):
- test_unit: [61%](https://output.circle-artifacts.com/output/job/8419bf9a-8d8e-4283-b392-e35c62501c5e/artifacts/0/tmp/coverage/htmlcov-test_unit/index.html)
