### PR TITLE
Update argo jobs' wandb token

### DIFF
--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -48,7 +48,7 @@ spec:
             value: offline_report
         envFrom:
           - secretRef:
-              name: wandb-token
+              name: wandb-service-token
         volumeMounts:
           - mountPath: /secret/gcp-credentials
             name: gcp-key-secret

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -45,7 +45,7 @@ spec:
             value: training
         envFrom: &training-container-envfrom
           - secretRef:
-              name: wandb-token
+              name: wandb-service-token
         volumeMounts: &training-container-volmounts
           - mountPath: /secret/gcp-credentials
             name: gcp-key-secret


### PR DESCRIPTION
This changes the training and offline argo templates to use the secret associated with the wandb GCP service account instead of my personal token.