### PR TITLE
Fix unrecognized quotation characters from #2106

### DIFF
--- a/.environment-scripts/gaea/activate_conda_environment.sh
+++ b/.environment-scripts/gaea/activate_conda_environment.sh
@@ -4,7 +4,7 @@ set -e
 CONDA_ENV=$1
 
 CONDA_PATH=/ncrc/sw/gaea-cle7/python/3.9/anaconda-base
-CONDA_SETUP=“$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)”
-eval “$CONDA_SETUP”
+CONDA_SETUP="$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)"
+eval "$CONDA_SETUP"
 echo "Activating conda environment: $CONDA_ENV"
 conda activate $CONDA_ENV

--- a/.environment-scripts/gaea/install_base_software.sh
+++ b/.environment-scripts/gaea/install_base_software.sh
@@ -5,8 +5,8 @@ INSTALL_PREFIX=$1
 CONDA_ENV=$2
 
 CONDA_PATH=/ncrc/sw/gaea-cle7/python/3.9/anaconda-base
-CONDA_SETUP=“$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)”
-eval “$CONDA_SETUP”
+CONDA_SETUP="$($CONDA_PATH/bin/conda shell.bash hook 2> /dev/null)"
+eval "$CONDA_SETUP"
 
 CONDA_PREFIX=$INSTALL_PREFIX/conda
 conda config --add pkgs_dirs $CONDA_PREFIX/pkgs


### PR DESCRIPTION
I guess this is what happens when you merge a (seemingly simple) PR that was open so long you forget whether you tested it...I'm not sure how these different quotation characters made it in here, but this fully restores things back to the way they were [here](https://github.com/ai2cm/fv3net/pull/2047/files/6dbb859f836677df03a118fb702398181a7958d4#diff-5594e73953cd77a2c885c6e61a47201d80bef8f900e034f4d7d5811ad0664489) as #2106 intended to do.  Without using the proper quotation mark characters the build process fails immediately within `install_base_software.sh`.

Coverage reports (updated automatically):
