### PR TITLE
Move black before flake8 in pre-commit order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 exclude: "external/gcsfs/"
 repos:
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      additional_dependencies: ["click==8.0.4"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
@@ -20,11 +25,6 @@ repos:
       files: "__init__.py"
       # ignore unused import error in __init__.py files
       args: ["--ignore=F401,E203", --config, setup.cfg]
--   repo: https://github.com/psf/black
-    rev: 19.10b0
-    hooks:
-    - id: black
-      additional_dependencies: ["click==8.0.4"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.770
     hooks:


### PR DESCRIPTION
Currently when pre-commit runs, flake8 will complain about issues before black has a chance to correct them. This PR moves black before flake8 in the pre-commit order, so that it has a chance to fix issues before flake8 checks for them.

- [ ] Tests added

Coverage reports (updated automatically):
