### PR TITLE
add SchedulerConfig to cyclegan training config

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/__init__.py
+++ b/external/fv3fit/fv3fit/pytorch/__init__.py
@@ -24,6 +24,6 @@ from .recurrent import (
     FMRTrainingConfig,
     FMRNetworkConfig,
 )
-from .optimizer import OptimizerConfig
+from .optimizer import OptimizerConfig, SchedulerConfig, Scheduler
 from .activation import ActivationConfig
 from .loss import LossConfig

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -127,6 +127,9 @@ def test_cyclegan_visual(tmpdir):
             generator_optimizer=fv3fit.pytorch.OptimizerConfig(
                 name="Adam", kwargs={"lr": 0.001}
             ),
+            scheduler=fv3fit.pytorch.SchedulerConfig(
+                name="ExponentialLR", kwargs={"gamma": 0.8}
+            ),
             discriminator=fv3fit.pytorch.DiscriminatorConfig(kernel_size=3),
             discriminator_optimizer=fv3fit.pytorch.OptimizerConfig(
                 name="Adam", kwargs={"lr": 0.001}

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
@@ -30,6 +30,7 @@ import logging
 import numpy as np
 from .reloadable import CycleGAN
 from .cyclegan_trainer import CycleGANNetworkConfig, CycleGANTrainer
+from ..optimizer import SchedulerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,8 @@ class CycleGANTrainingConfig:
             between epochs.
         checkpoint_path: if given, model checkpoints will be saved to this directory
             marked by timestamp, epoch, and a randomly generated run label
+        scheduler: configuration for the scheduler used to adjust the
+            learning rate of the optimizer
     """
 
     n_epoch: int = 20
@@ -84,6 +87,9 @@ class CycleGANTrainingConfig:
     validation_batch_size: Optional[int] = None
     in_memory: bool = False
     checkpoint_path: Optional[str] = None
+    scheduler: SchedulerConfig = dataclasses.field(
+        default_factory=lambda: SchedulerConfig(None)
+    )
 
     def fit_loop(
         self,
@@ -128,6 +134,10 @@ class CycleGANTrainingConfig:
         run_label = secrets.token_hex(4)
         # current time as e.g. 20230113-163005
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        generator_scheduler = self.scheduler.instance(train_model.optimizer_generator)
+        discriminator_scheduler = self.scheduler.instance(
+            train_model.optimizer_discriminator
+        )
         for i in range(1, self.n_epoch + 1):
             logger.info("starting epoch %d", i)
             train_losses = []
@@ -145,6 +155,8 @@ class CycleGANTrainingConfig:
                 val_loss = train_model.evaluate_on_dataset(validation_data)
                 logger.info("val_loss %s", val_loss)
 
+            generator_scheduler.step()
+            discriminator_scheduler.step()
             if self.checkpoint_path is not None:
                 current_path = (
                     Path(self.checkpoint_path)

--- a/external/fv3fit/fv3fit/pytorch/optimizer.py
+++ b/external/fv3fit/fv3fit/pytorch/optimizer.py
@@ -1,8 +1,11 @@
 import torch.optim as optim
+import torch.optim.lr_scheduler as lr_scheduler
 import dataclasses
 from typing import (
     Any,
     Mapping,
+    Optional,
+    Protocol,
 )
 
 
@@ -17,3 +20,27 @@ class OptimizerConfig:
         kwargs = dict(params=params, **self.kwargs)
 
         return cls(**kwargs)
+
+
+class Scheduler(Protocol):
+    def step(self):
+        ...
+
+
+class NullScheduler:
+    def step(self):
+        pass
+
+
+@dataclasses.dataclass
+class SchedulerConfig:
+    name: Optional[str] = None
+    kwargs: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+
+    def instance(self, optimizer) -> Scheduler:
+        if self.name is None:
+            return NullScheduler()
+        else:
+            cls = getattr(lr_scheduler, self.name)
+
+            return cls(optimizer, **self.kwargs)


### PR DESCRIPTION
The CycleGAN model seems to perform better when it is able to train on a high learning rate to get into the neighbourhood of correct results, then decrease to lower learning rates where artifacting behaviours can be learned out of the model.

This PR adds a "scheduler" configuration option with SchedulerConfig to allow the user to configure an arbitrary learning rate scheduler to use in CycleGAN training.

Added public API:
- added SchedulerConfig to fv3fit.pytorch.optimizer

Refactored public API:
- added "scheduler" option to CycleGANTrainingConfig, which defaults to no learning rate scheduling

- [x] Tests added

Coverage reports (updated automatically):
