### PR TITLE
Copy Discriminator and ImagePool into fv3fit.pytorch.recurrent

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/recurrent/discriminator.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/discriminator.py
@@ -1,0 +1,126 @@
+import dataclasses
+
+import torch.nn as nn
+from toolz import curry
+import torch
+from fv3fit.pytorch.cyclegan.modules import (
+    ConvolutionFactory,
+    single_tile_convolution,
+    leakyrelu_activation,
+    ConvBlock,
+)
+
+
+@dataclasses.dataclass
+class DiscriminatorConfig:
+    """
+    Configuration for a discriminator network.
+
+    Follows the architecture of Zhu et al. 2017, https://arxiv.org/abs/1703.10593.
+    Uses a series of strided convolutions with leaky ReLU activations, followed
+    by two convolutional layers.
+
+    Args:
+        n_convolutions: number of strided convolutional layers before the
+            final convolutional output layer, must be at least 1
+        kernel_size: size of convolutional kernels
+        max_filters: maximum number of filters in any convolutional layer,
+            equal to the number of filters in the final strided convolutional layer
+    """
+
+    n_convolutions: int = 3
+    kernel_size: int = 3
+    strided_kernel_size: int = 3
+    max_filters: int = 256
+
+    def build(
+        self, channels: int, convolution: ConvolutionFactory = single_tile_convolution,
+    ):
+        return Discriminator(
+            in_channels=channels,
+            n_convolutions=self.n_convolutions,
+            kernel_size=self.kernel_size,
+            strided_kernel_size=self.strided_kernel_size,
+            max_filters=self.max_filters,
+            convolution=convolution,
+        )
+
+
+class Discriminator(nn.Module):
+
+    # analogous to NLayerDiscriminator at
+    # https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/models/networks.py
+
+    def __init__(
+        self,
+        in_channels: int,
+        n_convolutions: int,
+        kernel_size: int,
+        strided_kernel_size: int,
+        max_filters: int,
+        convolution: ConvolutionFactory = single_tile_convolution,
+    ):
+        """
+        Args:
+            in_channels: number of input channels
+            n_convolutions: number of strided convolutional layers before the
+                final convolutional output layers, must be at least 1
+            kernel_size: size of non-strided convolutional kernels
+            strided_kernel_size: size of 2-strided convolutional kernels
+            max_filters: maximum number of filters in any convolutional layer,
+                equal to the number of filters in the final strided convolutional layer
+                and in the convolutional layer just before the output layer
+            convolution: factory for creating all convolutional layers
+        """
+        super(Discriminator, self).__init__()
+        if n_convolutions < 1:
+            raise ValueError("n_convolutions must be at least 1")
+        # max_filters = min_filters * 2 ** (n_convolutions - 1), therefore
+        min_filters = int(max_filters / 2 ** (n_convolutions - 1))
+        convs = [
+            ConvBlock(
+                in_channels=in_channels,
+                out_channels=min_filters,
+                convolution_factory=curry(convolution)(
+                    kernel_size=strided_kernel_size, stride=2,
+                ),
+                activation_factory=leakyrelu_activation(
+                    negative_slope=0.2, inplace=True
+                ),
+            )
+        ]
+        # we've already defined the first strided convolutional layer, so start at 1
+        for i in range(1, n_convolutions):
+            convs.append(
+                ConvBlock(
+                    in_channels=min_filters * 2 ** (i - 1),
+                    out_channels=min_filters * 2 ** i,
+                    convolution_factory=curry(convolution)(
+                        kernel_size=strided_kernel_size, stride=2
+                    ),
+                    activation_factory=leakyrelu_activation(
+                        negative_slope=0.2, inplace=True
+                    ),
+                )
+            )
+        # final_conv isn't strided so it's not included in the n_convolutions count
+        final_conv = ConvBlock(
+            in_channels=max_filters,
+            out_channels=max_filters,
+            convolution_factory=curry(convolution)(kernel_size=kernel_size),
+            activation_factory=leakyrelu_activation(negative_slope=0.2, inplace=True),
+        )
+        patch_output = convolution(
+            kernel_size=3, in_channels=max_filters, out_channels=1
+        )
+        self._sequential = nn.Sequential(*convs, final_conv, patch_output)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            inputs: tensor of shape (batch, tile, in_channels, height, width)
+
+        Returns:
+            tensor of shape (batch, tile, 1, height, width)
+        """
+        return self._sequential(inputs)

--- a/external/fv3fit/fv3fit/pytorch/recurrent/image_pool.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/image_pool.py
@@ -1,0 +1,59 @@
+# flake8: noqa
+# Taken from https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/eb6ae80412e23c09b4317b04d889f1af27526d2d/util/image_pool.py
+# Copyright (c) 2017, Jun-Yan Zhu and Taesung Park under a BSD license
+
+import random
+import torch
+
+
+class ImagePool:
+    """This class implements an image buffer that stores previously generated images.
+    This buffer enables us to update discriminators using a history of generated images
+    rather than the ones produced by the latest generators.
+    """
+
+    def __init__(self, pool_size):
+        """Initialize the ImagePool class
+        Parameters:
+            pool_size (int) -- the size of image buffer, if pool_size=0, no buffer will be created
+        """
+        self.pool_size = pool_size
+        if self.pool_size > 0:  # create an empty pool
+            self.num_imgs = 0
+            self.images = []
+
+    def query(self, images):
+        """Return an image from the pool.
+        Parameters:
+            images: the latest generated images from the generator
+        Returns images from the buffer.
+        By 50/100, the buffer will return input images.
+        By 50/100, the buffer will return images previously stored in the buffer,
+        and insert the current images to the buffer.
+        """
+        if self.pool_size == 0:  # if the buffer size is 0, do nothing
+            return images
+        return_images = []
+        for image in images:
+            image = torch.unsqueeze(image.data, 0)
+            if (
+                self.num_imgs < self.pool_size
+            ):  # if the buffer is not full; keep inserting current images to the buffer
+                self.num_imgs = self.num_imgs + 1
+                self.images.append(image)
+                return_images.append(image)
+            else:
+                p = random.uniform(0, 1)
+                if (
+                    p > 0.5
+                ):  # by 50% chance, the buffer will return a previously stored image, and insert the current image into the buffer
+                    random_id = random.randint(
+                        0, self.pool_size - 1
+                    )  # randint is inclusive
+                    tmp = self.images[random_id].clone()
+                    self.images[random_id] = image
+                    return_images.append(tmp)
+                else:  # by another 50% chance, the buffer will return the current image
+                    return_images.append(image)
+        return_images = torch.cat(return_images, 0)  # collect all the images and return
+        return return_images

--- a/external/fv3fit/fv3fit/pytorch/recurrent/test_fmr.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/test_fmr.py
@@ -14,7 +14,7 @@ import collections
 import os
 import fv3fit.pytorch
 import fv3fit
-import fv3fit.wandb
+import fv3fit.pytorch.recurrent.discriminator
 
 
 def get_tfdataset(nsamples, nbatch, ntime, nx, nz):
@@ -76,7 +76,9 @@ def test_fmr_runs_without_errors(tmpdir):
             generator_optimizer=fv3fit.pytorch.OptimizerConfig(
                 name="Adam", kwargs={"lr": 0.001}
             ),
-            discriminator=fv3fit.pytorch.DiscriminatorConfig(kernel_size=3),
+            discriminator=fv3fit.pytorch.recurrent.discriminator.DiscriminatorConfig(
+                kernel_size=3
+            ),
             discriminator_optimizer=fv3fit.pytorch.OptimizerConfig(
                 name="Adam", kwargs={"lr": 0.001}
             ),

--- a/external/fv3fit/fv3fit/pytorch/recurrent/train_fmr.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/train_fmr.py
@@ -3,7 +3,7 @@ from fv3fit._shared.hyperparameters import Hyperparameters
 import dataclasses
 from fv3fit._shared.predictor import Reloadable
 
-from fv3fit.pytorch.cyclegan.discriminator import (
+from .discriminator import (
     Discriminator,
     DiscriminatorConfig,
 )
@@ -11,7 +11,7 @@ from .generator import (
     RecurrentGenerator,
     RecurrentGeneratorConfig,
 )
-from fv3fit.pytorch.cyclegan.image_pool import ImagePool
+from .image_pool import ImagePool
 from fv3fit.pytorch.cyclegan.modules import (
     halo_convolution,
     single_tile_convolution,


### PR DESCRIPTION
Currently the FMR recurrent model in fv3fit.pytorch.recurrent re-uses Discriminator and ImagePool from the CycleGAN code. This means refactoring the CycleGAN model requires additionally refactoring the recurrent model, which is no longer in development.

Rather than refactor both models, this PR decouples the recurrent FMR model from Discriminator, DiscriminatorConfig, and ImagePool in the CycleGAN code by copying these into the recurrent module.

Significant internal changes:
- fv3fit.pytorch.recurrent no longer relies on CycleGAN's implementations of Discriminator, DiscriminatorConfig, or ImagePool

- [ ] Tests added

Coverage reports (updated automatically):
