### PR TITLE
Add use_geographic_embedded_bias options in CycleGAN

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
@@ -87,8 +87,12 @@ class CycleGANNetworkConfig:
         generator_b_to_a = self.generator.build(
             n_state, nx=nx, ny=ny, convolution=convolution
         )
-        discriminator_a = self.discriminator.build(n_state, convolution=convolution)
-        discriminator_b = self.discriminator.build(n_state, convolution=convolution)
+        discriminator_a = self.discriminator.build(
+            n_state, nx=nx, ny=ny, convolution=convolution
+        )
+        discriminator_b = self.discriminator.build(
+            n_state, nx=nx, ny=ny, convolution=convolution
+        )
         optimizer_generator = self.optimizer.instance(
             itertools.chain(
                 generator_a_to_b.parameters(), generator_b_to_a.parameters()

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
@@ -5,6 +5,7 @@ from toolz import curry
 import torch
 from .modules import (
     ConvolutionFactory,
+    GeographicBias,
     single_tile_convolution,
     leakyrelu_activation,
     ConvBlock,
@@ -24,17 +25,27 @@ class DiscriminatorConfig:
         n_convolutions: number of strided convolutional layers before the
             final convolutional output layer, must be at least 1
         kernel_size: size of convolutional kernels
+        strided_kernel_size: size of convolutional kernels in the
+            strided convolutions
         max_filters: maximum number of filters in any convolutional layer,
             equal to the number of filters in the final strided convolutional layer
+        use_geographic_embedded_bias: if True, include a layer that adds a trainable
+            bias vector after the initial encoding layer. This bias is a
+            function of horizontal coordinates.
     """
 
     n_convolutions: int = 3
     kernel_size: int = 3
     strided_kernel_size: int = 3
     max_filters: int = 256
+    use_geographic_embedded_bias: bool = False
 
     def build(
-        self, channels: int, convolution: ConvolutionFactory = single_tile_convolution,
+        self,
+        channels: int,
+        nx: int,
+        ny: int,
+        convolution: ConvolutionFactory = single_tile_convolution,
     ):
         return Discriminator(
             in_channels=channels,
@@ -42,7 +53,10 @@ class DiscriminatorConfig:
             kernel_size=self.kernel_size,
             strided_kernel_size=self.strided_kernel_size,
             max_filters=self.max_filters,
+            nx=nx,
+            ny=ny,
             convolution=convolution,
+            use_geographic_embedded_bias=self.use_geographic_embedded_bias,
         )
 
 
@@ -58,7 +72,10 @@ class Discriminator(nn.Module):
         kernel_size: int,
         strided_kernel_size: int,
         max_filters: int,
+        nx: int,
+        ny: int,
         convolution: ConvolutionFactory = single_tile_convolution,
+        use_geographic_embedded_bias: bool = False,
     ):
         """
         Args:
@@ -70,25 +87,33 @@ class Discriminator(nn.Module):
             max_filters: maximum number of filters in any convolutional layer,
                 equal to the number of filters in the final strided convolutional layer
                 and in the convolutional layer just before the output layer
+            nx: number of grid points in the x direction
+            ny: number of grid points in the y direction
             convolution: factory for creating all convolutional layers
+            use_geographic_embedded_bias: if True, include a layer that adds a
+                trainable bias vector after the initial encoding layer that is
+                a function of horizontal coordinates.
         """
         super(Discriminator, self).__init__()
         if n_convolutions < 1:
             raise ValueError("n_convolutions must be at least 1")
         # max_filters = min_filters * 2 ** (n_convolutions - 1), therefore
         min_filters = int(max_filters / 2 ** (n_convolutions - 1))
-        convs = [
-            ConvBlock(
+        convs = []
+        convs.append(
+            convolution(
                 in_channels=in_channels,
                 out_channels=min_filters,
-                convolution_factory=curry(convolution)(
-                    kernel_size=strided_kernel_size, stride=2,
-                ),
-                activation_factory=leakyrelu_activation(
-                    negative_slope=0.2, inplace=True
-                ),
+                kernel_size=strided_kernel_size,
+                stride=2,
             )
-        ]
+        )
+        if use_geographic_embedded_bias:
+            convs.append(
+                GeographicBias(channels=min_filters, nx=int(nx / 2), ny=int(ny / 2))
+            )
+        convs.append(leakyrelu_activation(negative_slope=0.2, inplace=True)())
+
         # we've already defined the first strided convolutional layer, so start at 1
         for i in range(1, n_convolutions):
             convs.append(

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -6,6 +6,7 @@ from .modules import (
     ConvBlock,
     ConvolutionFactory,
     FoldFirstDimension,
+    GeographicBias,
     single_tile_convolution,
     relu_activation,
     ResnetBlock,
@@ -43,6 +44,9 @@ class GeneratorConfig:
         disable_convolutions: if True, ignore all layers other than bias (if enabled).
             Useful for debugging and for testing the effect of the
             geographic bias layer.
+        use_geographic_embedded_bias: if True, include a layer that adds a
+            trainable bias vector after the initial encoding layer that is
+            a function of horizontal coordinates.
     """
 
     n_convolutions: int = 3
@@ -52,6 +56,7 @@ class GeneratorConfig:
     max_filters: int = 256
     use_geographic_bias: bool = True
     disable_convolutions: bool = False
+    use_geographic_embedded_bias: bool = False
 
     def build(
         self,
@@ -71,19 +76,6 @@ class GeneratorConfig:
         return Generator(
             config=self, channels=channels, convolution=convolution, nx=nx, ny=ny,
         )
-
-
-class GeographicBias(nn.Module):
-    """
-    Adds a trainable bias vector of shape [6, channels, nx, ny] to the layer input.
-    """
-
-    def __init__(self, channels: int, nx: int, ny: int):
-        super().__init__()
-        self.bias = nn.Parameter(torch.zeros(6, channels, nx, ny))
-
-    def forward(self, x):
-        return x + self.bias
 
 
 class Generator(nn.Module):
@@ -152,13 +144,19 @@ class Generator(nn.Module):
         if config.disable_convolutions:
             main = nn.Identity()
         else:
-            first_conv = nn.Sequential(
+            in_channels = channels
+            initial_layers = [
                 convolution(
-                    kernel_size=7, in_channels=channels, out_channels=min_filters,
+                    kernel_size=7, in_channels=in_channels, out_channels=min_filters,
                 ),
                 FoldFirstDimension(nn.InstanceNorm2d(min_filters)),
-                relu_activation()(),
-            )
+            ]
+            if config.use_geographic_embedded_bias:
+                initial_layers.append(
+                    GeographicBias(channels=min_filters, nx=nx, ny=ny)
+                )
+            initial_layers.append(relu_activation()())
+            first_conv = nn.Sequential(*initial_layers)
 
             encoder_decoder = SymmetricEncoderDecoder(
                 down_factory=down,

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
@@ -29,6 +29,19 @@ def no_activation():
     return nn.Identity()
 
 
+class GeographicBias(nn.Module):
+    """
+    Adds a trainable bias vector of shape [6, channels, nx, ny] to the layer input.
+    """
+
+    def __init__(self, channels: int, nx: int, ny: int):
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(6, channels, nx, ny))
+
+    def forward(self, x):
+        return x + self.bias
+
+
 class ConvolutionFactory(Protocol):
     def __call__(
         self,

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -195,10 +195,16 @@ def test_cyclegan_runs_without_errors(tmpdir, conv_type: str, regtest):
         state_variables=state_variables,
         network=CycleGANNetworkConfig(
             generator=fv3fit.pytorch.GeneratorConfig(
-                n_convolutions=2, n_resnet=5, max_filters=128, kernel_size=3
+                n_convolutions=2,
+                n_resnet=5,
+                max_filters=128,
+                kernel_size=3,
+                use_geographic_embedded_bias=True,
             ),
             optimizer=fv3fit.pytorch.OptimizerConfig(name="Adam", kwargs={"lr": 0.001}),
-            discriminator=fv3fit.pytorch.DiscriminatorConfig(kernel_size=3),
+            discriminator=fv3fit.pytorch.DiscriminatorConfig(
+                kernel_size=3, use_geographic_embedded_bias=True
+            ),
             convolution_type=conv_type,
             identity_weight=0.01,
             cycle_weight=10.0,

--- a/external/fv3fit/fv3fit/pytorch/recurrent/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/generator.py
@@ -8,11 +8,11 @@ from ..cyclegan.modules import (
     ConvBlock,
     ConvolutionFactory,
     FoldFirstDimension,
+    GeographicBias,
     single_tile_convolution,
     relu_activation,
     ResnetBlock,
 )
-from ..cyclegan.generator import GeographicBias
 from torch.utils.checkpoint import checkpoint
 import numpy as np
 from vcm.grid import get_grid_xyz


### PR DESCRIPTION
This PR adds `use_geographic_embedded_bias` options to DiscriminatorConfig and GeneratorConfig used by the CycleGAN training, which when enabled (default disabled) will add geographically-varying bias vectors to the first model layer output. This allows significantly more geographically-resolved features than the previous `use_geographic_bias` option, as bias is added in embedded space, more similar to what's done in FourCastNet.

Refactored public API:
- fv3fit.pytorch.cyclegan.DiscriminatorConfig and fv3fit.pytorch.cyclegan.GeneratorConfig now have `use_geographic_embedded_bias` options

- [ ] Tests added

Coverage reports (updated automatically):
