### PR TITLE
Fix/cyclegan gen odd kernel size

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -149,6 +149,7 @@ class Generator(nn.Module):
                 convolution_factory=curry(convolution)(
                     kernel_size=config.strided_kernel_size,
                     stride=2,
+                    output_padding=output_padding,
                     stride_type="transpose",
                 ),
                 activation_factory=relu_activation(),

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -125,12 +125,19 @@ class Generator(nn.Module):
             ]
             return nn.Sequential(*resnet_blocks)
 
+        if config.strided_kernel_size % 2 == 0:
+            output_padding = 0
+        else:
+            output_padding = 1
+
         def down(in_channels: int, out_channels: int):
             return ConvBlock(
                 in_channels=in_channels,
                 out_channels=out_channels,
                 convolution_factory=curry(convolution)(
-                    kernel_size=config.strided_kernel_size, stride=2
+                    kernel_size=config.strided_kernel_size,
+                    stride=2,
+                    output_padding=output_padding,
                 ),
                 activation_factory=relu_activation(),
             )

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -24,10 +24,6 @@ class GeneratorConfig:
     fractionally strided convolutions with stride 1/2, followed by an output
     convolutional layer with kernel size 7 to map to the output channels.
 
-    Generally we suggest using an even kernel size for strided convolutions,
-    and an odd kernel size for resnet (non-strided) convolutions. For an explanation
-    of this, see the docstring on halo_convolution.
-
     Attributes:
         n_convolutions: number of strided convolutional layers after the initial
             convolutional layer and before the residual blocks

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
@@ -163,10 +163,12 @@ def halo_convolution(
 
     Layer takes in and returns tensors of shape [batch, tile, channels, x, y].
 
-    Generally we suggest using an even kernel size for strided convolutions,
+    There may be reason to prefer using an even kernel size for strided convolutions,
     and an odd kernel size for non-strided convolutions. For the non-strided
     case, an even kernel size gives a symmetric kernel as desired. We've only reasoned
-    this for a stride of 2, but it should hold for any even stride.
+    this for a stride of 2, but it should hold for any even stride. However, this
+    should be tested in practice. We've found an odd kernel size can give better model
+    performance.
 
     The strided case (which uses a stride of 2) is more complex, but an even
     kernel size gives a symmetric kernel. This is because a (2, 2) patch of the input

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -180,7 +180,10 @@ def test_cyclegan_visual(tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("conv_type", ["conv2d", "halo_conv2d"])
-def test_cyclegan_runs_without_errors(tmpdir, conv_type: str, regtest):
+@pytest.mark.parametrize("strided_kernel_size", [3, 4])
+def test_cyclegan_runs_without_errors(
+    tmpdir, conv_type: str, strided_kernel_size: int, regtest
+):
     fv3fit.set_random_seed(0)
     # run the test in a temporary directory to delete artifacts when done
     os.chdir(tmpdir)
@@ -195,10 +198,16 @@ def test_cyclegan_runs_without_errors(tmpdir, conv_type: str, regtest):
         state_variables=state_variables,
         network=CycleGANNetworkConfig(
             generator=fv3fit.pytorch.GeneratorConfig(
-                n_convolutions=2, n_resnet=5, max_filters=128, kernel_size=3
+                n_convolutions=2,
+                n_resnet=5,
+                max_filters=128,
+                kernel_size=3,
+                strided_kernel_size=strided_kernel_size,
             ),
             optimizer=fv3fit.pytorch.OptimizerConfig(name="Adam", kwargs={"lr": 0.001}),
-            discriminator=fv3fit.pytorch.DiscriminatorConfig(kernel_size=3),
+            discriminator=fv3fit.pytorch.DiscriminatorConfig(
+                kernel_size=3, strided_kernel_size=strided_kernel_size,
+            ),
             convolution_type=conv_type,
             identity_weight=0.01,
             cycle_weight=10.0,

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -189,7 +189,7 @@ def test_cyclegan_runs_without_errors(
     os.chdir(tmpdir)
     # need a larger nx, ny for the sample data here since we're training
     # on whether we can autoencode sin waves, and need to resolve full cycles
-    nx = 32
+    nx = 24
     sizes = {"nbatch": 1, "ntime": 1, "nx": nx, "nz": 2}
     state_variables = ["var_3d", "var_2d"]
     train_tfdataset = get_tfdataset(nsamples=5, **sizes)
@@ -198,15 +198,18 @@ def test_cyclegan_runs_without_errors(
         state_variables=state_variables,
         network=CycleGANNetworkConfig(
             generator=fv3fit.pytorch.GeneratorConfig(
-                n_convolutions=2,
-                n_resnet=5,
-                max_filters=128,
+                n_convolutions=1,
+                n_resnet=3,
+                max_filters=32,
                 kernel_size=3,
                 strided_kernel_size=strided_kernel_size,
             ),
             optimizer=fv3fit.pytorch.OptimizerConfig(name="Adam", kwargs={"lr": 0.001}),
             discriminator=fv3fit.pytorch.DiscriminatorConfig(
-                kernel_size=3, strided_kernel_size=strided_kernel_size,
+                n_convolutions=1,
+                max_filters=32,
+                kernel_size=3,
+                strided_kernel_size=strided_kernel_size,
             ),
             convolution_type=conv_type,
             identity_weight=0.01,


### PR DESCRIPTION
Currently the CycleGAN generator cannot use an odd strided_kernel_size, as it produces incompatible output shapes. This PR supplies an `output_padding` argument in that case which fixes the output shapes, so that an odd strided_kernel_size can be used.

Using a strided kernel size of 3 instead of 4, like was done in the original Zhu et al., appears to give improved performance and skill.

Refactored public API:
- Fixed bug to allow cyclegan generator to use an odd `strided_kernel_size`.

- [x] Tests added

Coverage reports (updated automatically):
