### PR TITLE
Add handling for 'time' variable to WindowedZarrLoader

### DIFF
--- a/external/fv3fit/fv3fit/data/synthetic.py
+++ b/external/fv3fit/fv3fit/data/synthetic.py
@@ -158,8 +158,10 @@ def get_waves_tfdataset(
     grid_x, grid_y = np.broadcast_arrays(grid_x[:, None], grid_y[None, :])
     grid_x = grid_x[None, None, None, :, :, None]
     grid_y = grid_y[None, None, None, :, :, None]
+    time = 0
 
     def sample_generator():
+        nonlocal time
         # creates a timeseries where each time is the negation of time before it
         for _ in range(nsamples):
             ax = np.random.uniform(scale_min, scale_max, size=(nbatch, 1, ntile, nz))[
@@ -198,6 +200,13 @@ def get_waves_tfdataset(
                     out[varname].append(out[varname][-1] * -1.0)
             for varname in out:
                 out[varname] = np.concatenate(out[varname], axis=1)
+            if "time" in variable_names:
+                out["time"] = (
+                    np.arange(time, time + nbatch * ntime)
+                    .reshape((nbatch, ntime))
+                    .astype(np.float32)
+                )
+                time += nbatch * ntime
             yield out
 
     return generator_to_tfdataset(sample_generator)

--- a/external/fv3fit/fv3fit/data/tfdataset.py
+++ b/external/fv3fit/fv3fit/data/tfdataset.py
@@ -1,5 +1,6 @@
 import dataclasses
 import os
+import cftime
 from typing import List, Mapping, Sequence, Optional
 import tensorflow as tf
 from .base import TFDatasetLoader, register_tfdataset_loader, tfdataset_loader_from_dict
@@ -16,8 +17,7 @@ SAMPLE_DIM_NAME = "_fv3fit_sample"
 
 def stack(ds: xr.Dataset, unstacked_dims: Sequence[str]):
     stack_dims = [dim for dim in ds.dims if dim not in unstacked_dims]
-    unstacked_dims = [dim for dim in ds.dims if dim in unstacked_dims]
-    unstacked_dims.sort()  # needed to always get [x, y, z] dimensions
+    unstacked_dims = [dim for dim in unstacked_dims if dim in ds.dims]
     if len(stack_dims) == 0:
         ds_stacked = ds.expand_dims(dim=SAMPLE_DIM_NAME, axis=0)
     else:
@@ -47,21 +47,20 @@ class VariableConfig:
             raise TypeError("times must be one of 'window' or 'start'")
 
     def get_record(self, name: str, ds: xr.Dataset, unstacked_dims: Sequence[str]):
-        for dim in unstacked_dims[:-1]:
-            if dim not in ds[name].dims:
-                raise ValueError("variable {} has no dimension {}".format(name, dim))
         if self.times == "start":
             ds = ds.isel(time=0)
-        ds = stack(ds, unstacked_dims)
+        # must subset dataset to one variable to avoid attaching dimensions
+        # to it that happen to exist in other variables
+        ds = stack(ds[[name]], unstacked_dims)
         return ds[name].values
 
 
-def open_zarr_using_filecache(url: str):
+def open_zarr_using_filecache(url: str, decode_times: bool = False):
     cachedir = tempfile.mkdtemp()
     return xr.open_zarr(
         "filecache::" + url,
         storage_options={"filecache": {"cache_storage": cachedir}},
-        decode_times=False,
+        decode_times=decode_times,
     )
 
 
@@ -119,6 +118,10 @@ class WindowedZarrLoader(TFDatasetLoader):
     necessarily appear in each iteration over the tf.data.Dataset. Each sample window
     is independently selected along any stacked (sample) dimensions.
 
+    If the "time" variable itself is loaded, it will be converted to a number of
+    seconds since 1970-01-01. It is also required that the time variable be
+    one-dimensional in "time" (as opposed to varying along some perturbation axis).
+
     Attributes:
         data_path: path to zarr data
         unstacked_dims: dimensions to keep unstacked when loading data, data loaded
@@ -166,7 +169,13 @@ class WindowedZarrLoader(TFDatasetLoader):
                 variable name to variable value, and each value is a tensor whose
                 first dimension is the batch dimension
         """
-        ds = open_zarr_using_filecache(self.data_path)
+        if "time" in variable_names:
+            decode_times = True
+        else:
+            # if time is not requested, we can skip decoding it
+            # as decoding can cause errors if time is poorly formatted in the dataset
+            decode_times = False
+        ds = open_zarr_using_filecache(self.data_path, decode_times=decode_times)
         ds = ds.isel(time=slice(self.time_start_index, self.time_end_index))
         tfdataset = self._convert_to_tfdataset(ds, variable_names)
         # if local_download_path is given, cache on disk
@@ -239,7 +248,19 @@ def records(
                 array = config.get_record(name, window_ds, unstacked_dims)
                 if i_sample is None:
                     i_sample = np.random.randint(array.shape[0])
-                record[name] = array[i_sample, :]
+                if name == "time":
+                    try:
+                        item = cftime.date2num(array, "seconds since 1970-01-01")
+                    except ValueError:  # raised for arrays of datetime64
+                        item = (
+                            array - np.datetime64("1970-01-01T00:00:00Z")
+                        ) / np.timedelta64(1, "s")
+                else:
+                    try:
+                        item = array[i_sample, :]
+                    except IndexError:
+                        item = np.asarray(array[i_sample])
+                record[name] = item
             yield record
 
     return generator

--- a/external/fv3fit/tests/data_/test_windowed_zarr.py
+++ b/external/fv3fit/tests/data_/test_windowed_zarr.py
@@ -5,6 +5,8 @@ import xarray as xr
 import numpy as np
 import pytest
 import contextlib
+import cftime
+from datetime import timedelta
 
 NX, NY, NZ, NT = 5, 5, 8, 40
 
@@ -163,3 +165,75 @@ def test_loader_handles_time_range():
 )
 def test_get_n_windows(n_times, window_size, n_windows):
     assert get_n_windows(n_times, window_size) == n_windows
+
+
+def test_loader_decodes_time_from_cftime():
+    dir = tempfile.TemporaryDirectory()
+    ds = xr.Dataset(
+        data_vars={
+            "a": xr.DataArray(
+                np.random.randn(NT, NX, NY, NZ), dims=["time", "x", "y", "z"]
+            ),
+        },
+        coords={
+            "time": xr.DataArray(
+                [
+                    cftime.DatetimeJulian(2018, 1, 1) + timedelta(days=i)
+                    for i in range(NT)
+                ],
+                dims=["time"],
+            ),
+        },
+    )
+    ds.to_zarr(dir.name)
+    loader = WindowedZarrLoader(
+        data_path=dir.name,
+        window_size=10,
+        unstacked_dims=["time", "x", "y", "z"],
+        default_variable_config=VariableConfig(times="window"),
+        variable_configs={},
+    )
+    dataset = loader.open_tfdataset(
+        local_download_path=None, variable_names=["a", "time"]
+    )
+    item_tensors = next(iter(dataset))
+    a = item_tensors["a"].numpy()
+    time = item_tensors["time"].numpy()
+    assert time.shape[0] == a.shape[0]  # sample within batch
+    assert time.shape[1] == a.shape[1]  # window size
+    assert time[0, 1] - time[0, 0] == 60 * 60 * 24  # one day
+    assert len(time.shape) == 2
+
+
+def test_loader_decodes_time_from_datetime64():
+    dir = tempfile.TemporaryDirectory()
+    ds = xr.Dataset(
+        data_vars={
+            "a": xr.DataArray(
+                np.random.randn(NT, NX, NY, NZ), dims=["time", "x", "y", "z"]
+            ),
+        },
+        coords={
+            "time": xr.DataArray(
+                np.arange(NT), dims=["time"], attrs={"units": "days since 2018-01-01"}
+            ),
+        },
+    )
+    ds.to_zarr(dir.name)
+    loader = WindowedZarrLoader(
+        data_path=dir.name,
+        window_size=10,
+        unstacked_dims=["time", "x", "y", "z"],
+        default_variable_config=VariableConfig(times="window"),
+        variable_configs={},
+    )
+    dataset = loader.open_tfdataset(
+        local_download_path=None, variable_names=["a", "time"]
+    )
+    item_tensors = next(iter(dataset))
+    a = item_tensors["a"].numpy()
+    time = item_tensors["time"].numpy()
+    assert time.shape[0] == a.shape[0]  # sample within batch
+    assert time.shape[1] == a.shape[1]  # window size
+    assert len(time.shape) == 2
+    assert time[0, 1] - time[0, 0] == 60 * 60 * 24  # one day


### PR DESCRIPTION
This PR adds the ability to load time as a number of seconds since epoch to the WindowedZarrLoader.

Refactored public API:
- If "time" is requested from the WindowedZarrLoader, it will be returned in records as a number of samples since epoch (since 1970-01-01)
- SyntheticZarrLoader can now include time as a record variable
- WindowedZarrLoader now returns variables in the dimension order they were requested. This behavior was unintentionally changed in an earlier commit.
- WindowedZarrLoader can now return variables which are missing any of the requested dimensions, not just the last dimension. This was required in order to return the "time" variable.

- [x] Tests added

Coverage reports (updated automatically):
