### PR TITLE
Make offline create report compatible with scream

### DIFF
--- a/external/fv3viz/examples/plot_cube_fortran_diagnostic.py
+++ b/external/fv3viz/examples/plot_cube_fortran_diagnostic.py
@@ -11,7 +11,7 @@ import io
 import warnings
 import xarray as xr
 from fv3viz import plot_cube
-from vcm.cubedsphere import GridMetadata
+from vcm.cubedsphere import GridMetadataFV3
 
 warnings.filterwarnings(
     "ignore",
@@ -38,7 +38,7 @@ VAR = "LHTFLsfc"
 
 fortran_diagnostic_ds = get_web_dataset(DATA_URL)
 
-gfdl_grid_metadata = GridMetadata("grid_xt", "grid_yt", "grid_x", "grid_y")
+gfdl_grid_metadata = GridMetadataFV3("grid_xt", "grid_yt", "grid_x", "grid_y")
 
 # grid variables are already present in this Fortran diagnostic file
 _ = plot_cube(

--- a/external/fv3viz/examples/plot_cube_scream_diagnostics.py
+++ b/external/fv3viz/examples/plot_cube_scream_diagnostics.py
@@ -1,0 +1,52 @@
+"""
+plot_cube with DOE's SCREAM diagnostics
+===========================================
+
+Example of :py:func:`plot_cube` using SCREAM diagnostic data, with faceting
+over timesteps
+"""
+
+import requests
+import io
+import warnings
+import xarray as xr
+from fv3viz import plot_cube
+from vcm.cubedsphere import GridMetadataScream
+
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message=(
+        "Tight layout not applied. The left and right margins cannot be made "
+        "large enough to accommodate all axes decorations."
+    ),
+)
+
+
+def get_web_dataset(url):
+    r = requests.get(url)
+    ds = xr.open_dataset(io.BytesIO(r.content))
+    return ds
+
+
+DATA_URL = (
+    "https://raw.githubusercontent.com/ai2cm/vcm-ml-example-data/"
+    "main/fv3net/fv3viz/plot_cube_scream_sample.nc"
+)
+VAR = "T_2m"
+
+
+diagnostic_ds = get_web_dataset(DATA_URL)
+
+grid_metadata = GridMetadataScream("ncol", "lon", "lat")
+
+_ = plot_cube(
+    diagnostic_ds,
+    VAR,
+    grid_metadata=grid_metadata,
+    cmap="viridis_r",
+    col="time",
+    col_wrap=2,
+    plotting_function="tripcolor",
+    gsrm_name="scream",
+)

--- a/external/fv3viz/examples/plot_cube_scream_diagnostics.py
+++ b/external/fv3viz/examples/plot_cube_scream_diagnostics.py
@@ -47,6 +47,5 @@ _ = plot_cube(
     cmap="viridis_r",
     col="time",
     col_wrap=2,
-    plotting_function="tripcolor",
     gsrm_name="scream",
 )

--- a/external/fv3viz/examples/plot_cube_scream_diagnostics.py
+++ b/external/fv3viz/examples/plot_cube_scream_diagnostics.py
@@ -47,5 +47,4 @@ _ = plot_cube(
     cmap="viridis_r",
     col="time",
     col_wrap=2,
-    gsrm_name="scream",
 )

--- a/external/fv3viz/fv3viz/__init__.py
+++ b/external/fv3viz/fv3viz/__init__.py
@@ -10,6 +10,16 @@ from ._plot_diagnostics import (
 )
 from ._plot_helpers import infer_cmap_params
 from ._styles import use_colorblind_friendly_style, wong_palette
+from ._constants import (
+    COORD_X_CENTER,
+    COORD_Y_CENTER,
+    COORD_X_OUTER,
+    COORD_Y_OUTER,
+    VAR_LON_CENTER,
+    VAR_LAT_CENTER,
+    VAR_LON_OUTER,
+    VAR_LAT_OUTER,
+)
 
 __all__ = [
     "plot_daily_and_hourly_hist",

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -15,7 +15,7 @@ from ._plot_helpers import (
     _align_plot_var_dims,
 )
 from ._masking import _mask_antimeridian_quads
-from vcm.cubedsphere import GridMetadata, GridMetadataFV3
+from vcm.cubedsphere import GridMetadata, GridMetadataFV3, GridMetadataScream
 import xarray as xr
 import numpy as np
 from matplotlib import pyplot as plt
@@ -249,8 +249,11 @@ def _mappable_var(
     mappable_ds = xr.Dataset()
     for var, dims in grid_metadata.coord_vars.items():
         mappable_ds[var] = _align_grid_var_dims(ds[var], required_dims=dims)
-    var_da = _align_plot_var_dims(ds[var_name], grid_metadata.y, grid_metadata.x)
-    return mappable_ds.merge(var_da)
+    if isinstance(grid_metadata, GridMetadataFV3):
+        var_da = _align_plot_var_dims(ds[var_name], grid_metadata.y, grid_metadata.x)
+        return mappable_ds.merge(var_da)
+    elif isinstance(grid_metadata, GridMetadataScream):
+        return mappable_ds.merge(ds[var_name])
 
 
 def pcolormesh_cube(

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -150,7 +150,7 @@ def plot_cube(
         )
     """
 
-    mappable_ds = _mappable_var(ds, var_name, grid_metadata, gsrm_name)
+    mappable_ds = _mappable_var(ds, var_name, grid_metadata)
     array = mappable_ds[var_name].values
 
     kwargs["vmin"], kwargs["vmax"], kwargs["cmap"] = infer_cmap_params(

--- a/external/fv3viz/tests/test_visualize.py
+++ b/external/fv3viz/tests/test_visualize.py
@@ -18,7 +18,7 @@ from fv3viz._timestep_histograms import (
     plot_daily_hist,
     plot_hourly_hist,
 )
-from vcm.cubedsphere import GridMetadata
+from vcm.cubedsphere import GridMetadataFV3
 
 
 def test_version():
@@ -257,7 +257,7 @@ def sample_dataset(latb, lonb, lat, lon, t2m):
             "y": np.arange(2.0),
         }
     )
-    grid_metadata = GridMetadata("x", "y", "x_interface", "y_interface")
+    grid_metadata = GridMetadataFV3("x", "y", "x_interface", "y_interface")
     return dataset, grid_metadata
 
 
@@ -357,7 +357,7 @@ def example_gfdl_dataset(latb, lonb, lat, lon, t2m):
             "grid_yt": np.arange(2.0),
         }
     )
-    grid_metadata = GridMetadata("grid_xt", "grid_yt", "grid_x", "grid_y")
+    grid_metadata = GridMetadataFV3("grid_xt", "grid_yt", "grid_x", "grid_y")
     return dataset, grid_metadata
 
 

--- a/external/fv3viz/tests/test_visualize.py
+++ b/external/fv3viz/tests/test_visualize.py
@@ -242,6 +242,54 @@ def t2m():
 
 
 @pytest.fixture()
+def lon_scream():
+    return np.array(
+        [0.0, 36.0, 72.0, 108.0, 144.0, 180.0, 216.0, 252.0, 288.0, 324.0],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture()
+def lat_scream():
+    return np.array(
+        [-90.0, -70, -60.0, -30.0, 0.0, 20.0, 30.0, 60.0, 70.0, 90.0], dtype=np.float32,
+    )
+
+
+@pytest.fixture()
+def t2m_scream():
+    return np.array(
+        [
+            [
+                285.24548,
+                285.91785,
+                286.58337,
+                286.31308,
+                289.17456,
+                288.05328,
+                289.89584,
+                289.19724,
+                300.79932,
+                297.65076,
+            ],
+            [
+                300.42297,
+                301.45743,
+                305.09097,
+                301.1763,
+                293.6815,
+                293.9053,
+                293.52594,
+                293.69046,
+                293.8577,
+                293.46573,
+            ],
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture()
 def sample_dataset(latb, lonb, lat, lon, t2m):
     dataset = xr.Dataset(
         {
@@ -267,23 +315,16 @@ def sample_dataset(latb, lonb, lat, lon, t2m):
 
 
 @pytest.fixture()
-def scream_sample_dataset(lat, lon, t2m):
+def scream_sample_dataset(lat_scream, lon_scream, t2m_scream):
     dataset = xr.Dataset(
         {
-            "t2m": (["time", "tile", "y", "x"], t2m),
-            "lat": (["tile", "y", "x"], lat),
-            "lon": (["tile", "y", "x"], lon),
+            "t2m": (["time", "ncol"], t2m_scream),
+            "lat": (["ncol"], lat_scream),
+            "lon": (["ncol"], lon_scream),
         }
     )
-    dataset = dataset.assign_coords(
-        {
-            "time": np.arange(2),
-            "tile": np.arange(6),
-            "x": np.arange(2.0),
-            "y": np.arange(2.0),
-        }
-    )
-    grid_metadata = GridMetadataScream("x", "y",)
+    dataset = dataset.assign_coords({"time": np.arange(2), "ncol": np.arange(10)})
+    grid_metadata = GridMetadataScream()
     return dataset, grid_metadata
 
 
@@ -329,7 +370,7 @@ def test__plot_cube_axes(sample_dataset, plotting_function):
 
 
 @pytest.mark.parametrize(
-    "plotting_function", [("tripcolor"), ("tricontour"), ("tricontourf")]
+    "plotting_function", [("pcolormesh"), ("contour"), ("contourf")]
 )
 def test__plot_scream_axes(scream_sample_dataset, plotting_function):
     dataset, grid_metadata = scream_sample_dataset

--- a/external/vcm/vcm/cubedsphere/__init__.py
+++ b/external/vcm/vcm/cubedsphere/__init__.py
@@ -16,6 +16,6 @@ from .xgcm import create_fv3_grid
 from .coarsen_restarts import coarsen_restarts_on_pressure, coarsen_restarts_on_sigma
 from .regridz import regrid_vertical
 from .cross import to_cross
-from .grid_metadata import GridMetadata
+from .grid_metadata import GridMetadata, GridMetadataFV3, GridMetadataScream
 
 __all__ = [item for item in dir() if not item.startswith("_")]

--- a/external/vcm/vcm/cubedsphere/grid_metadata.py
+++ b/external/vcm/vcm/cubedsphere/grid_metadata.py
@@ -34,16 +34,14 @@ class GridMetadataFV3(GridMetadata):
 
 @dataclasses.dataclass
 class GridMetadataScream(GridMetadata):
-    x: str = "x"
-    y: str = "y"
-    tile: str = "tile"
+    ncol: str = "ncol"
     lon: str = "lon"
     lat: str = "lat"
 
     @property
     def coord_vars(self):
         coord_vars = {
-            self.lon: [self.y, self.x, self.tile],
-            self.lat: [self.y, self.x, self.tile],
+            self.lon: [self.ncol],
+            self.lat: [self.ncol],
         }
         return coord_vars

--- a/external/vcm/vcm/cubedsphere/grid_metadata.py
+++ b/external/vcm/vcm/cubedsphere/grid_metadata.py
@@ -1,8 +1,16 @@
 import dataclasses
+import abc
+
+
+class GridMetadata(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def coord_vars(self) -> dict:
+        ...
 
 
 @dataclasses.dataclass
-class GridMetadata:
+class GridMetadataFV3(GridMetadata):
     x: str = "x"
     y: str = "y"
     x_interface: str = "x_interface"
@@ -18,6 +26,23 @@ class GridMetadata:
         coord_vars = {
             self.lonb: [self.y_interface, self.x_interface, self.tile],
             self.latb: [self.y_interface, self.x_interface, self.tile],
+            self.lon: [self.y, self.x, self.tile],
+            self.lat: [self.y, self.x, self.tile],
+        }
+        return coord_vars
+
+
+@dataclasses.dataclass
+class GridMetadataScream(GridMetadata):
+    x: str = "x"
+    y: str = "y"
+    tile: str = "tile"
+    lon: str = "lon"
+    lat: str = "lat"
+
+    @property
+    def coord_vars(self):
+        coord_vars = {
             self.lon: [self.y, self.x, self.tile],
             self.lat: [self.y, self.x, self.tile],
         }

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/create_report.py
@@ -6,7 +6,6 @@ from typing import MutableMapping, Sequence, List
 import fsspec
 import wandb
 import json
-import loaders
 import fv3viz
 import matplotlib.pyplot as plt
 import numpy as np
@@ -403,7 +402,10 @@ def create_report(args):
         }
         wandb.init(config=wandb_config)
         wandb.log(metrics)
-    gsrm = loaders.BatchesLoader.from_dict(metadata["training_config"]).gsrm_name
+    if "ncol" in ds_diags.dims:
+        gsrm = "scream"
+    else:
+        gsrm = "fv3"
     html_index = render_index(
         metadata, metrics, ds_diags, ds_transect, output_dir=temp_output_dir.name,
     )

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 import fv3viz
 from fv3net.diagnostics.offline._helpers import units_from_name
+from vcm.cubedsphere import GridMetadata, GridMetadataFV3, GridMetadataScream
 
 
 def get_plot_dataset(ds, var_filter: str, column_filters: Sequence[str]):
@@ -139,18 +140,45 @@ def plot_column_integrated_var(
     dataset_dim: str = "dataset",
     dpi: int = 100,
     vmax: Union[int, float] = None,
+    gsrm_name: str = "fv3",
 ):
     ds_columns = (
         ds.sel(derivation=derivation_plot_coords)
         if derivation_plot_coords is not None
         else ds
     )
+    grid_metadata: GridMetadata
+    if gsrm_name == "fv3":
+        grid_metadata = GridMetadataFV3(
+            fv3viz.COORD_X_CENTER,
+            fv3viz.COORD_Y_CENTER,
+            fv3viz.COORD_X_OUTER,
+            fv3viz.COORD_Y_OUTER,
+            "tile",
+            fv3viz.VAR_LON_CENTER,
+            fv3viz.VAR_LON_OUTER,
+            fv3viz.VAR_LAT_CENTER,
+            fv3viz.VAR_LAT_OUTER,
+        )
+        plotting_function = "pcolormesh"
+    elif gsrm_name == "scream":
+        grid_metadata = GridMetadataScream(
+            fv3viz.COORD_X_CENTER,
+            fv3viz.COORD_Y_CENTER,
+            "tile",
+            fv3viz.VAR_LON_CENTER,
+            fv3viz.VAR_LAT_CENTER,
+        )
+        plotting_function = "tripcolor"
     f, _, _, _, facet_grid = fv3viz.plot_cube(
         ds_columns,
         var,
+        grid_metadata=grid_metadata,
+        plotting_function=plotting_function,
         col=derivation_dim,
         row=dataset_dim if dataset_dim in ds.dims else None,
         vmax=vmax,
+        gsrm_name=gsrm_name,
     )
     if facet_grid:
         facet_grid.set_titles(template="{value} ", maxchar=40)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -149,32 +149,18 @@ def plot_column_integrated_var(
     )
     grid_metadata: GridMetadata
     if gsrm_name == "fv3":
-        grid_metadata = GridMetadataFV3(
-            fv3viz.COORD_X_CENTER,
-            fv3viz.COORD_Y_CENTER,
-            fv3viz.COORD_X_OUTER,
-            fv3viz.COORD_Y_OUTER,
-            "tile",
-            fv3viz.VAR_LON_CENTER,
-            fv3viz.VAR_LON_OUTER,
-            fv3viz.VAR_LAT_CENTER,
-            fv3viz.VAR_LAT_OUTER,
-        )
-        plotting_function = "pcolormesh"
+        grid_metadata = GridMetadataFV3()
     elif gsrm_name == "scream":
         grid_metadata = GridMetadataScream(
             "ncol", fv3viz.VAR_LON_CENTER, fv3viz.VAR_LAT_CENTER,
         )
-        plotting_function = "tripcolor"
     f, _, _, _, facet_grid = fv3viz.plot_cube(
         ds_columns,
         var,
         grid_metadata=grid_metadata,
-        plotting_function=plotting_function,
         col=derivation_dim,
         row=dataset_dim if dataset_dim in ds.dims else None,
         vmax=vmax,
-        gsrm_name=gsrm_name,
     )
     if facet_grid:
         facet_grid.set_titles(template="{value} ", maxchar=40)

--- a/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/views/plot.py
@@ -163,11 +163,7 @@ def plot_column_integrated_var(
         plotting_function = "pcolormesh"
     elif gsrm_name == "scream":
         grid_metadata = GridMetadataScream(
-            fv3viz.COORD_X_CENTER,
-            fv3viz.COORD_Y_CENTER,
-            "tile",
-            fv3viz.VAR_LON_CENTER,
-            fv3viz.VAR_LAT_CENTER,
+            "ncol", fv3viz.VAR_LON_CENTER, fv3viz.VAR_LAT_CENTER,
         )
         plotting_function = "tripcolor"
     f, _, _, _, facet_grid = fv3viz.plot_cube(


### PR DESCRIPTION
In this PR, we add the capability of plotting scream data. 

Added public API:
- Added `GridMetadataFV3` and `GridMetadataScream`: for now they look rather similar just w/o `latb` and `lonb`, but in the future, we may consider retaining the native scream output dimension

Significant internal changes:
- `plot_cube`: uses grid metadata to determine whether to plot fv3 or scream data

- [x] Tests added

Coverage reports (updated automatically):
