### PR TITLE
Add plumbing to include time in cyclegan model code

### DIFF
--- a/external/fv3fit/fv3fit/data/synthetic.py
+++ b/external/fv3fit/fv3fit/data/synthetic.py
@@ -33,8 +33,8 @@ class SyntheticNoise(TFDatasetLoader):
         dataset = get_noise_tfdataset(
             variable_names,
             scalar_names=self.scalar_names,
-            nsamples=self.nsamples,
             nbatch=self.nbatch,
+            nsamples=self.nsamples,
             ntime=self.ntime,
             nx=self.nx,
             ny=self.nx,
@@ -110,8 +110,8 @@ class SyntheticWaves(TFDatasetLoader):
         dataset = get_waves_tfdataset(
             variable_names,
             scalar_names=self.scalar_names,
-            nsamples=self.nsamples,
             nbatch=self.nbatch,
+            nsamples=self.nsamples,
             ntime=self.ntime,
             nx=self.nx,
             ny=self.nx,
@@ -138,8 +138,8 @@ def get_waves_tfdataset(
     variable_names,
     *,
     scalar_names,
-    nsamples: int,
     nbatch: int,
+    nsamples: int,
     ntime: int,
     nx: int,
     ny: int,
@@ -158,27 +158,29 @@ def get_waves_tfdataset(
     grid_x, grid_y = np.broadcast_arrays(grid_x[:, None], grid_y[None, :])
     grid_x = grid_x[None, None, None, :, :, None]
     grid_y = grid_y[None, None, None, :, :, None]
+    time = 0
 
     def sample_generator():
+        nonlocal time
         # creates a timeseries where each time is the negation of time before it
-        for _ in range(nsamples):
-            ax = np.random.uniform(scale_min, scale_max, size=(nbatch, 1, ntile, nz))[
+        for _ in range(nbatch):
+            ax = np.random.uniform(scale_min, scale_max, size=(nsamples, 1, ntile, nz))[
                 :, :, :, None, None, :
             ]
-            bx = np.random.uniform(period_min, period_max, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
-            cx = np.random.uniform(
-                0.0, 2 * np.pi * phase_range, size=(nbatch, 1, ntile, nz)
+            bx = np.random.uniform(
+                period_min, period_max, size=(nsamples, 1, ntile, nz)
             )[:, :, :, None, None, :]
-            ay = np.random.uniform(scale_min, scale_max, size=(nbatch, 1, ntile, nz))[
+            cx = np.random.uniform(
+                0.0, 2 * np.pi * phase_range, size=(nsamples, 1, ntile, nz)
+            )[:, :, :, None, None, :]
+            ay = np.random.uniform(scale_min, scale_max, size=(nsamples, 1, ntile, nz))[
                 :, :, :, None, None, :
             ]
-            by = np.random.uniform(period_min, period_max, size=(nbatch, 1, ntile, nz))[
-                :, :, :, None, None, :
-            ]
+            by = np.random.uniform(
+                period_min, period_max, size=(nsamples, 1, ntile, nz)
+            )[:, :, :, None, None, :]
             cy = np.random.uniform(
-                0.0, 2 * np.pi * phase_range, size=(nbatch, 1, ntile, nz)
+                0.0, 2 * np.pi * phase_range, size=(nsamples, 1, ntile, nz)
             )[:, :, :, None, None, :]
             data = (
                 ax
@@ -198,6 +200,13 @@ def get_waves_tfdataset(
                     out[varname].append(out[varname][-1] * -1.0)
             for varname in out:
                 out[varname] = np.concatenate(out[varname], axis=1)
+            if "time" in variable_names:
+                out["time"] = (
+                    np.arange(time, time + nsamples * ntime)
+                    .reshape((nsamples, ntime))
+                    .astype(np.float32)
+                )
+                time += nsamples * ntime
             yield out
 
     return generator_to_tfdataset(sample_generator)
@@ -207,8 +216,8 @@ def get_noise_tfdataset(
     variable_names,
     *,
     scalar_names,
-    nsamples: int,
     nbatch: int,
+    nsamples: int,
     ntime: int,
     nx: int,
     ny: int,
@@ -216,11 +225,13 @@ def get_noise_tfdataset(
     noise_amplitude: float,
 ):
     ntile = 6
+    time = 0
 
     def sample_generator():
+        nonlocal time
         # creates a timeseries where each time is the negation of time before it
-        for _ in range(nsamples):
-            data = noise_amplitude * np.random.randn(nbatch, 1, ntile, nx, ny, nz)
+        for _ in range(nbatch):
+            data = noise_amplitude * np.random.randn(nsamples, 1, ntile, nx, ny, nz)
             start = {}
             for varname in variable_names:
                 if varname in scalar_names:
@@ -233,6 +244,13 @@ def get_noise_tfdataset(
                     out[varname].append(out[varname][-1] * -1.0)
             for varname in out:
                 out[varname] = np.concatenate(out[varname], axis=1)
+            if "time" in variable_names:
+                out["time"] = (
+                    np.arange(time, time + nsamples * ntime)
+                    .reshape((nsamples, ntime))
+                    .astype(np.float32)
+                )
+                time += nsamples * ntime
             yield out
 
     return generator_to_tfdataset(sample_generator)

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/discriminator.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Tuple
 
 import torch.nn as nn
 from toolz import curry
@@ -115,12 +116,13 @@ class Discriminator(nn.Module):
         )
         self._sequential = nn.Sequential(*convs, final_conv, patch_output)
 
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+    def forward(self, inputs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
         """
         Args:
-            inputs: tensor of shape (batch, tile, in_channels, height, width)
+            inputs: A tuple containing a tensor of shape (batch, 1) with the time and
+                a tensor of shape (batch, tile, in_channels, height, width)
 
         Returns:
             tensor of shape (batch, tile, 1, height, width)
         """
-        return self._sequential(inputs)
+        return self._sequential(inputs[1])

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Tuple
 import torch.nn as nn
 from toolz import curry
 import torch
@@ -186,15 +187,17 @@ class Generator(nn.Module):
             self._input_bias = nn.Identity()
             self._output_bias = nn.Identity()
 
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+    def forward(self, inputs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
         """
         Args:
-            inputs: tensor of shape [batch, tile, channels, x, y]
+            inputs: A tuple containing a tensor of shape (batch, 1) with the time and
+                a tensor of shape (batch, tile, in_channels, height, width)
 
         Returns:
             tensor of shape [batch, tile, channels, x, y]
         """
-        x = self._input_bias(inputs)
+        _, state = inputs
+        x = self._input_bias(state)
         x = self._main(x)
         outputs: torch.Tensor = self._output_bias(x)
         return outputs

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/image_pool.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/image_pool.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017, Jun-Yan Zhu and Taesung Park under a BSD license
 
 import random
+from typing import Tuple
 import torch
 
 
@@ -21,8 +22,11 @@ class ImagePool:
         if self.pool_size > 0:  # create an empty pool
             self.num_imgs = 0
             self.images = []
+            self.times = []
 
-    def query(self, images):
+    def query(
+        self, images: Tuple[torch.Tensor, torch.Tensor]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Return an image from the pool.
         Parameters:
             images: the latest generated images from the generator
@@ -33,14 +37,18 @@ class ImagePool:
         """
         if self.pool_size == 0:  # if the buffer size is 0, do nothing
             return images
+        return_times = []
         return_images = []
-        for image in images:
+        for time, image in zip(*images):
+            time = torch.unsqueeze(time.data, 0)
             image = torch.unsqueeze(image.data, 0)
             if (
                 self.num_imgs < self.pool_size
             ):  # if the buffer is not full; keep inserting current images to the buffer
                 self.num_imgs = self.num_imgs + 1
+                self.times.append(time)
                 self.images.append(image)
+                return_times.append(time)
                 return_images.append(image)
             else:
                 p = random.uniform(0, 1)
@@ -50,10 +58,15 @@ class ImagePool:
                     random_id = random.randint(
                         0, self.pool_size - 1
                     )  # randint is inclusive
-                    tmp = self.images[random_id].clone()
+                    tmp_time = self.times[random_id].clone()
+                    tmp_img = self.images[random_id].clone()
+                    self.times[random_id] = time
                     self.images[random_id] = image
-                    return_images.append(tmp)
+                    return_times.append(tmp_time)
+                    return_images.append(tmp_img)
                 else:  # by another 50% chance, the buffer will return the current image
+                    return_times.append(time)
                     return_images.append(image)
+        return_times = torch.cat(return_times, 0)  # collect all the times and return
         return_images = torch.cat(return_images, 0)  # collect all the images and return
-        return return_images
+        return (return_times, return_images)

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/reloadable.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/reloadable.py
@@ -4,14 +4,16 @@ from fv3fit._shared.scaler import StandardScaler
 from fv3fit.pytorch.predict import (
     _dump_pytorch,
     _load_pytorch,
-    _pack_to_tensor,
     _unpack_tensor,
 )
+from fv3fit.pytorch.system import DEVICE
 from .generator import Generator
 from .discriminator import Discriminator
-from typing import Mapping, Iterable
+from typing import Mapping, Iterable, Tuple
 import torch
 import xarray as xr
+import numpy as np
+import cftime
 
 
 class CycleGANModule(torch.nn.Module):
@@ -117,10 +119,10 @@ class CycleGAN(Reloadable):
             for name, scaler in self.scalers.items()
             if name.startswith(f"{domain}_")
         }
-        tensor = _pack_to_tensor(
+        time, tensor = _pack_to_tensor(
             ds=ds, timesteps=0, state_variables=self.state_variables, scalers=scalers,
         )
-        return tensor.permute([0, 1, 4, 2, 3])
+        return time, tensor.permute([0, 1, 4, 2, 3])
 
     def unpack_tensor(self, data: torch.Tensor, domain: str = "b") -> xr.Dataset:
         """
@@ -149,6 +151,8 @@ class CycleGAN(Reloadable):
         """
         Predict a state in the output domain from a state in the input domain.
 
+        "time" must be a variable present in the dataset decoded into datetime.
+
         Args:
             X: input dataset
             reverse: if True, transform from the output domain to the input domain
@@ -161,7 +165,7 @@ class CycleGAN(Reloadable):
         else:
             input_domain, output_domain = "a", "b"
 
-        tensor = self.pack_to_tensor(X, domain=input_domain)
+        time, tensor = self.pack_to_tensor(X, domain=input_domain)
         if reverse:
             generator = self.generator_b_to_a
         else:
@@ -170,7 +174,80 @@ class CycleGAN(Reloadable):
         outputs = torch.zeros_like(tensor)
         with torch.no_grad():
             for i in range(0, tensor.shape[0], n_batch):
-                new: torch.Tensor = generator(tensor[i : i + n_batch])
+                new: torch.Tensor = generator(
+                    (time[i : i + n_batch], tensor[i : i + n_batch])
+                )
                 outputs[i : i + new.shape[0]] = new
         predicted = self.unpack_tensor(outputs, domain=output_domain)
+        predicted["time"] = X["time"]
         return predicted
+
+
+def _pack_to_tensor(
+    ds: xr.Dataset,
+    timesteps: int,
+    state_variables: Iterable[str],
+    scalers: Mapping[str, StandardScaler],
+) -> torch.Tensor:
+    """
+    Packs the dataset into a tensor to be used by the pytorch model.
+
+    Subdivides the dataset evenly into windows
+    of size (timesteps + 1) with overlapping start and end points.
+    Overlapping the window start and ends is necessary so that every
+    timestep (evolution from one time to the next) is included within
+    one of the windows.
+
+    Args:
+        ds: dataset containing values to pack
+        timesteps: number timesteps to include in each window after initial time
+
+    Returns:
+        tensor of shape [window, time, tile, x, y, feature]
+    """
+
+    expected_dims: Tuple[str, ...] = ("time", "tile", "x", "y")
+    if "z" in ds.dims:
+        expected_dims += ("z",)
+    ds = ds.transpose(..., *expected_dims)
+    if timesteps > 0:
+        n_times = ds.time.size
+        n_windows = int((n_times - 1) // timesteps)
+        # times need to be evenly divisible into windows
+        ds = ds.isel(time=slice(None, n_windows * timesteps + 1))
+    all_data = []
+    for varname in state_variables:
+        var_dims = ds[varname].dims
+        if tuple(var_dims[:4]) != expected_dims[:4]:
+            raise ValueError(
+                f"received variable {varname} with " f"unexpected dimensions {var_dims}"
+            )
+        data = ds[varname].values
+        normalized_data = scalers[varname].normalize(data)
+        if timesteps > 0:
+            # segment time axis into windows, excluding last time of each window
+            data = normalized_data[:-1, :].reshape(
+                n_windows, timesteps, *data.shape[1:]
+            )
+            # append first time of next window to end of each window
+            if n_windows > 1:
+                end_data = np.concatenate(
+                    [data[1:, :1, :], normalized_data[None, -1:, :]], axis=0
+                )
+            else:
+                end_data = normalized_data[None, -1:, :]
+            data = np.concatenate([data, end_data], axis=1)
+        else:
+            data = normalized_data
+        if "z" not in var_dims:
+            # need a z-axis for concatenation into feature axis
+            data = data[..., np.newaxis]
+        all_data.append(data)
+    concatenated_data = np.concatenate(all_data, axis=-1)
+    time = cftime.date2num(ds["time"].values, "seconds since 1970-01-01").astype(
+        np.float32
+    )
+    return (
+        torch.as_tensor(time).float().to(DEVICE),
+        torch.as_tensor(concatenated_data).float().to(DEVICE),
+    )

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_cyclegan.py
@@ -16,6 +16,7 @@ import fv3fit
 import matplotlib.pyplot as plt
 import pytest
 import fv3fit.wandb
+import cftime
 
 
 def get_tfdataset(nsamples, nbatch, ntime, nx, nz):
@@ -50,7 +51,7 @@ def get_tfdataset(nsamples, nbatch, ntime, nx, nz):
         ]
     )
     dataset = config.open_tfdataset(
-        local_download_path=None, variable_names=["var_3d", "var_2d"]
+        local_download_path=None, variable_names=["var_3d", "var_2d", "time"]
     )
     return dataset
 
@@ -79,7 +80,7 @@ def get_noise_tfdataset(nsamples, nbatch, ntime, nx, nz):
         ]
     )
     dataset = config.open_tfdataset(
-        local_download_path=None, variable_names=["var_3d", "var_2d"]
+        local_download_path=None, variable_names=["var_3d", "var_2d", "time"]
     )
     return dataset
 
@@ -103,6 +104,9 @@ def tfdataset_to_xr_dataset(tfdataset, dims: Sequence[str]):
     for name in data_sequences:
         data = np.concatenate(data_sequences[name])
         data_vars[name] = xr.DataArray(data, dims=dims[: len(data.shape)])
+    data_vars["time"] = cftime.num2date(
+        data_vars["time"], units="seconds since 2000-01-01"
+    )
     return xr.Dataset(data_vars)
 
 

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_image_pool.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_image_pool.py
@@ -1,0 +1,17 @@
+from fv3fit.pytorch.cyclegan.image_pool import ImagePool
+import numpy as np
+import torch
+
+
+def test_image_times_are_paired():
+    pool = ImagePool(20)
+    times = torch.as_tensor(np.arange(10))
+    images = torch.as_tensor(np.arange(10)[:, None, None])
+    pool.query((times, images))
+    pool.query((times, images))
+    result = pool.query((times, images))
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert not np.all(result[0].cpu().numpy() == times.cpu().numpy())
+    for time, image in zip(result[0], result[1]):
+        assert np.all(image.cpu().numpy() == time.cpu().numpy())

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
@@ -7,11 +7,16 @@ import tensorflow as tf
 import torch
 from fv3fit.pytorch.system import DEVICE
 import tensorflow_datasets as tfds
-from fv3fit.tfdataset import apply_to_tuple
+from fv3fit.tfdataset import (
+    apply_to_mapping_with_exclude,
+    select_keys,
+    apply_to_tuple,
+)
 import secrets
 from datetime import datetime
 
 from fv3fit._shared import register_training_function
+from fv3fit._shared.scaler import StandardScaler
 from typing import (
     Callable,
     Iterable,
@@ -23,11 +28,6 @@ from typing import (
 )
 
 from fv3fit.tfdataset import ensure_nd
-from fv3fit.pytorch.graph.train import get_Xy_map_fn as get_Xy_map_fn_single_domain
-from fv3fit._shared.scaler import (
-    get_standard_scaler_mapping,
-    get_mapping_standard_scale_func,
-)
 from fv3fit._shared import io
 import logging
 import numpy as np
@@ -63,7 +63,7 @@ class CycleGANHyperparameters(Hyperparameters):
 
     @property
     def variables(self):
-        return tuple(self.state_variables)
+        return tuple(self.state_variables) + ("time",)
 
 
 @dataclasses.dataclass
@@ -137,15 +137,21 @@ class CycleGANTrainingConfig:
         self,
         train_model: CycleGANTrainer,
         train_states: Iterable[Tuple[torch.Tensor, torch.Tensor]],
-        validation_data: Optional[tf.data.Dataset],
+        validation_states: Optional[Iterable[Tuple[torch.Tensor, torch.Tensor]]],
     ):
         reporter = Reporter()
         for state_a, state_b in train_states:
-            train_example_a, train_example_b = (state_a[:1, :], state_b[:1, :])
+            train_example_a, train_example_b = (
+                (state_a[0], state_a[1][:1, :]),
+                (state_b[0], state_b[1][:1, :]),
+            )
             break
-        if validation_data is not None:
-            for state_a, state_b in validation_data:
-                val_example_a, val_example_b = (state_a[:1, :], state_b[:1, :])
+        if validation_states is not None:
+            for state_a, state_b in validation_states:
+                val_example_a, val_example_b = (
+                    (state_a[0], state_a[1][:1, :]),
+                    (state_b[0], state_b[1][:1, :]),
+                )
                 break
         else:
             val_example_a, val_example_b = None, None  # type: ignore
@@ -184,10 +190,10 @@ class CycleGANTrainingConfig:
             )
             reporter.log(train_plots)
 
-            if validation_data is not None:
+            if validation_states is not None:
                 val_aggregator = ResultsAggregator(histogram_vmax=self.histogram_vmax)
                 val_losses = []
-                for state_a, state_b in validation_data:
+                for state_a, state_b in validation_states:
                     with torch.no_grad():
                         val_losses.append(
                             train_model.train_on_batch(
@@ -225,9 +231,11 @@ def dataset_to_tuples(dataset) -> List[Tuple[torch.Tensor, torch.Tensor]]:
     states = []
     batch_state: Tuple[np.ndarray, np.ndarray]
     for batch_state in dataset:
-        state_a = torch.as_tensor(batch_state[0]).float().to(DEVICE)
-        state_b = torch.as_tensor(batch_state[1]).float().to(DEVICE)
-        states.append((state_a, state_b))
+        time_a = torch.as_tensor(batch_state[0][0]).float().to(DEVICE)
+        state_a = torch.as_tensor(batch_state[0][1]).float().to(DEVICE)
+        time_b = torch.as_tensor(batch_state[1][0]).float().to(DEVICE)
+        state_b = torch.as_tensor(batch_state[1][1]).float().to(DEVICE)
+        states.append(((time_a, state_a), (time_b, state_b)))
     return states
 
 
@@ -239,17 +247,22 @@ class DatasetStateIterator:
 
     def __iter__(self):
         for batch_state in self.dataset:
-            state_a = torch.as_tensor(batch_state[0]).float().to(DEVICE)
-            state_b = torch.as_tensor(batch_state[1]).float().to(DEVICE)
-            yield state_a, state_b
+            time_a = torch.as_tensor(batch_state[0][0]).float().to(DEVICE)
+            state_a = torch.as_tensor(batch_state[0][1]).float().to(DEVICE)
+            time_b = torch.as_tensor(batch_state[1][0]).float().to(DEVICE)
+            state_b = torch.as_tensor(batch_state[1][1]).float().to(DEVICE)
+            yield (time_a, state_a), (time_b, state_b)
 
 
-def apply_to_tuple_mapping(func):
+def apply_to_tuple_mapping(func, exclude: Optional[Sequence[str]] = None):
     # not sure why, but tensorflow doesn't like parsing
     # apply_to_tuple(apply_to_mapping(func)), so we do it manually
     def wrapped(*tuple_of_mapping):
         return tuple(
-            {name: func(value) for name, value in mapping.items()}
+            {
+                name: func(value) if name not in exclude else value
+                for name, value in mapping.items()
+            }
             for mapping in tuple_of_mapping
         )
 
@@ -264,6 +277,14 @@ def get_Xy_map_fn(
         ...,  # noqa: W504
     ],
 ):
+    """
+    Args:
+        state_variables: names of state variables to extract
+        n_dims: number of dimensions in the state variables
+        mapping_scale_funcs: one mapping scale function for each domain for which
+            we are generating a state. In practice for a basic CycleGAN this will
+            contain two scale functions, one for domain A and one for domain B.
+    """
     funcs = tuple(
         get_Xy_map_fn_single_domain(
             state_variables=state_variables, n_dims=n_dims, mapping_scale_func=func
@@ -277,9 +298,46 @@ def get_Xy_map_fn(
     return Xy_map_fn
 
 
-def channels_first(data: tf.Tensor) -> tf.Tensor:
+def get_Xy_map_fn_single_domain(
+    state_variables: Sequence[str],
+    n_dims: int,
+    mapping_scale_func: Callable[[Mapping[str, np.ndarray]], Mapping[str, np.ndarray]],
+):
+    """
+    Returns a function which when given a tf.data.Dataset with mappings from
+    variable name to samples
+    returns a tf.data.Dataset whose entries are 2-tuples conntaining
+    "time" and tensors of the requested state variables concatenated along
+    the feature dimension.
+    Args:
+        state_variables: names of variables to include in returned tensor
+        n_dims: number of dimensions of each sample, including feature dimension
+        mapping_scale_func: function which scales data stored as a mapping
+            from variable name to array
+        data: tf.data.Dataset with mappings from variable name
+            to sample tensors
+    Returns:
+        tf.data.Dataset where each sample is a single tensor
+            containing normalized and concatenated state variables
+    """
+    ensure_dims = apply_to_mapping_with_exclude(ensure_nd(n_dims), exclude=("time",))
+
+    def map_fn(data):
+        time = data["time"]
+        data = mapping_scale_func(data)
+        data = ensure_dims(data)
+        data = select_keys(state_variables, data)
+        data = tf.concat(data, axis=-1)
+        return (time, data)
+
+    return map_fn
+
+
+def channels_first(data: Tuple[tf.Tensor, tf.Tensor]) -> Tuple[tf.Tensor, tf.Tensor]:
     # [batch, time, tile, x, y, z] -> [batch, time, tile, z, x, y]
-    return tf.transpose(data, perm=[0, 1, 2, 5, 3, 4])
+    # first entry of tuple is state label information (time)
+    # which we don't want to transpose
+    return (data[0], tf.transpose(data[1], perm=[0, 1, 2, 5, 3, 4]))
 
 
 def force_cudnn_initialization():
@@ -289,6 +347,31 @@ def force_cudnn_initialization():
     torch.nn.functional.conv2d(
         torch.zeros(s, s, s, s, device=DEVICE), torch.zeros(s, s, s, s, device=DEVICE)
     )
+
+
+def get_standard_scaler_mapping(
+    sample: Mapping[str, np.ndarray]
+) -> Mapping[str, StandardScaler]:
+    scalers = {}
+    for name, array in sample.items():
+        if name != "time":
+            s = StandardScaler(n_sample_dims=5)
+            s.fit(array)
+            scalers[name] = s
+    return scalers
+
+
+def get_mapping_standard_scale_func(
+    scalers: Mapping[str, StandardScaler]
+) -> Callable[[Mapping[str, np.ndarray]], Mapping[str, np.ndarray]]:
+    def scale(data: Mapping[str, np.ndarray]):
+        output = {**data}
+        for name, array in data.items():
+            if name != "time":
+                output[name] = scalers[name].normalize(array)
+        return output
+
+    return scale
 
 
 @register_training_function("cyclegan", CycleGANHyperparameters)
@@ -308,7 +391,9 @@ def train_cyclegan(
             where each tensor has dimensions [sample, time, tile, x, y(, z)]
     """
     force_cudnn_initialization()
-    train_batches = train_batches.map(apply_to_tuple_mapping(ensure_nd(6)))
+    train_batches = train_batches.map(
+        apply_to_tuple_mapping(ensure_nd(6), exclude=("time",))
+    )
     sample_batch = next(
         iter(train_batches.unbatch().batch(hyperparameters.normalization_fit_samples))
     )
@@ -331,7 +416,7 @@ def train_cyclegan(
 
     train_state = train_batches.map(get_Xy)
 
-    sample: tf.Tensor = next(iter(train_state))[0]
+    sample: tf.Tensor = next(iter(train_state))[0][1]  # discard time of first sample
     train_model = hyperparameters.network.build(
         nx=sample.shape[-3],
         ny=sample.shape[-2],

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/train_cyclegan.py
@@ -405,7 +405,7 @@ def train_cyclegan(
 
     get_Xy = get_Xy_map_fn(
         state_variables=hyperparameters.state_variables,
-        n_dims=6,  # [batch, sample, tile, x, y, z]
+        n_dims=6,
         mapping_scale_funcs=mapping_scale_funcs,
     )
 

--- a/external/fv3fit/fv3fit/tfdataset.py
+++ b/external/fv3fit/fv3fit/tfdataset.py
@@ -27,6 +27,26 @@ def apply_to_mapping(
     return {name: tensor_func(tensor) for name, tensor in data.items()}
 
 
+@curry
+def apply_to_mapping_with_exclude(
+    tensor_func: Callable[[T_in], T_in],
+    data: Mapping[str, T_in],
+    exclude: Optional[Sequence[str]],
+) -> Dict[str, T_in]:
+    # need a duplicate function of this because having an exclude key
+    # limits the call signature of tensor_func to have the same output and
+    # input types
+    if exclude is None:
+        exclude = tuple()
+    return_mapping = {}
+    for name, tensor in data.items():
+        if name not in exclude:
+            return_mapping[name] = tensor_func(tensor)
+        else:
+            return_mapping[name] = tensor
+    return return_mapping
+
+
 def apply_to_tuple(
     tensor_func: Callable[[T_in], T_out],
 ) -> Callable[[Tuple[T_in, ...]], Tuple[T_out, ...]]:

--- a/external/fv3fit/tests/data_/test_synthetic.py
+++ b/external/fv3fit/tests/data_/test_synthetic.py
@@ -1,0 +1,35 @@
+from fv3fit.data import SyntheticWaves, SyntheticNoise
+
+
+def test_waves_has_correct_time_shape():
+    config = SyntheticWaves(
+        nsamples=10,
+        nbatch=2,
+        ntime=3,
+        nx=4,
+        nz=5,
+        scalar_names=["var_2d"],
+        scale_min=0.5,
+        scale_max=1.0,
+        period_min=8,
+        period_max=16,
+        wave_type="sinusoidal",
+    )
+    tfdataset = config.open_tfdataset(local_download_path=None, variable_names=["time"])
+    sample = next(iter(tfdataset))
+    assert tuple(sample["time"].shape) == (10, 3)
+
+
+def test_noise_has_correct_time_shape():
+    config = SyntheticNoise(
+        nsamples=10,
+        nbatch=2,
+        ntime=3,
+        nx=4,
+        nz=5,
+        scalar_names=["var_2d"],
+        noise_amplitude=1.0,
+    )
+    tfdataset = config.open_tfdataset(local_download_path=None, variable_names=["time"])
+    sample = next(iter(tfdataset))
+    assert tuple(sample["time"].shape) == (10, 3)


### PR DESCRIPTION
This PR modifies the CycleGAN training function so that the discriminator and generator take time as an input.

In this PR, they do not make use of the time variable, but the soon-to-be-added GeographicFeatures will make use of it in a follow-on PR.

Refactored public API:
- Discriminator and Generator in the CycleGAN code now take in a tuple of time and its previous state.
- The CycleGAN training function now takes time as a hard-coded required variable

Significant internal changes:
- Internal APIs of the cyclegan training function were added to propagate time of each sample as input

- [x] Tests added

Coverage reports (updated automatically):
