### PR TITLE
Add use_geographic_features option to generator and discriminator

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
@@ -447,42 +447,72 @@ class CycleGANTrainer:
         self._script_gen_b_to_a = None
         self._script_disc_a = None
         self._script_disc_b = None
+        # This flag can be manually used to disable compilation, for clearer
+        # error messages and debugging. It should always be set to True in PRs.
+        self._compile = True  # if this is False in a PR, say something!
+        self._compiled_shape = None
 
-    def _call_generator_a_to_b(self, input):
-        if self._script_gen_a_to_b is None:
-            self._script_gen_a_to_b = torch.jit.trace(
-                self.generator_a_to_b.forward, (input,)
-            )
-        return self._script_gen_a_to_b(input)
+    def _call_generator_a_to_b(
+        self, input: Tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor:
+        if self._compile:
+            if self._script_gen_a_to_b is None:
+                self._script_gen_a_to_b = torch.jit.trace(
+                    self.generator_a_to_b.forward, input,
+                )
+            try:
+                return self._script_gen_a_to_b(*input)
+            except RuntimeError:
+                # gives better messages for true errors, but also lets us process
+                # a smaller batch at the end of the dataset if one exists
+                return self.generator_a_to_b(*input)
+        else:
+            return self.generator_a_to_b(*input)
 
-    def _call_generator_b_to_a(self, input):
-        if self._script_gen_b_to_a is None:
-            self._script_gen_b_to_a = torch.jit.trace(
-                self.generator_b_to_a.forward, (input,)
-            )
-        return self._script_gen_b_to_a(input)
+    def _call_generator_b_to_a(
+        self, input: Tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor:
+        if self._compile:
+            if self._script_gen_b_to_a is None:
+                self._script_gen_b_to_a = torch.jit.trace(
+                    self.generator_b_to_a.forward, input,
+                )
+            try:
+                return self._script_gen_b_to_a(*input)
+            except RuntimeError:
+                return self.generator_b_to_a(*input)
+        else:
+            return self.generator_b_to_a(*input)
 
-    def _call_discriminator_a(self, input):
-        if self._script_disc_a is None:
-            self._script_disc_a = torch.jit.trace(
-                self.discriminator_a.forward, (input,)
-            )
-        return self._script_disc_a(input)
+    def _call_discriminator_a(
+        self, input: Tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor:
+        if self._compile:
+            if self._script_disc_a is None:
+                self._script_disc_a = torch.jit.trace(
+                    self.discriminator_a.forward, input,
+                )
+            try:
+                return self._script_disc_a(*input)
+            except RuntimeError:
+                return self.discriminator_a(*input)
+        else:
+            return self.discriminator_a(*input)
 
-    def _call_discriminator_b(self, input):
-        if self._script_disc_b is None:
-            self._script_disc_b = torch.jit.trace(
-                self.discriminator_b.forward, (input,)
-            )
-        return self._script_disc_b(input)
-
-    def _init_targets(self, shape: Tuple[int, ...]):
-        self.target_real = torch.autograd.Variable(
-            torch.Tensor(shape).fill_(1.0).to(DEVICE), requires_grad=False
-        )
-        self.target_fake = torch.autograd.Variable(
-            torch.Tensor(shape).fill_(0.0).to(DEVICE), requires_grad=False
-        )
+    def _call_discriminator_b(
+        self, input: Tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor:
+        if self._compile:
+            if self._script_disc_b is None:
+                self._script_disc_b = torch.jit.trace(
+                    self.discriminator_b.forward, input,
+                )
+            try:
+                return self._script_disc_b(*input)
+            except RuntimeError:
+                return self.discriminator_b(*input)
+        else:
+            return self.discriminator_b(*input)
 
     def train_on_batch(
         self,
@@ -518,9 +548,10 @@ class CycleGANTrainer:
         # Generators A2B and B2A ######
 
         # don't update discriminators when training generators to fool them
-        set_requires_grad(
-            [self.discriminator_a, self.discriminator_b], requires_grad=False
-        )
+        if training:
+            set_requires_grad(
+                [self.discriminator_a, self.discriminator_b], requires_grad=False
+            )
 
         # Identity loss
         # G_A2B(B) should equal B if real B is fed
@@ -535,14 +566,26 @@ class CycleGANTrainer:
         # GAN loss
         pred_fake_b = self._call_discriminator_b((time_a, fake_b))
         if self.target_real is None:
-            self._init_targets(pred_fake_b.shape)
+            self.target_real = torch.autograd.Variable(
+                torch.Tensor(pred_fake_b.shape).fill_(1.0).to(DEVICE),
+                requires_grad=False,
+            )
+        if self.target_fake is None:
+            self.target_fake = torch.autograd.Variable(
+                torch.Tensor(pred_fake_b.shape).fill_(0.0).to(DEVICE),
+                requires_grad=False,
+            )
+        n_samples = pred_fake_b.shape[0]
+        # last batch may have fewer samples, so we slice the target output 1/0's
+        target_real = self.target_real[:n_samples]
+        target_fake = self.target_fake[:n_samples]
         loss_gan_a_to_b = (
-            self.gan_loss(pred_fake_b, self.target_real) * self.generator_weight
+            self.gan_loss(pred_fake_b, target_real) * self.generator_weight
         )
 
         pred_fake_a = self._call_discriminator_a((time_b, fake_a))
         loss_gan_b_to_a = (
-            self.gan_loss(pred_fake_a, self.target_real) * self.generator_weight
+            self.gan_loss(pred_fake_a, target_real) * self.generator_weight
         )
         loss_gan = loss_gan_a_to_b + loss_gan_b_to_a
 
@@ -578,7 +621,7 @@ class CycleGANTrainer:
         # Real loss
         pred_real = self._call_discriminator_a((time_a, real_a))
         loss_d_a_real = (
-            self.gan_loss(pred_real, self.target_real) * self.discriminator_weight
+            self.gan_loss(pred_real, target_real) * self.discriminator_weight
         )
 
         # Fake loss
@@ -586,15 +629,15 @@ class CycleGANTrainer:
             time_b, fake_a = self.fake_a_buffer.query(
                 (time_b.detach(), fake_a.detach())
             )
-        pred_a_fake = self.discriminator_a((time_b, fake_a))
+        pred_a_fake = self._call_discriminator_a((time_b, fake_a))
         loss_d_a_fake = (
-            self.gan_loss(pred_a_fake, self.target_fake) * self.discriminator_weight
+            self.gan_loss(pred_a_fake, target_fake) * self.discriminator_weight
         )
 
         # Real loss
         pred_real = self._call_discriminator_b((time_b, real_b))
         loss_d_b_real = (
-            self.gan_loss(pred_real, self.target_real) * self.discriminator_weight
+            self.gan_loss(pred_real, target_real) * self.discriminator_weight
         )
 
         # Fake loss
@@ -604,7 +647,7 @@ class CycleGANTrainer:
             )
         pred_b_fake = self._call_discriminator_b((time_a, fake_b))
         loss_d_b_fake = (
-            self.gan_loss(pred_b_fake, self.target_fake) * self.discriminator_weight
+            self.gan_loss(pred_b_fake, target_fake) * self.discriminator_weight
         )
 
         # Total loss

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/cyclegan_trainer.py
@@ -450,7 +450,6 @@ class CycleGANTrainer:
         # This flag can be manually used to disable compilation, for clearer
         # error messages and debugging. It should always be set to True in PRs.
         self._compile = True  # if this is False in a PR, say something!
-        self._compiled_shape = None
 
     def _call_generator_a_to_b(
         self, input: Tuple[torch.Tensor, torch.Tensor]

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/generator.py
@@ -205,7 +205,6 @@ class Generator(nn.Module):
         Returns:
             tensor of shape [batch, tile, channels, x, y]
         """
-        # time, state = inputs
         x = self._input_bias(state)
         x = self._geographic_features((time, x))
         x = self._main(x)

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/modules.py
@@ -94,12 +94,8 @@ class GeographicFeatures(nn.Module):
                 self.local_time_zero_radians[None, :]
                 + local_time_offset_radians[:, None, None, None, None]
             )
-            if hasattr(self, "cos_lat"):
-                time_x = torch.sin(local_time) * self.cos_lat[None, :]
-                time_y = torch.cos(local_time) * self.cos_lat[None, :]
-            else:
-                time_x = torch.sin(local_time)
-                time_y = torch.cos(local_time)
+            time_x = torch.sin(local_time)
+            time_y = torch.cos(local_time)
             xyz = torch.stack([self.xyz for _ in range(x.shape[0])])
             geo_features = torch.cat([time_x, time_y, xyz], dim=2)
         except ValueError:

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/reloadable.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/reloadable.py
@@ -175,7 +175,7 @@ class CycleGAN(Reloadable):
         with torch.no_grad():
             for i in range(0, tensor.shape[0], n_batch):
                 new: torch.Tensor = generator(
-                    (time[i : i + n_batch], tensor[i : i + n_batch])
+                    time[i : i + n_batch], tensor[i : i + n_batch]
                 )
                 outputs[i : i + new.shape[0]] = new
         predicted = self.unpack_tensor(outputs, domain=output_domain)

--- a/external/fv3fit/fv3fit/pytorch/cyclegan/test_modules.py
+++ b/external/fv3fit/fv3fit/pytorch/cyclegan/test_modules.py
@@ -1,0 +1,79 @@
+from fv3fit.pytorch.cyclegan.modules import GeographicFeatures
+import torch
+import numpy as np
+import fv3fit
+import pytest
+
+
+@pytest.mark.parametrize("n_batch", [1, 3], ids=["n_batch=1", "n_batch=3"])
+def test_geographic_features_have_correct_range(n_batch: int):
+    fv3fit.set_random_seed(0)
+    nx = 48
+    ny = 48
+    n_channel = 2
+    module = GeographicFeatures(nx=nx, ny=ny)
+    SECONDS_PER_DAY = 24 * 60 * 60
+    time = torch.rand(n_batch) * SECONDS_PER_DAY
+    x = torch.rand(n_batch, 6, n_channel, nx, ny)
+    y = module((time, x))
+    assert y.shape[2] == n_channel + GeographicFeatures.N_FEATURES
+    geo_features = y[:, :, n_channel:, :, :]
+    # time_x, time_y, and geo x, y, z all have mean 0 and range [-1, 1]
+    # as they correspond to evenly spaced grid points on a sphere
+    for i in range(GeographicFeatures.N_FEATURES):
+        assert np.abs(np.mean(geo_features[:, :, i, :, :].cpu().numpy())) < 1e-3, i
+        assert np.abs(geo_features[:, :, i, :, :].cpu().numpy().max() - 1) < 1e-3, i
+        assert np.abs(geo_features[:, :, i, :, :].cpu().numpy().min() + 1) < 1e-3, i
+
+
+#    # The following code can be uncommented to visualize the geographic features
+#    # as cross plots. Useful during development.
+
+#     plot_cross(
+#         [
+#             geo_features[0, :, i, :, :].cpu().numpy()
+#             for i in range(geo_features.shape[2])
+#         ],
+#         "0.0",
+#     )
+#     SECONDS_PER_DAY = 24 * 60 * 60
+#     time[:] = 0.25 * SECONDS_PER_DAY
+#     x = torch.rand(n_batch, 6, n_channel, nx, ny)
+#     y = module((time, x))
+#     geo_features = y[:, :, n_channel:, :, :]
+#     plot_cross(
+#         [
+#             geo_features[0, :, i, :, :].cpu().numpy()
+#             for i in range(geo_features.shape[2])
+#         ],
+#         "0.5",
+#     )
+
+
+# def plot_cross(
+#     data_list, label: str,
+# ):
+#     import xarray as xr
+#     import matplotlib.pyplot as plt
+#     from vcm.cubedsphere import to_cross
+
+#     """
+#     Plot global states as cross-plots.
+
+#     Args:
+#         real_a: Real state from domain A, shape [tile, x, y]
+#         real_b: Real state from domain B, shape [tile, x, y]
+#         fake_a: Fake state from domain A, shape [tile, x, y]
+#         fake_b: Fake state from domain B, shape [tile, x, y]
+
+#     Returns:
+#         io.BytesIO: BytesIO object containing the plot
+#     """
+
+#     fig, ax = plt.subplots(len(data_list), 1, figsize=(7, 3.5 * len(data_list)))
+#     for i, data in enumerate(data_list):
+#         to_cross(
+#             xr.DataArray(data, dims=["tile", "grid_xt", "grid_yt"])
+#         ).plot(ax=ax[i])
+#     plt.tight_layout()
+#     plt.savefig(f"test_geographic_features_have_correct_range_{label}.png")


### PR DESCRIPTION
This PR adds the use_geographic_features option (default True) to the Generator and Discriminator used by CycleGAN.

Refactored public API:
- Added the use_geographic_features option (default True) to the Generator and Discriminator used by CycleGAN.

Significant internal changes:
- The CycleGAN trainer now has a private variable which can be toggled to disable compilation, for more helpful error messages.

- [x] Tests added

Coverage reports (updated automatically):
