### PR TITLE
Minor updates associated with CycleGAN work

### DIFF
--- a/external/fv3fit/fv3fit/pytorch/recurrent/discriminator.py
+++ b/external/fv3fit/fv3fit/pytorch/recurrent/discriminator.py
@@ -24,6 +24,8 @@ class DiscriminatorConfig:
         n_convolutions: number of strided convolutional layers before the
             final convolutional output layer, must be at least 1
         kernel_size: size of convolutional kernels
+        strided_kernel_size: size of convolutional kernels in the
+            strided convolutions
         max_filters: maximum number of filters in any convolutional layer,
             equal to the number of filters in the final strided convolutional layer
     """

--- a/external/fv3fit/tests/data_/test_windowed_zarr.py
+++ b/external/fv3fit/tests/data_/test_windowed_zarr.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import contextlib
 import cftime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 NX, NY, NZ, NT = 5, 5, 8, 40
 
@@ -165,6 +165,20 @@ def test_loader_handles_time_range():
 )
 def test_get_n_windows(n_times, window_size, n_windows):
     assert get_n_windows(n_times, window_size) == n_windows
+
+
+def test_variable_config_stacks_requested_order():
+    config = VariableConfig(times="start")
+    ds = xr.Dataset(
+        data_vars={
+            "a": (("time", "r", "q", "t", "s"), np.zeros((1, 2, 3, 4, 5))),
+            "time": (("time",), [datetime.now()]),
+        }
+    )
+    result = config.get_record("a", ds=ds, unstacked_dims=["r", "q", "t", "s"])
+    assert result.shape == (1, 2, 3, 4, 5)
+    result = config.get_record("a", ds=ds, unstacked_dims=["s", "t", "q", "r"])
+    assert result.shape == (1, 5, 4, 3, 2)
 
 
 def test_loader_decodes_time_from_cftime():


### PR DESCRIPTION
This PR contains two minor updates from the CycleGAN working branch.

Refactored public API:
- Added details for strided_kernel_size argument to DiscriminatorConfig docstring in recurrent training.

Significant internal changes:
- Added unit test of VariableConfig stacking order.

- [x] Tests added

Coverage reports (updated automatically):
