### PR TITLE
Add build_model function for minimal autoencoder

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/autoencoder.py
@@ -214,8 +214,8 @@ def build_concat_and_scale_only_autoencoder(
     decoder = tf.keras.Model(inputs=decoder_input, outputs=denorm_output_layers)
 
     model = Autoencoder(encoder=encoder, decoder=decoder)
-    # need to call model once so it can save without compiling
-    model([np.ones((3, arr.shape[-1])) for arr in X])
+    # Need to call custom model once so it has forward pass information before saving
+    model(X)
     return model
 
 

--- a/external/fv3fit/tests/reservoir/test_autoencoder.py
+++ b/external/fv3fit/tests/reservoir/test_autoencoder.py
@@ -1,0 +1,22 @@
+import numpy as np
+from fv3fit.reservoir.autoencoder import build_concat_and_scale_only_autoencoder
+
+a = np.array([[10, 10], [0.0, 0.0]])  # size=2, mean=5, std=5
+b = np.array([[2.0, 2.0], [0.0, 0.0]])  # size=2, mean=1, std=1
+
+test_inputs = [
+    np.array([10, 10]).reshape(1, -1),
+    np.array([3, 3]).reshape(1, -1),
+]
+
+
+def test_build_concat_and_scale_only_autoencoder_normalize():
+    model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
+    np.testing.assert_array_almost_equal(
+        model.encode(test_inputs).reshape(-1), np.array([1, 1, 2, 2])
+    )
+
+
+def test_build_concat_and_scale_only_autoencoder_predict():
+    model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
+    np.testing.assert_array_almost_equal(model.predict(test_inputs), test_inputs)

--- a/external/fv3fit/tests/reservoir/test_autoencoder.py
+++ b/external/fv3fit/tests/reservoir/test_autoencoder.py
@@ -1,5 +1,8 @@
 import numpy as np
-from fv3fit.reservoir.autoencoder import build_concat_and_scale_only_autoencoder
+from fv3fit.reservoir.autoencoder import (
+    Autoencoder,
+    build_concat_and_scale_only_autoencoder,
+)
 
 a = np.array([[10, 10], [0.0, 0.0]])  # size=2, mean=5, std=5
 b = np.array([[2.0, 2.0], [0.0, 0.0]])  # size=2, mean=1, std=1
@@ -20,3 +23,13 @@ def test_build_concat_and_scale_only_autoencoder_normalize():
 def test_build_concat_and_scale_only_autoencoder_predict():
     model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
     np.testing.assert_array_almost_equal(model.predict(test_inputs), test_inputs)
+
+
+def test_concat_and_scale_only_autoencoder_dump_load(tmpdir):
+    output_path = f"{str(tmpdir)}/model"
+    model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
+    encoded = model.encode(test_inputs)
+    model.dump(output_path)
+    loaded_model = Autoencoder.load(output_path)
+    loaded_encoded = loaded_model.encode(test_inputs)
+    np.testing.assert_array_equal(encoded, loaded_encoded)


### PR DESCRIPTION
The reservoir training now relies on the autoencoder to do the feature concatentation and normalization/denormalization, which makes the autoencoder a nonoptional component in the reservoir training. This PR adds a function to the autoencoder module to build a minimal autoencoder that has no trainable parameters and only handles the necessary concatenation and normalization. It can be used in the case of no autoencoder path being specified, ex. in tests.
  

- [x] Tests added
 

Coverage reports (updated automatically):
