### PR TITLE
Fix ordering of sorted netcdfs in loader

### DIFF
--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -52,6 +52,17 @@ def nc_files_to_tf_dataset(
     )
 
 
+def _convert_int(s):
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+def _numerical_sort_names(names):
+    names.sort(key=lambda fname: [_convert_int(c) for c in re.split("([0-9]+)", fname)])
+
+
 def nc_dir_to_tfdataset(
     nc_dir: str,
     convert: Callable[[xr.Dataset], Mapping[str, tf.Tensor]],
@@ -96,7 +107,7 @@ def nc_dir_to_tfdataset(
         )
 
     if sort_files:
-        files.sort()
+        _numerical_sort_names(files)
 
     if nfiles is not None:
         files = files[:nfiles]

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -52,15 +52,13 @@ def nc_files_to_tf_dataset(
     )
 
 
-def _convert_int(s):
-    try:
-        return int(s)
-    except ValueError:
-        return s
-
-
-def _numerical_sort_names(names):
-    names.sort(key=lambda fname: [_convert_int(c) for c in re.split("([0-9]+)", fname)])
+def _natural_sort(names):
+    return sorted(
+        names,
+        key=lambda string: [
+            int(s) if s.isdigit() else s for s in re.split("([0-9]+)", string)
+        ],
+    )
 
 
 def nc_dir_to_tfdataset(
@@ -92,10 +90,8 @@ def nc_dir_to_tfdataset(
     cache = cache or CACHE_DIR
 
     files = get_nc_files(nc_dir)
-
     if match is not None:
         files = [f for f in files if re.search(match, Path(f).name)]
-
     if shuffle:
         if random_state is None:
             random_state = np.random.RandomState(
@@ -105,9 +101,8 @@ def nc_dir_to_tfdataset(
         files = random_state.choice(
             files, size=len(files), replace=False  # type: ignore
         )
-
     if sort_files:
-        _numerical_sort_names(files)
+        files = _natural_sort(files)
 
     if nfiles is not None:
         files = files[:nfiles]

--- a/external/fv3fit/tests/data_/test_netcdf.py
+++ b/external/fv3fit/tests/data_/test_netcdf.py
@@ -8,6 +8,7 @@ import pytest
 import tempfile
 import xarray as xr
 import tensorflow as tf
+from fv3fit.data.netcdf.load import _numerical_sort_names
 
 
 def test_NCDirLoader(tmp_path: Path):
@@ -125,3 +126,22 @@ def test_error_missing_data_dim_in_specified_order():
             loader.open_tfdataset(
                 local_download_path=None, variable_names=["a_sfc", "b"]
             )
+
+
+@pytest.mark.parametrize(
+    "names, sorted_names",
+    [
+        (["c.nc", "a.nc", "b.nc"], ["a.nc", "b.nc", "c.nc"]),
+        (
+            ["3.nc", "0.nc", "1.nc", "10.nc", "2.nc"],
+            ["0.nc", "1.nc", "2.nc", "3.nc", "10.nc"],
+        ),
+        (
+            ["t_0.nc", "t_1.nc", "t_10.nc", "t_2.nc"],
+            ["t_0.nc", "t_1.nc", "t_2.nc", "t_10.nc"],
+        ),
+    ],
+)
+def test_sort_netcdfs(names, sorted_names):
+    _numerical_sort_names(names)
+    assert names == sorted_names

--- a/external/fv3fit/tests/data_/test_netcdf.py
+++ b/external/fv3fit/tests/data_/test_netcdf.py
@@ -8,7 +8,7 @@ import pytest
 import tempfile
 import xarray as xr
 import tensorflow as tf
-from fv3fit.data.netcdf.load import _numerical_sort_names
+from fv3fit.data.netcdf.load import _natural_sort
 
 
 def test_NCDirLoader(tmp_path: Path):
@@ -144,5 +144,5 @@ def test_error_missing_data_dim_in_specified_order():
     ],
 )
 def test_sort_netcdfs(names, sorted_names):
-    _numerical_sort_names(names)
+    names = _natural_sort(names)
     assert names == sorted_names

--- a/external/fv3fit/tests/data_/test_netcdf.py
+++ b/external/fv3fit/tests/data_/test_netcdf.py
@@ -140,6 +140,7 @@ def test_error_missing_data_dim_in_specified_order():
             ["t_0.nc", "t_1.nc", "t_10.nc", "t_2.nc"],
             ["t_0.nc", "t_1.nc", "t_2.nc", "t_10.nc"],
         ),
+        (["b_0_c_1", "b_0_c_0", "a_1_b_1"], ["a_1_b_1", "b_0_c_0", "b_0_c_1"]),
     ],
 )
 def test_sort_netcdfs(names, sorted_names):


### PR DESCRIPTION
Fixes issue with loaded netcdfs being out of numerical order when using generic string sort, e.g. 0.nc, 1.nc, 10.nc, 2.nc

 
- [x] Tests added
 

Coverage reports (updated automatically):
