### PR TITLE
The "to_url" function returning the proper result for absolute local paths.

### DIFF
--- a/external/vcm/tests/test_cloud_fsspec.py
+++ b/external/vcm/tests/test_cloud_fsspec.py
@@ -35,6 +35,7 @@ def test_copy(tmpdir, content_type):
     [
         ("gs", "some-path", "gs://some-path"),
         ("file", "some-path", "file://some-path"),
+        ("file", "/absolute/file/path", "file:///absolute/file/path"),
         ("http", "some-path", "http://some-path"),
     ],
 )

--- a/external/vcm/vcm/cloud/fsspec.py
+++ b/external/vcm/vcm/cloud/fsspec.py
@@ -45,7 +45,7 @@ def to_url(fs: fsspec.AbstractFileSystem, path: str):
     else:
         protocol = fs.protocol[0]
 
-    return protocol + "://" + path.lstrip("/")
+    return protocol + "://" + path
 
 
 def copy(source: str, destination: str, content_type: str = None):

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import subprocess
 from runtime.segmented_run.append import read_last_segment
+from vcm.cloud import get_fs
 import uuid
 
 
@@ -11,7 +12,9 @@ def test_read_last_segment(tmpdir):
     arts.mkdir(date1)
     arts.mkdir(date2)
     ans = read_last_segment(str(tmpdir))
-    assert f"file:/{str(tmpdir)}/artifacts/20160102.000000" == ans
+    assert f"file://{str(tmpdir)}/artifacts/20160102.000000" == ans
+    fs = get_fs(ans)
+    assert fs.exists(ans)
 
 
 def test_read_last_segment_gcs(tmp_path: Path):


### PR DESCRIPTION
This pull request introduces a slight modification to the return value of `to_url` function. This change is motivated by the fact that the existing configuration of the function cannot properly deal with the HPC cluster directory structure. Performing the fv3net-style segmented simulations on HPC cluster (Stellar) requires locating of the restart files within the output directory. The output directory is local absolute path rather then the path on the cloud. 

Refactored public API:
- `return protocol + "://" + path`: this return value of the `to_url` function replaces the existing `return protocol + "://" + path.lstrip("/")`

- [x] Tests added
The test was added to the `test_fsspec_cloud.py` file.
The predicate (`assert` statement) was modified in the `test_read_last_segment` function (`test_append.py`).
A new predicate (`assert` statement) was added to the `test_read_last_segment` function (`test_append.py`). It checks the existence of the supplied path.

Resolves #2202 