### PR TITLE
Fix array reshaping bug in prediction

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/_reshaping.py
+++ b/external/fv3fit/fv3fit/reservoir/_reshaping.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+
+def flatten_2d_keeping_columns_contiguous(arr: np.ndarray):
+    # ex. [[1,2],[3,4], [5,6]] -> [1,3,5,2,4,6]
+    return np.reshape(arr, -1, "F")

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -1,15 +1,16 @@
 import fsspec
-from fv3fit.reservoir.readout import ReservoirComputingReadout
 import os
 from typing import Optional, Iterable, Hashable
 import yaml
 
 from fv3fit import Predictor
+from .readout import ReservoirComputingReadout
 from .reservoir import Reservoir
 from .domain import RankDivider
 from fv3fit._shared import io
 from .utils import square_even_terms
 from .autoencoder import Autoencoder
+from ._reshaping import flatten_2d_keeping_columns_contiguous
 
 
 @io.register("pure-reservoir")
@@ -60,10 +61,8 @@ class ReservoirComputingModel(Predictor):
             readout_input = self.reservoir.state
         # For prediction over multiple subdomains (>1 column in reservoir state
         # array), flatten state into 1D vector before predicting
-        readout_input = readout_input.reshape(-1)
-
+        readout_input = flatten_2d_keeping_columns_contiguous(readout_input)
         prediction = self.readout.predict(readout_input).reshape(-1)
-
         return prediction
 
     def reset_state(self):

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -136,6 +136,7 @@ def train_reservoir_model(
         readout=readout,
         square_half_hidden_state=hyperparameters.square_half_hidden_state,
         rank_divider=rank_divider,
+        autoencoder=autoencoder,
     )
     return model
 

--- a/external/fv3fit/tests/reservoir/test__reshaping.py
+++ b/external/fv3fit/tests/reservoir/test__reshaping.py
@@ -1,0 +1,9 @@
+import numpy as np
+from fv3fit.reservoir._reshaping import flatten_2d_keeping_columns_contiguous
+
+
+def test_flatten_2d_keeping_columns_contiguous():
+    x = np.array([[1, 2], [3, 4], [5, 6]])
+    np.testing.assert_array_equal(
+        flatten_2d_keeping_columns_contiguous(x), np.array([1, 3, 5, 2, 4, 6])
+    )


### PR DESCRIPTION
The reservoir models were working as expected when trained on a single subdomain, but predictions were way off for the same subdomain when trained on a larger domain (split into parallel trained subdomains). Models should give the same result for the same subdomain in these two cases.

I traced the source of the error to the final readout prediction step, where `np.reshape` was used improperly. For array reshaping here and in future inference code I think it would be safest to write testable functions so that a short example of the desired reshaping can unit tested. In this short PR I just added a reshaping function that calls a one-liner of np.reshape for a 2d -> 1d case, but in future PRs the reshaping is much more complex.
 
- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
