### PR TITLE
Parallel jobs on HPC cluster: `srun` versus `mpirun` submission commands

### DIFF
--- a/workflows/prognostic_c48_run/docs/local-execution.rst
+++ b/workflows/prognostic_c48_run/docs/local-execution.rst
@@ -77,6 +77,27 @@ the end of the previous one will be appended. For example, the following for loo
 
         runfv3 append gs://path/to/failing/run
 
+.. note::
+
+    An option "mpi_launcher" has been added to the subcommand "append". This option 
+    allows users to configure the segmented runs on High Perfromance Computing
+    systems and cloud platfroms. The supported values are "mpirun" and "srun".
+   
+    An example of runnning model with 5 segments on the cloud platform:
+
+    for i in {1..5}
+    do
+       runfv3 append --wrapper mpirun gs://bucket/prognostic_run
+    done
+
+    An example of running model with 5 segments on HPC cluster:
+
+    for i in {1..5}
+    do
+       runfv3 append --wrapper srun /absolute/file/path
+    done
+
+    
 .. warning::
 
     For segmented runs, there is a requirement that the chunk size along the
@@ -97,6 +118,14 @@ This writes the run directory described by the ``fv3config.yaml`` to the
 specified local path and executes the model there. The command is used for
 example by the tests.
 
+.. note::
+ 
+   For the purposes of perfroming simulaitons on both cloud and HPC platfroms,
+   the subcommand run-native was supplemented with mpi_launcher option. Please see
+   the example below on how to use it on HPC cluster
+
+   runfv3 run-native fv3config.yaml path/to/local/rundir --mpi_launcher srun
+    
 .. warning::
 
     ``runfv3 run-native`` produces outputs that aren't post-processed for

--- a/workflows/prognostic_c48_run/docs/local-execution.rst
+++ b/workflows/prognostic_c48_run/docs/local-execution.rst
@@ -79,10 +79,10 @@ the end of the previous one will be appended. For example, the following for loo
 
 .. note::
 
-    An option "mpi_launcher" has been added to the subcommand "append". This option 
+    An option "mpi_launcher" has been added to the subcommand "append". This option
     allows users to configure the segmented runs on High Perfromance Computing
     systems and cloud platfroms. The supported values are "mpirun" and "srun".
-   
+
     An example of runnning model with 5 segments on the cloud platform:
 
     for i in {1..5}
@@ -97,7 +97,7 @@ the end of the previous one will be appended. For example, the following for loo
        runfv3 append --wrapper srun /absolute/file/path
     done
 
-    
+
 .. warning::
 
     For segmented runs, there is a requirement that the chunk size along the
@@ -119,13 +119,13 @@ specified local path and executes the model there. The command is used for
 example by the tests.
 
 .. note::
- 
+
    For the purposes of perfroming simulaitons on both cloud and HPC platfroms,
    the subcommand run-native was supplemented with mpi_launcher option. Please see
    the example below on how to use it on HPC cluster
 
    runfv3 run-native fv3config.yaml path/to/local/rundir --mpi_launcher srun
-    
+
 .. warning::
 
     ``runfv3 run-native`` produces outputs that aren't post-processed for

--- a/workflows/prognostic_c48_run/docs/local-execution.rst
+++ b/workflows/prognostic_c48_run/docs/local-execution.rst
@@ -83,8 +83,8 @@ the end of the previous one will be appended. For example, the following for loo
     option allows users to specify the system-specific MPI launcher used when running
     the model. By default it takes the value "mpirun", which is relevant for running
     in Docker. The only other currently supported value is "srun", which is relevant
-    when running on SLURM-based High Performance Computing (HPC) systems. 
-   
+    when running on SLURM-based High Performance Computing (HPC) systems.
+
     An example of running model with 5 segments on an HPC cluster::
 
         for i in {1..5}
@@ -114,13 +114,13 @@ specified local path and executes the model there. The command is used for
 example by the tests.
 
 .. note::
- 
+
    For the purposes of performing simulations on both Docker and HPC platforms,
    the subcommand ``run-native`` was supplemented with the ``mpi_launcher``
    option. Please see the example below on how to use it on an HPC cluster::
 
        runfv3 run-native fv3config.yaml path/to/local/rundir --mpi_launcher srun
-    
+
 .. warning::
 
     ``runfv3 run-native`` produces outputs that aren't post-processed for

--- a/workflows/prognostic_c48_run/runtime/segmented_run/append.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/append.py
@@ -35,7 +35,7 @@ def read_run_config(run_url):
     return fv3config.load(io.BytesIO(s))
 
 
-def append_segment_to_run_url(run_url):
+def append_segment_to_run_url(run_url, wrapper):
     """Append an segment to an initialized segmented run
 
     Either runs the first segment, or additional ones
@@ -63,7 +63,7 @@ def append_segment_to_run_url(run_url):
         rundir = os.path.join(dir_, "rundir")
         post_processed_out = os.path.join(dir_, "post_processed")
 
-        exit_code = run_segment(config, rundir)
+        exit_code = run_segment(config, rundir, wrapper)
         if exit_code != 0:
             warnings.warn(
                 UserWarning(f"FV3 exited with a nonzero exit-code: {exit_code}")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/append.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/append.py
@@ -35,7 +35,7 @@ def read_run_config(run_url):
     return fv3config.load(io.BytesIO(s))
 
 
-def append_segment_to_run_url(run_url, wrapper="mpirun"):
+def append_segment_to_run_url(run_url, mpi_launcher="mpirun"):
     """Append an segment to an initialized segmented run
 
     Either runs the first segment, or additional ones
@@ -63,7 +63,7 @@ def append_segment_to_run_url(run_url, wrapper="mpirun"):
         rundir = os.path.join(dir_, "rundir")
         post_processed_out = os.path.join(dir_, "post_processed")
 
-        exit_code = run_segment(config, rundir, wrapper)
+        exit_code = run_segment(config, rundir, mpi_launcher)
         if exit_code != 0:
             warnings.warn(
                 UserWarning(f"FV3 exited with a nonzero exit-code: {exit_code}")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/append.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/append.py
@@ -35,7 +35,7 @@ def read_run_config(run_url):
     return fv3config.load(io.BytesIO(s))
 
 
-def append_segment_to_run_url(run_url, wrapper):
+def append_segment_to_run_url(run_url, wrapper="mpirun"):
     """Append an segment to an initialized segmented run
 
     Either runs the first segment, or additional ones

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -67,8 +67,8 @@ def append(mpi_launcher: str, url: str):
 @click.option(
     "--mpi_launcher",
     default="mpirun",
-    help="MPI launcher used to run the simulation.\
-          Supported values are 'mpirun' and 'srun'.",
+    help="MPI launcher used to run the simulation. "
+         "Supported values are 'mpirun' and 'srun'.",
 )
 @click.argument("fv3config_path")
 @click.argument("rundir")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -53,20 +53,20 @@ def create(url: str, fv3config_path: str):
 @cli.command()
 @click.option("--mpi_launcher", default="mpirun", help="MPI launcher used to run the simulation.  Supported values are 'mpirun' and 'srun'.")
 @click.argument("url")
-def append(wrapper: str, url: str):
+def append(mpi_launcher: str, url: str):
     """Append a segment to a segmented run"""
-    sys.exit(api.append(url, wrapper))
+    sys.exit(api.append(url, mpi_launcher))
 
 
 @cli.command("run-native")
-@click.option("--wrapper", default="mpirun", help="MPI wrapper")
+@click.option("--mpi_launcher", default="mpirun", help="MPI launcher used to run the simulation.  Supported values are 'mpirun' and 'srun'.")
 @click.argument("fv3config_path")
 @click.argument("rundir")
-def run_native(fv3config_path: str, rundir: str, wrapper: str):
+def run_native(fv3config_path: str, rundir: str, mpi_launcher: str):
     """Setup a run-directory and run the model. Used for testing/debugging."""
     with open(fv3config_path) as f:
         config = fv3config.load(f)
-    sys.exit(run_segment(config, rundir, wrapper))
+    sys.exit(run_segment(config, rundir, mpi_launcher))
 
 
 @cli.command("parse-logs")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -51,7 +51,7 @@ def create(url: str, fv3config_path: str):
 
 
 @cli.command()
-@click.option("--wrapper", default="mpirun", help="MPI wrapper")
+@click.option("--mpi_launcher", default="mpirun", help="MPI launcher used to run the simulation.  Supported values are 'mpirun' and 'srun'.")
 @click.argument("url")
 def append(wrapper: str, url: str):
     """Append a segment to a segmented run"""

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -51,20 +51,22 @@ def create(url: str, fv3config_path: str):
 
 
 @cli.command()
+@click.option("--wrapper", default="mpirun", help="MPI wrapper")
 @click.argument("url")
-def append(url: str):
+def append(wrapper: str, url: str):
     """Append a segment to a segmented run"""
-    sys.exit(api.append(url))
+    sys.exit(api.append(url, wrapper))
 
 
 @cli.command("run-native")
+@click.option("--wrapper", default="mpirun", help="MPI wrapper")
 @click.argument("fv3config_path")
 @click.argument("rundir")
-def run_native(fv3config_path: str, rundir: str):
+def run_native(fv3config_path: str, rundir: str, wrapper: str):
     """Setup a run-directory and run the model. Used for testing/debugging."""
     with open(fv3config_path) as f:
         config = fv3config.load(f)
-    sys.exit(run_segment(config, rundir))
+    sys.exit(run_segment(config, rundir, wrapper))
 
 
 @cli.command("parse-logs")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -55,7 +55,7 @@ def create(url: str, fv3config_path: str):
     "--mpi_launcher",
     default="mpirun",
     help="MPI launcher used to run the simulation. "
-         "Supported values are 'mpirun' and 'srun'.",
+    "Supported values are 'mpirun' and 'srun'.",
 )
 @click.argument("url")
 def append(mpi_launcher: str, url: str):
@@ -68,7 +68,7 @@ def append(mpi_launcher: str, url: str):
     "--mpi_launcher",
     default="mpirun",
     help="MPI launcher used to run the simulation. "
-         "Supported values are 'mpirun' and 'srun'.",
+    "Supported values are 'mpirun' and 'srun'.",
 )
 @click.argument("fv3config_path")
 @click.argument("rundir")

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -51,7 +51,12 @@ def create(url: str, fv3config_path: str):
 
 
 @cli.command()
-@click.option("--mpi_launcher", default="mpirun", help="MPI launcher used to run the simulation.  Supported values are 'mpirun' and 'srun'.")
+@click.option(
+    "--mpi_launcher",
+    default="mpirun",
+    help="MPI launcher used to run the simulation.\
+          Supported values are 'mpirun' and 'srun'.",
+)
 @click.argument("url")
 def append(mpi_launcher: str, url: str):
     """Append a segment to a segmented run"""
@@ -59,7 +64,12 @@ def append(mpi_launcher: str, url: str):
 
 
 @cli.command("run-native")
-@click.option("--mpi_launcher", default="mpirun", help="MPI launcher used to run the simulation.  Supported values are 'mpirun' and 'srun'.")
+@click.option(
+    "--mpi_launcher",
+    default="mpirun",
+    help="MPI launcher used to run the simulation.\
+          Supported values are 'mpirun' and 'srun'.",
+)
 @click.argument("fv3config_path")
 @click.argument("rundir")
 def run_native(fv3config_path: str, rundir: str, mpi_launcher: str):

--- a/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/cli.py
@@ -54,8 +54,8 @@ def create(url: str, fv3config_path: str):
 @click.option(
     "--mpi_launcher",
     default="mpirun",
-    help="MPI launcher used to run the simulation.\
-          Supported values are 'mpirun' and 'srun'.",
+    help="MPI launcher used to run the simulation. "
+         "Supported values are 'mpirun' and 'srun'.",
 )
 @click.argument("url")
 def append(mpi_launcher: str, url: str):

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -22,10 +22,17 @@ def cwd(path):
 def find(path: str):
     return glob.glob(os.path.join(path, "**"), recursive=True)
 
-def compose_simulation_command(mpi_launcher: str, nprocs: int): 
 
-    command = ["-n " + str(nprocs), sys.executable, "-m", "mpi4py", runfile.absolute().as_posix()]
-    
+def compose_simulation_command(mpi_launcher: str, nprocs: int):
+
+    command = [
+        "-n " + str(nprocs),
+        sys.executable,
+        "-m",
+        "mpi4py",
+        runfile.absolute().as_posix(),
+    ]
+
     if mpi_launcher == "mpirun":
         command.insert(0, mpi_launcher)
 
@@ -33,7 +40,10 @@ def compose_simulation_command(mpi_launcher: str, nprocs: int):
         command.insert(0, mpi_launcher)
         command.insert(1, "--export=ALL")
     else:
-        raise Exception("Unrecognized MPI launcher option. Please choose between 'mpirun' or 'srun'.")
+        raise Exception(
+            "Unrecognized MPI launcher option.\
+            Please choose between 'mpirun' or 'srun'."
+        )
 
     return command
 
@@ -49,8 +59,8 @@ def run_segment(config: dict, rundir: str, mpi_launcher: str):
         x, y = config["namelist"]["fv_core_nml"]["layout"]
         nprocs = x * y * 6
 
-        command = compose_simulation_command(mpi_launcher, nprocs) 
-        
+        command = compose_simulation_command(mpi_launcher, nprocs)
+
         with open("logs.txt", "w") as f:
             process = subprocess.Popen(
                 command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -25,16 +25,23 @@ def find(path: str):
 
 def compose_simulation_command(mpi_launcher: str, nprocs: int):
 
-    command = ["-n", str(nprocs), sys.executable, "-m", "mpi4py", runfile.absolute().as_posix()]
-    
-    if mpi_launcher == "mpirun":
-        command.insert(0, mpi_launcher)
+    command = [
+        mpi_launcher,
+        "-n",
+        str(nprocs),
+        sys.executable,
+        "-m",
+        "mpi4py",
+        runfile.absolute().as_posix(),
+    ]
 
-    elif mpi_launcher == "srun":
-        command.insert(0, mpi_launcher)
+    if mpi_launcher == "srun":
         command.insert(1, "--export=ALL")
-    else:
-        raise ValueError("Unrecognized mpi_launcher option. Please choose between 'mpirun' or 'srun'.")
+
+    if not (mpi_launcher == "mpirun" or mpi_launcher == "srun"):
+        raise ValueError(
+            "Unrecognized mpi_launcher option. Please choose between 'mpirun' or 'srun'"
+        )
 
     return command
 

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -40,7 +40,8 @@ def compose_simulation_command(nprocs: int, mpi_launcher: str = "mpirun"):
 
     if not (mpi_launcher == "mpirun" or mpi_launcher == "srun"):
         raise ValueError(
-            "Unrecognized mpi_launcher option. Please choose between 'mpirun' or 'srun'"
+            f"Unrecognized mpi_launcher option, {mpi_launcher!r}. Please choose "
+            f"between 'mpirun' or 'srun'"
         )
 
     return command

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -23,7 +23,7 @@ def find(path: str):
     return glob.glob(os.path.join(path, "**"), recursive=True)
 
 
-def run_segment(config: dict, rundir: str):
+def run_segment(config: dict, rundir: str, wrapper: str):
     fv3config.write_run_directory(config, rundir)
     with cwd(rundir):
         manifest = find(".")
@@ -33,20 +33,31 @@ def run_segment(config: dict, rundir: str):
 
         x, y = config["namelist"]["fv_core_nml"]["layout"]
         nprocs = x * y * 6
+
+        if wrapper == "mpirun":
+            command = [
+                "mpirun",
+                "-n",
+                str(nprocs),
+                sys.executable,
+                "-m",
+                "mpi4py",
+                runfile.absolute().as_posix(),
+            ]
+        else:
+            command = [
+                "srun",
+                "--export=ALL",
+                "--ntasks=" + str(nprocs),
+                sys.executable,
+                "-m",
+                "mpi4py",
+                runfile.absolute().as_posix(),
+            ]
+
         with open("logs.txt", "w") as f:
             process = subprocess.Popen(
-                [
-                    "mpirun",
-                    "-n",
-                    str(nprocs),
-                    sys.executable,
-                    "-m",
-                    "mpi4py",
-                    runfile.absolute().as_posix(),
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
+                command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
             )
             # need this assertion so that mypy knows that stdout is not None
             assert process.stdout, "stdout should not be None"

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -23,7 +23,7 @@ def find(path: str):
     return glob.glob(os.path.join(path, "**"), recursive=True)
 
 
-def compose_simulation_command(nprocs: int, mpi_launcher = "mpirun"):
+def compose_simulation_command(nprocs: int, mpi_launcher: str = "mpirun"):
 
     command = [
         mpi_launcher,

--- a/workflows/prognostic_c48_run/runtime/segmented_run/run.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/run.py
@@ -23,7 +23,7 @@ def find(path: str):
     return glob.glob(os.path.join(path, "**"), recursive=True)
 
 
-def compose_simulation_command(mpi_launcher: str, nprocs: int):
+def compose_simulation_command(nprocs: int, mpi_launcher = "mpirun"):
 
     command = [
         mpi_launcher,
@@ -57,7 +57,7 @@ def run_segment(config: dict, rundir: str, mpi_launcher: str):
         x, y = config["namelist"]["fv_core_nml"]["layout"]
         nprocs = x * y * 6
 
-        command = compose_simulation_command(mpi_launcher, nprocs)
+        command = compose_simulation_command(nprocs, mpi_launcher)
 
         with open("logs.txt", "w") as f:
             process = subprocess.Popen(

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -39,8 +39,8 @@ def test_read_last_segment_gcs(tmp_path: Path):
 def test_compose_simulation_command(mpi_launcher):
 
     nprocs = "10"
-    runfile = "/home/mr7417/ML_workflow/model_environment/fv3net/workflows/prognostic_c48_run/runtime/main.py" 
-    sys_exe = "/home/mr7417/ML_workflow/model_environment/conda/envs/fv3net/bin/python3.8"
+    runfile_as_str = runfile.absolute().as_posix()
+    sys_exe = sys.executable
 
     if mpi_launcher == "mpirun":
         expected = [mpi_launcher, '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile]

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -49,7 +49,7 @@ def test_compose_simulation_command(mpi_launcher):
     elif mpi_launcher == "srun":
         expected = [mpi_launcher, '--export=ALL', '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile_as_str]
         assert expected == compose_simulation_command(nprocs, mpi_launcher)
-    elif mpi_launcher == None:
+    elif mpi_launcher is None:
         expected = ["mpirun", '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile_as_str]
         assert expected == compose_simulation_command(nprocs)
     else:

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -36,14 +36,19 @@ def test_read_last_segment_gcs(tmp_path: Path):
         subprocess.check_call(["gsutil", "cp", file.as_posix(), dest])
 
 @pytest.mark.parametrize("mpi_launcher", ["srun", "mpirun", None])
-def test_compose_simulation_command(regtest, mpi_launcher):
+def test_compose_simulation_command(mpi_launcher):
 
     nprocs = "10"
+    runfile = "/home/mr7417/ML_workflow/model_environment/fv3net/workflows/prognostic_c48_run/runtime/main.py" 
+    sys_exe = "/home/mr7417/ML_workflow/model_environment/conda/envs/fv3net/bin/python3.8"
 
-    if mpi_launcher == "mpirun" or mpi_launcher == "srun":
-        ans = compose_simulation_command(nprocs, mpi_launcher)
+    if mpi_launcher == "mpirun":
+        expected = [mpi_launcher, '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile]
+        assert expected == compose_simulation_command(nprocs, mpi_launcher)
+    elif mpi_launcher == "srun":
+        expected = [mpi_launcher, '--export=ALL', '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile]
+        assert expected == compose_simulation_command(nprocs, mpi_launcher)
     else:
-        ans = compose_simulation_command(nprocs)
-
-    print(ans, file=regtest)
+        expected = ["mpirun", '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile]
+        assert expected == compose_simulation_command(nprocs)
 

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import subprocess
 from runtime.segmented_run.append import read_last_segment
-from runtime.segmented_run.run import compose_simulation_command
+from runtime.segmented_run.run import compose_simulation_command, runfile
 from vcm.cloud import get_fs
 import uuid
 import pytest

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -7,6 +7,7 @@ from vcm.cloud import get_fs
 import uuid
 import pytest
 
+
 def test_read_last_segment(tmpdir):
     date1 = "20160101.000000"
     date2 = "20160102.000000"
@@ -36,6 +37,7 @@ def test_read_last_segment_gcs(tmp_path: Path):
         file.write_text("hello")
         subprocess.check_call(["gsutil", "cp", file.as_posix(), dest])
 
+
 @pytest.mark.parametrize("mpi_launcher", ["srun", "mpirun", None, "doesnotexistrun"])
 def test_compose_simulation_command(mpi_launcher):
 
@@ -44,15 +46,39 @@ def test_compose_simulation_command(mpi_launcher):
     sys_exe = sys.executable
 
     if mpi_launcher == "mpirun":
-        expected = [mpi_launcher, '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile_as_str]
+        expected = [
+            mpi_launcher,
+            "-n",
+            str(nprocs),
+            sys_exe,
+            "-m",
+            "mpi4py",
+            runfile_as_str,
+        ]
         assert expected == compose_simulation_command(nprocs, mpi_launcher)
     elif mpi_launcher == "srun":
-        expected = [mpi_launcher, '--export=ALL', '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile_as_str]
+        expected = [
+            mpi_launcher,
+            "--export=ALL",
+            "-n",
+            str(nprocs),
+            sys_exe,
+            "-m",
+            "mpi4py",
+            runfile_as_str,
+        ]
         assert expected == compose_simulation_command(nprocs, mpi_launcher)
     elif mpi_launcher is None:
-        expected = ["mpirun", '-n', str(nprocs), sys_exe, "-m", "mpi4py", runfile_as_str]
+        expected = [
+            "mpirun",
+            "-n",
+            str(nprocs),
+            sys_exe,
+            "-m",
+            "mpi4py",
+            runfile_as_str,
+        ]
         assert expected == compose_simulation_command(nprocs)
     else:
         with pytest.raises(ValueError, match=r"Unrecognized mpi_launcher .*"):
             compose_simulation_command(nprocs, mpi_launcher)
-

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 import subprocess
 from runtime.segmented_run.append import read_last_segment
+from runtime.segmented_run.run import compose_simulation_command
 from vcm.cloud import get_fs
 import uuid
-
+import pytest
 
 def test_read_last_segment(tmpdir):
     date1 = "20160101.000000"
@@ -33,3 +34,16 @@ def test_read_last_segment_gcs(tmp_path: Path):
         file = tmp_path / "hello.txt"
         file.write_text("hello")
         subprocess.check_call(["gsutil", "cp", file.as_posix(), dest])
+
+@pytest.mark.parametrize("mpi_launcher", ["srun", "mpirun", None])
+def test_compose_simulation_command(regtest, mpi_launcher):
+
+    nprocs = "10"
+
+    if mpi_launcher == "mpirun" or mpi_launcher == "srun":
+        ans = compose_simulation_command(nprocs, mpi_launcher)
+    else:
+        ans = compose_simulation_command(nprocs)
+
+    print(ans, file=regtest)
+


### PR DESCRIPTION
Performing parallel simulations with `FV3GFS` model rely on the availability of the MPI (Message Passing Interface) library. Scheduling and submitting jobs on HPC (High Performance Computing) cluster is accomplished via SLURM (Simple Linux Utility for Resource Management) job scheduler. In contrast to cloud platforms, clusters are configured to use the `srun` submission command, which is the SLURM analog to `mpirun`. This PR introduces the changes to the code to toggle between `mpirun` versus `sun` submission commands at user's disposal.

Added public API:
- Added option `wrapper` to both `append` and `run_native` commands in the command line interface of the `runfv3` tool (`cli.py` script). The option `wrapper` is needed to toggle between the submission commands on the HPC cluster versus Cloud.

Refactored public API:
- `append_segment_to_run_url` and `run_segment` accept a new argument `wrapper` (`append.py` and `run.py` scripts) 
- the variable `command` was introduced to the `run_segment` function (`run.py` script). 

- [x] Tests added
   A new test has been developed to validate the value of "mpi_launcher" within "compose_simulation_command" function.

Resolves #2203 
