### PR TITLE
Bump version of xpartition to 0.2.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -315,7 +315,7 @@ wrapt==1.13.3
 xarray==0.19.0
 xgcm==0.6.1
 xmltodict==0.12.0
-xpartition==0.2.0
+xpartition==0.2.1
 yarl==1.6.3
 yq==2.11.0
 zarr==2.13.2

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -39,7 +39,7 @@ h5netcdf>=0.12.0
 # the rest of fv3net. Google controls the dataflow runtime environment, so it
 # is too hard to ensure that local fv3net matches the installed dependencies of
 # dataflow workers.
-xpartition>=0.2.0
+xpartition>=0.2.1
 
 # xpartition needs >=0.16.2 for region feature of to_zarr
 # pip-compile doesn't work with setup.cfg


### PR DESCRIPTION
This PR bumps the version of xpartition to 0.2.1, which was just released, and includes a safety-oriented bug fix.  This fix should eliminate the risk of corrupted coordinate data, which we only observed once on a recently created dataset, but is important to address.

xref: https://github.com/spencerkclark/xpartition/pull/17

Coverage reports (updated automatically):
