### PR TITLE
fv3fit: keras dense model without column data

### DIFF
--- a/external/fv3fit/fv3fit/keras/__init__.py
+++ b/external/fv3fit/fv3fit/keras/__init__.py
@@ -9,5 +9,5 @@ from ._models.shared.training_loop import (
 )
 from ._models.shared.utils import standard_denormalize, full_standard_normalized_input
 from ._models.shared.loss import LossConfig
-from ._models.dense import train_column_model
+from ._models.dense import train_pure_keras_model
 from ._models.shared.clip import ClipConfig

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -103,7 +103,7 @@ def train_dense_model(
         training_loop=hyperparameters.training_loop,
         build_samples=hyperparameters.normalization_fit_samples,
         callbacks=hyperparameters.callbacks,
-        predict_columns=hyperparameters.predict_columns,
+        unstacked_dims=("z",) if hyperparameters.predict_columns else (),
     )
 
 
@@ -172,7 +172,7 @@ def train_pure_keras_model(
     training_loop: TrainingLoopConfig,
     callbacks: List[CallbackConfig],
     build_samples: int = 500_000,
-    predict_columns: bool = True,
+    unstacked_dims: Sequence[str] = ("z",),
 ) -> PureKerasModel:
     """
     Train a PureKerasModel.
@@ -189,8 +189,8 @@ def train_pure_keras_model(
         training_loop: configuration of training loop
         callbacks: configuration for keras callbacks
         build_samples: the number of samples to pass to build_model
-        predict_columns: if True (default), assume an unstacked "z" dimension in inputs
-            and outputs, otherwise assume no unstacked dimensions
+        unstacked_dims: Unstacked data dimensions to be serialized and used in
+            prediction
     """
     train_batches = train_batches.map(
         tfdataset.apply_to_mapping(tfdataset.float64_to_float32)
@@ -229,7 +229,7 @@ def train_pure_keras_model(
         input_variables=input_variables,
         output_variables=output_variables,
         model=predict_model,
-        unstacked_dims=("z",) if predict_columns else (),
+        unstacked_dims=unstacked_dims,
         n_halo=0,
     )
 

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -48,8 +48,6 @@ class DenseHyperparameters(Hyperparameters):
             variable names and values are either a scalar referring to the
             total weight of the variable. Default is a total weight of 1
             for each variable.
-        normalize_loss: if True (default), normalize outputs by their standard
-            deviation before computing the loss function
         optimizer_config: selection of algorithm to be used in gradient descent
         dense_network: configuration of dense network
         training_loop: configuration of training loop
@@ -59,12 +57,13 @@ class DenseHyperparameters(Hyperparameters):
         output_limit_config: configuration for limiting output values.
         normalization_fit_samples: number of samples to use when fitting normalization
         callback_config: configuration for keras callbacks
+        predict_columns: if True (default), assume an unstacked "z" dimension in inputs
+            and outputs, otherwise assume no unstacked dimensions
     """
 
     input_variables: List[str]
     output_variables: List[str]
     weights: Optional[Mapping[str, Union[int, float]]] = None
-    normalize_loss: bool = True
     optimizer_config: OptimizerConfig = dataclasses.field(
         default_factory=lambda: OptimizerConfig("Adam")
     )
@@ -81,6 +80,7 @@ class DenseHyperparameters(Hyperparameters):
     )
     normalization_fit_samples: int = 500_000
     callbacks: List[CallbackConfig] = dataclasses.field(default_factory=list)
+    predict_columns: bool = True
 
     @property
     def variables(self) -> Set[str]:
@@ -93,7 +93,7 @@ def train_dense_model(
     train_batches: tf.data.Dataset,
     validation_batches: Optional[tf.data.Dataset],
 ) -> Predictor:
-    return train_column_model(
+    return train_pure_keras_model(
         train_batches=train_batches,
         validation_batches=validation_batches,
         build_model=curry(build_model)(config=hyperparameters),
@@ -103,6 +103,7 @@ def train_dense_model(
         training_loop=hyperparameters.training_loop,
         build_samples=hyperparameters.normalization_fit_samples,
         callbacks=hyperparameters.callbacks,
+        predict_columns=hyperparameters.predict_columns,
     )
 
 
@@ -161,7 +162,7 @@ def get_Xy_dataset(
     return data.map(map_fn)
 
 
-def train_column_model(
+def train_pure_keras_model(
     train_batches: tf.data.Dataset,
     validation_batches: Optional[tf.data.Dataset],
     build_model: ModelBuilder,
@@ -171,21 +172,25 @@ def train_column_model(
     training_loop: TrainingLoopConfig,
     callbacks: List[CallbackConfig],
     build_samples: int = 500_000,
+    predict_columns: bool = True,
 ) -> PureKerasModel:
     """
-    Train a columnwise PureKerasModel.
+    Train a PureKerasModel.
 
     Args:
         train_batches: training data, as a dataset of Mapping[str, tf.Tensor]
         validation_batches: validation data, as a dataset of Mapping[str, tf.Tensor]
-        build_model: the function which produces a columnwise keras model
+        build_model: the function which produces a keras model
             from input and output samples. The models returned must take a list of
             tensors as input and return a list of tensors as output.
         input_variables: names of inputs for the keras model
         output_variables: names of outputs for the keras model
         clip_config: configuration of input and output clipping of last dimension
         training_loop: configuration of training loop
+        callbacks: configuration for keras callbacks
         build_samples: the number of samples to pass to build_model
+        predict_columns: if True (default), assume an unstacked "z" dimension in inputs
+            and outputs, otherwise assume no unstacked dimensions
     """
     train_batches = train_batches.map(
         tfdataset.apply_to_mapping(tfdataset.float64_to_float32)
@@ -224,7 +229,7 @@ def train_column_model(
         input_variables=input_variables,
         output_variables=output_variables,
         model=predict_model,
-        unstacked_dims=("z",),
+        unstacked_dims=("z",) if predict_columns else (),
         n_halo=0,
     )
 

--- a/external/fv3fit/fv3fit/keras/_models/precipitative.py
+++ b/external/fv3fit/fv3fit/keras/_models/precipitative.py
@@ -1,5 +1,5 @@
 import dataclasses
-from fv3fit.keras._models.dense import train_column_model
+from fv3fit.keras._models.dense import train_pure_keras_model
 from toolz.functoolz import curry
 from typing import List, Optional, Sequence, Tuple, Set
 from fv3fit._shared.config import OptimizerConfig, RegularizerConfig
@@ -165,7 +165,7 @@ def train_precipitative_model(
     train_batches: tf.data.Dataset,
     validation_batches: Optional[tf.data.Dataset],
 ):
-    return train_column_model(
+    return train_pure_keras_model(
         train_batches=train_batches,
         validation_batches=validation_batches,
         build_model=curry(build_model)(config=hyperparameters),

--- a/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/pure_keras.py
@@ -81,13 +81,17 @@ class PureKerasModel(Predictor):
     ) -> xr.Dataset:
         ds = xr.Dataset()
         for name, output in zip(names, outputs):
-            dims = [SAMPLE_DIM_NAME] + list(self._unstacked_dims)
-            scalar_singleton_dim = (
-                len(output.shape) == len(dims) and output.shape[-1] == 1
-            )
-            if scalar_singleton_dim:  # remove singleton dimension
+            if len(self._unstacked_dims) > 0:
+                dims = [SAMPLE_DIM_NAME] + list(self._unstacked_dims)
+                scalar_singleton_dim = (
+                    len(output.shape) == len(dims) and output.shape[-1] == 1
+                )
+                if scalar_singleton_dim:  # remove singleton dimension
+                    output = output[..., 0]
+                    dims = dims[:-1]
+            else:
+                dims = [SAMPLE_DIM_NAME]
                 output = output[..., 0]
-                dims = dims[:-1]
             da = xr.DataArray(
                 data=output, dims=dims, coords={SAMPLE_DIM_NAME: stacked_coords},
             ).unstack(SAMPLE_DIM_NAME)

--- a/external/fv3fit/fv3fit/reservoir/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/autoencoder.py
@@ -14,7 +14,7 @@ from fv3fit._shared import (
 from fv3fit._shared.training_config import Hyperparameters
 
 from fv3fit.keras import (
-    train_column_model,
+    train_pure_keras_model,
     CallbackConfig,
     TrainingLoopConfig,
     LossConfig,
@@ -291,7 +291,7 @@ def train_dense_autoencoder(
     validation_batches: Optional[tf.data.Dataset],
 ) -> PureKerasModel:
 
-    pure_keras = train_column_model(
+    pure_keras = train_pure_keras_model(
         train_batches=train_batches,
         validation_batches=validation_batches,
         build_model=curry(build_autoencoder)(config=hyperparameters),

--- a/external/fv3fit/tests/keras/test_pure_keras.py
+++ b/external/fv3fit/tests/keras/test_pure_keras.py
@@ -1,9 +1,13 @@
 import pathlib
 import fv3fit
-from fv3fit.keras._models.shared.pure_keras import PureKerasDictPredictor
+from fv3fit.keras._models.shared.pure_keras import (
+    PureKerasDictPredictor,
+    PureKerasModel,
+)
 import tensorflow as tf
 import pytest
 import xarray
+import numpy as np
 
 
 def test_PureKerasDictPredictor_dump_load(tmp_path: pathlib.Path):
@@ -27,3 +31,38 @@ def test_PureKerasDictPredictor_predict():
     in_xr = xarray.Dataset({"a": (["blah", "z"], [[1]])})
     out = predictor.predict(in_xr)
     assert float(out["out"][0]) == pytest.approx(r)
+
+
+@pytest.mark.parametrize(
+    ["unstacked_dims"],
+    [
+        pytest.param((), id="no_unstacked_dims"),
+        pytest.param(("z",), id="column_unstacked_dim"),
+    ],
+)
+def test_PureKerasModel_predict(unstacked_dims):
+    input_variable = xarray.DataArray(np.arange(100).reshape(5, 20), dims=["x", "z"],)
+    input_shape = _get_input_shape(input_variable, unstacked_dims)
+    model = _get_dummy_model(input_shape)
+    predictor = PureKerasModel(
+        input_variables=["a"],
+        output_variables=["b"],
+        model=model,
+        unstacked_dims=unstacked_dims,
+    )
+    prediction = predictor.predict(xarray.Dataset({"a": input_variable}))
+    assert set(prediction["b"].dims) == set(["x", "z"])
+
+
+def _get_input_shape(da, unstacked_dims):
+    unstacked_shape = [da.sizes[dim] for dim in unstacked_dims]
+    if len(unstacked_shape) == 0:
+        unstacked_shape = [1]
+    return tuple(unstacked_shape)
+
+
+def _get_dummy_model(input_shape):
+    in_ = tf.keras.Input(shape=input_shape)
+    out_ = tf.keras.layers.Lambda(lambda x: x)(in_)
+    model = tf.keras.Model(inputs=in_, outputs=out_)
+    return model

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -173,7 +173,6 @@ spec:
                   "output_variables": [
                     "dQ2"
                   ],
-                  "normalize_loss": true,
                   "optimizer_config": {
                     "name": "Adam",
                     "kwargs": {


### PR DESCRIPTION
Allows the fv3fit `dense` model to work with fully stacked (no unstacked dimension) data, i.e., predicting scalars from scalars. 

Added public API:
- Added a `predict_columns` attribute to `DenseHyperparameters`, which defaults to true and specifies that dense models are saved with `z` as an unstacked dim (the prior behavior); if false models are saved with no unstacked dims.

Refactored public API:
- Renamed the package-public function `train_column_model` to `train_pure_keras_model` and added an `unstacked_dims` argument, given generalization of this function's capabilities.

- [X] Tests added

Coverage reports (updated automatically):
