### PR TITLE
Add output limiter option to autoencoder

### DIFF
--- a/external/fv3fit/fv3fit/keras/__init__.py
+++ b/external/fv3fit/fv3fit/keras/__init__.py
@@ -11,3 +11,4 @@ from ._models.shared.utils import standard_denormalize, full_standard_normalized
 from ._models.shared.loss import LossConfig
 from ._models.dense import train_pure_keras_model
 from ._models.shared.clip import ClipConfig
+from ._models.shared.output_limit import OutputLimitConfig

--- a/external/fv3fit/fv3fit/reservoir/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/autoencoder.py
@@ -152,7 +152,9 @@ class DenseAutoencoderHyperparameters(Hyperparameters):
     training_loop: configuration of training loop
     optimizer_config: selection of algorithm to be used in gradient descent
     callback_config: configuration for keras callbacks
-    normalization_fit_samples: number of samples to use when fitting normalization
+    normalization_fit_samples: number of samples
+    output_limit_config: configuration for limiting output values.
+        to use when fitting normalization
 
     """
 

--- a/external/fv3fit/fv3fit/reservoir/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/autoencoder.py
@@ -153,8 +153,8 @@ class DenseAutoencoderHyperparameters(Hyperparameters):
     optimizer_config: selection of algorithm to be used in gradient descent
     callback_config: configuration for keras callbacks
     normalization_fit_samples: number of samples
-    output_limit_config: configuration for limiting output values.
         to use when fitting normalization
+    output_limit_config: configuration for limiting output values.
 
     """
 


### PR DESCRIPTION
When testing the effect of autoencoder roundtrip errors in online prognostic runs, some runs crash due to specific humidity going negative. This PR adds the `output_limiter_config` option to the `DenseAutoencoder`, where the final layer in the model limits the output range. Similar to the dense model training, the loss is calculated on the limited outputs.

Added public API:
- `DenseAutoencoderHyperparameters.output_limit_config` 

Coverage reports (updated automatically):
