### PR TITLE
radiation: fix broken year warnings

### DIFF
--- a/external/radiation/radiation/radiation_astronomy.py
+++ b/external/radiation/radiation/radiation_astronomy.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 from .phys_const import con_pi, con_solr, con_solr_old
 
@@ -147,7 +146,7 @@ class AstronomyClass:
                     while iyr < iyr1:
                         iyr += icy
                     if rank == 0:
-                        warnings.warn(
+                        print(
                             f"*** Year {iyear} out of table range!",
                             f"{iyr1}, {iyr2}",
                             f"Using the closest-cycle year ('{iyr}')",
@@ -157,7 +156,7 @@ class AstronomyClass:
                     while iyr > iyr2:
                         iyr -= icy
                     if rank == 0:
-                        warnings.warn(
+                        print(
                             f"*** Year {iyear} out of table range!",
                             f"{iyr1}, {iyr2}",
                             f"Using the closest-cycle year ('{iyr}')",

--- a/external/radiation/radiation/radiation_driver.py
+++ b/external/radiation/radiation/radiation_driver.py
@@ -1,5 +1,4 @@
 import numpy as np
-import warnings
 
 from .types import DTYPE_INT
 from .radphysparam import ictmflg, ivflip
@@ -184,9 +183,7 @@ class RadiationDriver:
             raise ValueError(f"- ERROR!!! ISUBCSW={isubcsw}, is not a valid option")
 
         if isubcsw != isubclw:
-            warnings.warn(
-                "- *** Notice *** ISUBCSW /= ISUBCLW !!!", f"{isubcsw}, {isubclw}"
-            )
+            print("- *** Notice *** ISUBCSW /= ISUBCLW !!!", f"{isubcsw}, {isubclw}")
 
         if uni_cld:
             raise ValueError(f"uni_cld = True Not implemented")


### PR DESCRIPTION
The radiation port, if run for certain years, had warning statements that inadvertently crashed it. This PR replaces them with print statements (the way the rest of the port outputs to console at runtime; should probably be replaced by logging throughout but that's a separate issue). 

Coverage reports (updated automatically):
