### PR TITLE
fv3fit: dense model output squashing

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -60,6 +60,8 @@ class DenseHyperparameters(Hyperparameters):
         callback_config: configuration for keras callbacks
         predict_columns: if True (default), assume an unstacked "z" dimension in inputs
             and outputs, otherwise assume no unstacked dimensions
+        output_squashing: configuration for squashing predicted values based on an
+            output threshold for a particular output.
     """
 
     input_variables: List[str]

--- a/external/fv3fit/fv3fit/keras/_models/dense.py
+++ b/external/fv3fit/fv3fit/keras/_models/dense.py
@@ -294,12 +294,6 @@ def build_model(
         for array in clipped_output_arrays
     )
 
-    # Apply output squashing, if needed
-    if config.output_squashing.squash_on_train:
-        clipped_denorm_output_layers = config.output_squashing.squash_outputs(
-            names=config.output_variables, outputs=clipped_denorm_output_layers
-        )
-
     train_model = tf.keras.Model(
         inputs=input_layers, outputs=clipped_denorm_output_layers
     )

--- a/external/fv3fit/fv3fit/keras/_models/shared/__init__.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/__init__.py
@@ -13,4 +13,4 @@ from .loss import LossConfig
 from .utils import standard_denormalize, standard_normalize
 from .halos import append_halos
 from .clip import ClipConfig
-from .output_limit import OutputLimitConfig
+from .output_limit import OutputLimitConfig, OutputSquashConfig

--- a/external/fv3fit/fv3fit/keras/_models/shared/output_limit.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/output_limit.py
@@ -73,9 +73,9 @@ class OutputLimitConfig:
 
 @dataclasses.dataclass
 class OutputSquashConfig:
+    squash_by_name: Optional[str] = None
     squash_threshold: Optional[float] = None
     squash_to: Optional[float] = None
-    squash_by_name: Optional[str] = None
     squash_on_train: bool = False
 
     """Config class squashing outputs in keras models.
@@ -83,12 +83,12 @@ class OutputSquashConfig:
     a specific output.
 
     Attributes:
-        squash_threshold: value in the specified output which will determine
-        whether outputs are squashed
-        squash_to: value to which values will be squashed
         squash_by_name: name of the output to which the threshold will be applied;
         must be present in the outputs and this output must be broadcastable to
         every output
+        squash_threshold: value in the specified output which will determine
+        whether outputs are squashed
+        squash_to: value to which values will be squashed
         squash_on_train: if true, apply squashing on during model training; otherwise,
         apply only on prediction
     """
@@ -120,8 +120,6 @@ class OutputSquashConfig:
 
     def _squash_output(self, target_output: Output, squash_by_output: Output) -> Output:
         x = target_output
-        squashed = tf.constant(self.squash_to, dtype=np.float32) * tf.ones_like(
-            x, dtype=np.float32
-        )
+        squashed = tf.multiply(tf.constant(self.squash_to), tf.ones_like(x),)
         x = tf.where(tf.math.less(squash_by_output, self.squash_threshold), squashed, x)
         return x

--- a/external/fv3fit/fv3fit/keras/_models/shared/output_limit.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/output_limit.py
@@ -76,7 +76,6 @@ class OutputSquashConfig:
     squash_by_name: Optional[str] = None
     squash_threshold: Optional[float] = None
     squash_to: Optional[float] = None
-    squash_on_train: bool = False
 
     """Config class squashing outputs in keras models.
     Will squash all outputs to a specified target (e.g. 0.) based on a threshold for
@@ -86,20 +85,19 @@ class OutputSquashConfig:
         squash_by_name: name of the output to which the threshold will be applied;
         must be present in the outputs and this output must be broadcastable to
         every output
-        squash_threshold: value in the specified output which will determine
-        whether outputs are squashed
+        squash_threshold: value in the output specified by `squash_by_name` which
+        will determine whether all outputs at that position are squashed
         squash_to: value to which values will be squashed
-        squash_on_train: if true, apply squashing on during model training; otherwise,
-        apply only on prediction
     """
 
     def __post_init__(self):
-        if self.squash_by_name is not None:
-            if self.squash_threshold is None or self.squash_to is None:
-                raise ValueError(
-                    "If squash_by_name is specified, squash_threshold and squash_to "
-                    "must be also."
-                )
+        if (self.squash_by_name is not None) and (
+            self.squash_threshold is None or self.squash_to is None
+        ):
+            raise ValueError(
+                "If squash_by_name is specified, squash_threshold and squash_to "
+                "must be also."
+            )
 
     def squash_outputs(
         self, names: Sequence[str], outputs: Sequence[Output]

--- a/external/fv3fit/tests/keras/test_output_limit.py
+++ b/external/fv3fit/tests/keras/test_output_limit.py
@@ -3,7 +3,7 @@ import pytest
 from fv3fit.keras._models.shared.output_limit import OutputLimit, OutputSquashConfig
 
 
-OUTPUT = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+OUTPUT = np.array([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=np.float32)
 OUTPUT_DICT = {"a": OUTPUT, "b": 0.1 * OUTPUT}
 
 

--- a/external/fv3fit/tests/keras/test_output_limit.py
+++ b/external/fv3fit/tests/keras/test_output_limit.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
-from fv3fit.keras._models.shared.output_limit import OutputLimit
+from fv3fit.keras._models.shared.output_limit import OutputLimit, OutputSquashConfig
+
+
+OUTPUT = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+OUTPUT_DICT = {"a": OUTPUT, "b": 0.1 * OUTPUT}
 
 
 @pytest.mark.parametrize(
@@ -18,6 +22,53 @@ from fv3fit.keras._models.shared.output_limit import OutputLimit
 )
 def test_OutputLimit(min, max, expected):
     range = OutputLimit(min=min, max=max)
-    output = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
-    limited_output = range.limit_output(output)
+    limited_output = range.limit_output(OUTPUT)
     assert np.array_equal(expected, limited_output)
+
+
+@pytest.mark.parametrize(
+    ["squash_to", "squash_threshold", "expected"],
+    [
+        pytest.param(None, None, OUTPUT_DICT, id="no squash"),
+        pytest.param(
+            0.0,
+            1.5,
+            {"a": [0.0, 0.0, 0.0, 0.0, 2.0], "b": [0.0, 0.0, 0.0, 0.0, 0.2]},
+            id="1.5_to_zero",
+        ),
+        pytest.param(
+            0.0,
+            -1.5,
+            {"a": [0.0, -1.0, 0.0, 1.0, 2.0], "b": [0.0, -0.1, 0.0, 0.1, 0.2]},
+            id="-1.5_to_zero",
+        ),
+    ],
+)
+def test_OutputSquashConfig_squash_outputs(squash_to, squash_threshold, expected):
+    squash_by_name = "a" if squash_to is not None else None
+    squash = OutputSquashConfig(
+        squash_to=squash_to,
+        squash_threshold=squash_threshold,
+        squash_by_name=squash_by_name,
+    )
+    squashed_output = squash.squash_outputs(
+        names=tuple(OUTPUT_DICT.keys()), outputs=tuple(OUTPUT_DICT.values())
+    )
+    squashed_output_dict = {k: v for k, v in zip(OUTPUT_DICT.keys(), squashed_output)}
+    for name in squashed_output_dict:
+        np.testing.assert_allclose(squashed_output_dict[name], expected[name])
+
+
+def test_OutputSquashConfig_squash_name_error():
+    with pytest.raises(ValueError):
+        OutputSquashConfig(squash_by_name="a")
+
+
+def test_OutputSquashConfig_not_in_output_error():
+    squash = OutputSquashConfig(squash_to=0.0, squash_threshold=0.5, squash_by_name="a")
+    output_without_name = {"b": OUTPUT}
+    with pytest.raises(ValueError):
+        squash.squash_outputs(
+            names=tuple(output_without_name.keys()),
+            outputs=tuple(output_without_name.values()),
+        )


### PR DESCRIPTION
Allows outputs of a `dense` model to be squashed (set to 0 or another specified value) for all outputs of that sample, if the predicted value is below a given threshold for a specified output. For example, allows a sample in which the predicted cloud amount field is less than a threshold value to have cloud amount and other predictors (mixing ratios) set to zero. [Here's](https://github.com/ai2cm/explore/blob/master/brianh/2023-05-03-cloud-ml-NN-debugging/2023-05-24-dense-model-output-squashing.ipynb) a notebook showing that models with this enabled behave as expected.

Added public API:
- Adds an `output_squashing` entry to the `DenseHyperparameters`, which specifies the name of the field to squash by, the threshold, and the value to squash to. 

- [X] Tests added

Coverage reports (updated automatically):
