### PR TITLE
`DatasetPredictor`

### DIFF
--- a/external/fv3fit/fv3fit/_shared/__init__.py
+++ b/external/fv3fit/fv3fit/_shared/__init__.py
@@ -21,3 +21,4 @@ from .stacking import (
 )
 from .models import EnsembleModel, DerivedModel, TransformedPredictor
 from .filesystem import get_dir, put_dir
+from .xr_prediction import DatasetPredictor

--- a/external/fv3fit/fv3fit/_shared/xr_prediction.py
+++ b/external/fv3fit/fv3fit/_shared/xr_prediction.py
@@ -109,7 +109,7 @@ class DatasetPredictor(Predictor):
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
         model: ArrayPredictor,
-        unstacked_dims: Sequence[str],
+        unstacked_dims: Sequence[str] = ("z",),
         n_halo: int = 0,
     ):
         """Initialize the predictor

--- a/external/fv3fit/fv3fit/_shared/xr_prediction.py
+++ b/external/fv3fit/fv3fit/_shared/xr_prediction.py
@@ -105,7 +105,7 @@ class DatasetPredictor(Predictor):
         Args:
             input_variables: names of input variables
             output_variables: names of output variables
-            model: keras model to wrap
+            model: base model to wrap. Must be in fv3fit.io registry
             unstacked_dims: non-sample dimensions of model output
             n_halo: number of halo points required in input data
         """

--- a/external/fv3fit/fv3fit/_shared/xr_prediction.py
+++ b/external/fv3fit/fv3fit/_shared/xr_prediction.py
@@ -79,6 +79,7 @@ def predict_on_dataset(
     return match_prediction_to_input_coords(X, return_ds)
 
 
+@io.register("dataset-predictor")
 class DatasetPredictor(Predictor):
     """
     Base model is an ArrayPredictor which takes in a sequence of

--- a/external/fv3fit/fv3fit/_shared/xr_prediction.py
+++ b/external/fv3fit/fv3fit/_shared/xr_prediction.py
@@ -1,16 +1,23 @@
 import numpy as np
-from typing import Sequence, Iterable, Hashable, Protocol
+import os
+from typing import Sequence, Iterable, Hashable
 import xarray as xr
+import yaml
 
 from fv3fit._shared.halos import append_halos, append_halos_using_mpi
 from fv3fit._shared import (
     match_prediction_to_input_coords,
     SAMPLE_DIM_NAME,
     stack,
+    io,
+    Predictor,
+    get_dir,
+    put_dir,
 )
+from .predictor import Reloadable
 
 
-class ArrayPredictor(Protocol):
+class ArrayPredictor(Reloadable):
     def predict(self, inputs: Sequence[np.ndarray]) -> Sequence[np.ndarray]:
         ...
 
@@ -70,3 +77,85 @@ def predict_on_dataset(
         unstacked_dims=unstacked_dims,
     )
     return match_prediction_to_input_coords(X, return_ds)
+
+
+class DatasetPredictor(Predictor):
+    """
+    Base model is an ArrayPredictor which takes in a sequence of
+    input arrays and outputs a sequence of output arrays.
+    Normalization is contained within the base ArrayPredictor.
+
+    Assumes wrapped model accepts [sample, feature] arrays.
+    """
+
+    _BASE_MODEL_NAME = "base_model"
+    _CONFIG_FILENAME = "config.yaml"
+
+    def __init__(
+        self,
+        input_variables: Iterable[Hashable],
+        output_variables: Iterable[Hashable],
+        model: ArrayPredictor,
+        unstacked_dims: Sequence[str],
+        n_halo: int = 0,
+    ):
+        """Initialize the predictor
+
+        Args:
+            input_variables: names of input variables
+            output_variables: names of output variables
+            model: keras model to wrap
+            unstacked_dims: non-sample dimensions of model output
+            n_halo: number of halo points required in input data
+        """
+        super().__init__(input_variables, output_variables)
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+        self.model = model
+        self._n_halo = n_halo
+        self._unstacked_dims = unstacked_dims
+
+    def predict(self, X: xr.Dataset) -> xr.Dataset:
+        """Predict an output xarray dataset from an input xarray dataset."""
+        return predict_on_dataset(
+            model=self.model,
+            X=X,
+            input_variables=self.input_variables,
+            output_variables=self.output_variables,
+            n_halo=self._n_halo,
+            unstacked_dims=self._unstacked_dims,
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "DatasetPredictor":
+        """Load a serialized model from a directory."""
+        with get_dir(path) as path:
+            base_model_filename = os.path.join(path, cls._BASE_MODEL_NAME)
+            base_model: ArrayPredictor = io.load(base_model_filename)  # type: ignore
+            with open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
+                config = yaml.load(f, Loader=yaml.Loader)
+            obj = cls(
+                input_variables=config["input_variables"],
+                output_variables=config["output_variables"],
+                model=base_model,
+                unstacked_dims=config.get("unstacked_dims", None),
+                n_halo=config.get("n_halo", 0),
+            )
+
+            return obj
+
+    def dump(self, path: str) -> None:
+        with put_dir(path) as path:
+            if self.model is not None:
+                io.dump(self.model, os.path.join(path, self._BASE_MODEL_NAME))
+            with open(os.path.join(path, self._CONFIG_FILENAME), "w") as f:
+                f.write(
+                    yaml.dump(
+                        {
+                            "input_variables": self.input_variables,
+                            "output_variables": self.output_variables,
+                            "unstacked_dims": self._unstacked_dims,
+                            "n_halo": self._n_halo,
+                        }
+                    )
+                )

--- a/external/fv3fit/fv3fit/_shared/xr_prediction.py
+++ b/external/fv3fit/fv3fit/_shared/xr_prediction.py
@@ -1,3 +1,4 @@
+import abc
 import numpy as np
 import os
 from typing import Sequence, Iterable, Hashable
@@ -14,12 +15,23 @@ from fv3fit._shared import (
     get_dir,
     put_dir,
 )
-from .predictor import Reloadable
 
 
-class ArrayPredictor(Reloadable):
+class ArrayPredictor(abc.ABC):
+    @abc.abstractmethod
     def predict(self, inputs: Sequence[np.ndarray]) -> Sequence[np.ndarray]:
-        ...
+        pass
+
+    @abc.abstractmethod
+    def dump(self, path: str) -> None:
+        """Serialize to a directory."""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def load(cls, path: str) -> "ArrayPredictor":
+        """Load a serialized model from a directory."""
+        pass
 
 
 def _array_prediction_to_dataset(
@@ -148,7 +160,10 @@ class DatasetPredictor(Predictor):
     def dump(self, path: str) -> None:
         with put_dir(path) as path:
             if self.model is not None:
-                io.dump(self.model, os.path.join(path, self._BASE_MODEL_NAME))
+                io.dump(
+                    self.model,  # type: ignore
+                    os.path.join(path, self._BASE_MODEL_NAME),
+                )
             with open(os.path.join(path, self._CONFIG_FILENAME), "w") as f:
                 f.write(
                     yaml.dump(

--- a/external/fv3fit/tests/test_xr_prediction.py
+++ b/external/fv3fit/tests/test_xr_prediction.py
@@ -1,11 +1,52 @@
 from fv3fit._shared.xr_prediction import predict_on_dataset, DatasetPredictor
-from fv3fit._shared import io
-
+from fv3fit._shared.io import register
+import contextlib
 import numpy as np
 import os
 import pytest
 import tensorflow as tf
 import xarray
+
+
+class ConstantArrayPredictor:
+    """
+    A simple predictor meant to be used for testing.
+
+    Supports scalar and vector outputs, where the vector outputs are all
+    of the same shape and assigned a dimension name of "z".
+    """
+
+    _MODEL_NAME = "model.tf"
+
+    def __init__(self, model: tf.keras.Model):
+        """Initialize the predictor
+
+        Args:
+            model: keras model returning identity
+
+        """
+        self.model = model
+
+    def predict(self, X):
+        return [
+            self.model(X),
+        ]
+
+    def dump(self, path: str) -> None:
+        self.model.save(os.path.join(path, self._MODEL_NAME))
+
+    @classmethod
+    def load(cls, path: str) -> "ConstantArrayPredictor":
+        model = tf.keras.models.load_model(os.path.join(path, cls._MODEL_NAME))
+        return cls(model)
+
+
+@contextlib.contextmanager
+def registration_context():
+    try:
+        yield
+    finally:
+        register._register_class(ConstantArrayPredictor, "constant-array")
 
 
 @pytest.mark.parametrize(
@@ -44,79 +85,49 @@ def _get_dummy_model(input_shape):
     return model
 
 
-@io.register("constant-array")
-class ConstantArrayPredictor:
-    """
-    A simple predictor meant to be used for testing.
-
-    Supports scalar and vector outputs, where the vector outputs are all
-    of the same shape and assigned a dimension name of "z".
-    """
-
-    _MODEL_NAME = "model.tf"
-
-    def __init__(self, model: tf.keras.Model):
-        """Initialize the predictor
-
-        Args:
-            model: keras model returning identity
-
-        """
-        self.model = model
-
-    def predict(self, X):
-        return [
-            self.model(X),
-        ]
-
-    def dump(self, path: str) -> None:
-        self.model.save(os.path.join(path, self._MODEL_NAME))
-
-    @classmethod
-    def load(cls, path: str) -> "ConstantArrayPredictor":
-        model = tf.keras.models.load_model(os.path.join(path, cls._MODEL_NAME))
-        return cls(model)
-
-
 def test_DatasetPredictor_predict():
-    input_vars = ["in0"]
-    output_vars = ["out0"]
-    input_shape = 5
-    n_samples = 3
-    base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
-    predictor = DatasetPredictor(
-        input_variables=input_vars,
-        output_variables=output_vars,
-        model=base_model,
-        unstacked_dims=["z"],
-        n_halo=0,
-    )
-    in_xr = xarray.Dataset(
-        {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
-    )
-    out = predictor.predict(in_xr)
-    np.testing.assert_allclose(in_xr["in0"], out["out0"])
+    with registration_context():
+        input_vars = ["in0"]
+        output_vars = ["out0"]
+        input_shape = 5
+        n_samples = 3
+        base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
+        predictor = DatasetPredictor(
+            input_variables=input_vars,
+            output_variables=output_vars,
+            model=base_model,
+            unstacked_dims=["z"],
+            n_halo=0,
+        )
+        in_xr = xarray.Dataset(
+            {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
+        )
+        out = predictor.predict(in_xr)
+        np.testing.assert_allclose(in_xr["in0"], out["out0"])
 
 
 def test_DatasetPredictor_dump_load(tmpdir):
+    with registration_context():
 
-    input_vars = ["in0"]
-    output_vars = ["out0"]
-    input_shape = 5
-    n_samples = 3
-    base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
-    predictor = DatasetPredictor(
-        input_variables=input_vars,
-        output_variables=output_vars,
-        model=base_model,
-        unstacked_dims=["z"],
-        n_halo=0,
-    )
-    save_path = os.path.join(str(tmpdir), "dataset_predictor")
-    predictor.dump(save_path)
-    loaded_predictor = DatasetPredictor.load(save_path)
+        input_vars = ["in0"]
+        output_vars = ["out0"]
+        input_shape = 5
+        n_samples = 3
+        base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
+        predictor = DatasetPredictor(
+            input_variables=input_vars,
+            output_variables=output_vars,
+            model=base_model,
+            unstacked_dims=["z"],
+            n_halo=0,
+        )
+        save_path = os.path.join(str(tmpdir), "dataset_predictor")
+        predictor.dump(save_path)
+        loaded_predictor = DatasetPredictor.load(save_path)
 
-    in_xr = xarray.Dataset(
-        {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
-    )
-    np.testing.assert_allclose(loaded_predictor.predict(in_xr)["out0"], in_xr["in0"])
+        in_xr = xarray.Dataset(
+            {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
+        )
+        np.testing.assert_allclose(
+            loaded_predictor.predict(in_xr)["out0"], in_xr["in0"]
+        )

--- a/external/fv3fit/tests/test_xr_prediction.py
+++ b/external/fv3fit/tests/test_xr_prediction.py
@@ -1,8 +1,11 @@
-from fv3fit._shared.xr_prediction import predict_on_dataset
-import tensorflow as tf
-import pytest
-import xarray
+from fv3fit._shared.xr_prediction import predict_on_dataset, DatasetPredictor
+from fv3fit._shared import io
+
 import numpy as np
+import os
+import pytest
+import tensorflow as tf
+import xarray
 
 
 @pytest.mark.parametrize(
@@ -39,3 +42,81 @@ def _get_dummy_model(input_shape):
     out_ = tf.keras.layers.Lambda(lambda x: x)(in_)
     model = tf.keras.Model(inputs=in_, outputs=out_)
     return model
+
+
+@io.register("constant-array")
+class ConstantArrayPredictor:
+    """
+    A simple predictor meant to be used for testing.
+
+    Supports scalar and vector outputs, where the vector outputs are all
+    of the same shape and assigned a dimension name of "z".
+    """
+
+    _MODEL_NAME = "model.tf"
+
+    def __init__(self, model: tf.keras.Model):
+        """Initialize the predictor
+
+        Args:
+            model: keras model returning identity
+
+        """
+        self.model = model
+
+    def predict(self, X):
+        return [
+            self.model(X),
+        ]
+
+    def dump(self, path: str) -> None:
+        self.model.save(os.path.join(path, self._MODEL_NAME))
+
+    @classmethod
+    def load(cls, path: str) -> "ConstantArrayPredictor":
+        model = tf.keras.models.load_model(os.path.join(path, cls._MODEL_NAME))
+        return cls(model)
+
+
+def test_DatasetPredictor_predict():
+    input_vars = ["in0"]
+    output_vars = ["out0"]
+    input_shape = 5
+    n_samples = 3
+    base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
+    predictor = DatasetPredictor(
+        input_variables=input_vars,
+        output_variables=output_vars,
+        model=base_model,
+        unstacked_dims=["z"],
+        n_halo=0,
+    )
+    in_xr = xarray.Dataset(
+        {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
+    )
+    out = predictor.predict(in_xr)
+    np.testing.assert_allclose(in_xr["in0"], out["out0"])
+
+
+def test_DatasetPredictor_dump_load(tmpdir):
+
+    input_vars = ["in0"]
+    output_vars = ["out0"]
+    input_shape = 5
+    n_samples = 3
+    base_model = ConstantArrayPredictor(model=_get_dummy_model(input_shape))
+    predictor = DatasetPredictor(
+        input_variables=input_vars,
+        output_variables=output_vars,
+        model=base_model,
+        unstacked_dims=["z"],
+        n_halo=0,
+    )
+    save_path = os.path.join(str(tmpdir), "dataset_predictor")
+    predictor.dump(save_path)
+    loaded_predictor = DatasetPredictor.load(save_path)
+
+    in_xr = xarray.Dataset(
+        {"in0": (["_fv3net_sample", "z"], np.random.rand(n_samples, input_shape))}
+    )
+    np.testing.assert_allclose(loaded_predictor.predict(in_xr)["out0"], in_xr["in0"])


### PR DESCRIPTION
This adds the `DatasetPredictor` class, which uses the dataset prediction functions that were refactored out of `PureKerasModel` in a previous PR. This makes it easier to save other non-keras models as objects that still have the convenient feature of being able to take inputs/provide outputs  within prognostic runs.

The main difference between this and the `PureKerasModel` is that the dump/load is on a general base model, which should have predict, dump, and load methods, and must be in the `fv3fit.io` registry.

Added public API:
- `DatasetPredictor` 

- [x] Tests added
 
