### PR TITLE
fv3fit: squashed output model

### DIFF
--- a/external/fv3fit/docs/composite-models.rst
+++ b/external/fv3fit/docs/composite-models.rst
@@ -43,7 +43,9 @@ Models augmented with out-of-sample detection can be defined with a config file 
 Tapered models
 --------------------
 A tapering transform can be applied to an existing saved model:
+
 .. code-block:: yaml
+
     model: gs://vcm-ml-experiments/some_path
     tapering:
         dQ1:
@@ -60,7 +62,23 @@ Combined models
 Combines multiple models with nonoverlapping output variables into a single model.
 Similar functionality is also in the prognostic run's MultipleModelAdapter, but sometimes it
 is more efficient to combine models earlier in the workflow.
+
 .. code-block:: yaml
-models:
-    - gs://vcm-ml-experiments/model1
-    - gs://vcm-ml-experiments/model2
+
+    models:
+        - gs://vcm-ml-experiments/model1
+        - gs://vcm-ml-experiments/model2
+
+
+Squashed output models
+----------------------
+"Squashes" the output of a model, which means that samples less than a threshold value for a
+particular output variable will be set to a target.
+
+.. code-block:: yaml
+
+    base_model_path: gs://vcm-ml-experiments/model1
+    squash_output:
+        squash_by_name: "cloud_amount"
+        squash_threshold: 0.08
+        squash_to: 0.0

--- a/external/fv3fit/tests/test_squashed_output_model.py
+++ b/external/fv3fit/tests/test_squashed_output_model.py
@@ -1,0 +1,62 @@
+import numpy as np
+import xarray as xr
+import pytest
+from fv3fit._shared.models import SquashedOutputModel
+from fv3fit.testing import ConstantOutputPredictor
+
+
+ARRAY = np.array([[-2.0, -1.0, 0.0, 1.0, 2.0]])
+OUTPUT_DICT = {"a": ARRAY, "b": 0.1 * ARRAY}
+
+
+@pytest.mark.parametrize(
+    ["squash_to", "squash_threshold", "expected"],
+    [
+        pytest.param(None, None, OUTPUT_DICT, id="no squash"),
+        pytest.param(
+            0.0,
+            1.5,
+            {"a": [[0.0, 0.0, 0.0, 0.0, 2.0]], "b": [[0.0, 0.0, 0.0, 0.0, 0.2]]},
+            id="1.5_to_zero",
+        ),
+        pytest.param(
+            0.0,
+            -1.5,
+            {"a": [[0.0, -1.0, 0.0, 1.0, 2.0]], "b": [[0.0, -0.1, 0.0, 0.1, 0.2]]},
+            id="-1.5_to_zero",
+        ),
+    ],
+)
+def test_squashed_output_model_predict(squash_to, squash_threshold, expected):
+    base_model = ConstantOutputPredictor(
+        input_variables=["n"], output_variables=["a", "b"]
+    )
+    base_model.set_outputs(
+        **{k: v.squeeze() for k, v in OUTPUT_DICT.items()}
+    )  # set_outputs adds the sample dim
+    squashed_model = SquashedOutputModel(
+        base_model,
+        squash_by_name=(None if squash_to is None else "a"),
+        squash_threshold=squash_threshold,
+        squash_to=squash_to,
+    )
+    inputs = xr.Dataset({"n": xr.DataArray(ARRAY, dims=["x", "z"])})
+    predictions = squashed_model.predict(inputs)
+    for name in predictions:
+        np.testing.assert_allclose(predictions[name].values, expected[name])
+
+
+def test_squashed_output_model_name_error():
+    base_model = ConstantOutputPredictor(input_variables=["x"], output_variables=["a"])
+    with pytest.raises(ValueError):
+        SquashedOutputModel(
+            base_model, squash_by_name="a", squash_threshold=None, squash_to=None
+        )
+
+
+def test_squashed_output_model_not_in_output_error():
+    base_model = ConstantOutputPredictor(input_variables=["x"], output_variables=["b"])
+    with pytest.raises(ValueError):
+        SquashedOutputModel(
+            base_model, squash_by_name="a", squash_threshold=0.5, squash_to=0.0
+        )


### PR DESCRIPTION
Allows outputs of an `fv3fit.Predictor` model to be squashed (set to 0 or another specified value) for all outputs of that sample, if the predicted value is below a given threshold for a specified output. For example, allows a sample in which the predicted cloud amount field is less than a threshold value to have cloud amount and other predictors (mixing ratios) set to zero. [Here's](https://github.com/ai2cm/explore/blob/master/brianh/2023-05-03-cloud-ml-NN-debugging/2023-05-24-dense-model-output-squashing.ipynb) a notebook showing these models behave as expected.

Added public API:
- `SquashedOutputModel` added to `fv3fit.io` registry

- [X] Tests added

Coverage reports (updated automatically):
