### PR TITLE
Allow use of multiple steppers in postphysics

### DIFF
--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -62,12 +62,13 @@ class UserConfig:
     prephysics: Optional[
         List[Union[PrescriberConfig, MachineLearningConfig, IntervalConfig]]
     ] = None
+
     scikit_learn: Optional[MachineLearningConfig] = None
     nudging: Optional[NudgingConfig] = None
     tendency_prescriber: Optional[TendencyPrescriberConfig] = None
     online_emulator: Optional[runtime.transformers.fv3fit.Config] = None
     radiation_scheme: Optional[RadiationStepperConfig] = None
-    bias_correction: Optional[PrescriberConfig] = None
+    bias_correction: Optional[Union[PrescriberConfig, IntervalConfig]] = None
 
     @property
     def diagnostic_variables(self) -> Iterable[str]:

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -592,11 +592,11 @@ class TimeLoop(
             )
             _replace_precip_rate_with_accumulation(state_updates, self._timestep)
 
-            self._log_info(
+            self._log_debug(
                 "Postphysics stepper adds tendency update to state for "
                 f"{self._tendencies.keys()}"
             )
-            self._log_info(
+            self._log_debug(
                 "Postphysics stepper updates state directly for "
                 f"{state_updates.keys()}"
             )
@@ -638,22 +638,13 @@ class TimeLoop(
                 diagnostics.update(
                     state_updates_from_tendency(updated_state_from_tendency)
                 )
-                diagnostics.update(
-                    {
-                        "air_temperature_before_tendency_update": self._state[
-                            "air_temperature"
-                        ]
-                    }
-                )
                 self._state.update_mass_conserving(updated_state_from_tendency)
                 diagnostics.update(tendencies_filled_frac)
 
         self._log_info(
-            f"{self._state.time}  Applying state updates to postphysics dycore state: "
+            f"{self._state.time} Applying state updates to postphysics dycore state: "
             f"{self._state_updates.keys()}"
         )
-
-        self._log_info(f"Updating state for keys: {list(self._state_updates.keys())}")
         self._state.update_mass_conserving(self._state_updates)
 
         diagnostics.update({name: self._state[name] for name in self._states_to_output})

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -361,8 +361,12 @@ class TimeLoop(
                 self._log_info(
                     f"Using old non-MSE-conserving moisture limiter for step {step}"
                 )
+            limit_mse = base_stepper_config.use_mse_conserving_humidity_limiter
             stepper = PureMLStepper(
-                model=model, timestep=self._timestep, hydrostatic=hydrostatic,
+                model=model,
+                timestep=self._timestep,
+                hydrostatic=hydrostatic,
+                mse_conserving_limiter=limit_mse,
             )
         elif isinstance(base_stepper_config, NudgingConfig):
             self._log_info(f"Using NudgingStepper for step {step}")
@@ -397,7 +401,7 @@ class TimeLoop(
             prephysics_steppers: List[Stepper] = []
             for prephysics_config in config.prephysics:
                 prephysics_steppers.append(
-                    self._get_stepper(prephysics_config, "prephysics")
+                    self._get_stepper(prephysics_config, "prephysics", hydrostatic)
                 )
             return CombinedStepper(prephysics_steppers)
 
@@ -411,7 +415,7 @@ class TimeLoop(
         for postphysics_config in postphysics_configs:
             postphysics_steppers.append(
                 self._get_stepper(
-                    postphysics_config, "postphysics"  # type: ignore
+                    postphysics_config, "postphysics", hydrostatic  # type: ignore
                 )
             )
         if len(postphysics_steppers) > 0:

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -338,7 +338,7 @@ class TimeLoop(
         else:
             return func
 
-    def _get_prescriber_or_ml_stepper(
+    def _get_stepper(
         self,
         stepper_config: Union[
             PrescriberConfig, MachineLearningConfig, NudgingConfig, IntervalConfig
@@ -397,7 +397,7 @@ class TimeLoop(
             prephysics_steppers: List[Stepper] = []
             for prephysics_config in config.prephysics:
                 prephysics_steppers.append(
-                    self._get_prescriber_or_ml_stepper(prephysics_config, "prephysics")
+                    self._get_stepper(prephysics_config, "prephysics")
                 )
             return CombinedStepper(prephysics_steppers)
 
@@ -410,7 +410,7 @@ class TimeLoop(
         postphysics_steppers: List[Stepper] = []
         for postphysics_config in postphysics_configs:
             postphysics_steppers.append(
-                self._get_prescriber_or_ml_stepper(
+                self._get_stepper(
                     postphysics_config, "postphysics"  # type: ignore
                 )
             )
@@ -428,9 +428,7 @@ class TimeLoop(
         if config.radiation_scheme is not None:
             radiation_input_generator_config = config.radiation_scheme.input_generator
             if radiation_input_generator_config is not None:
-                radiation_input_generator: Optional[
-                    Stepper
-                ] = self._get_prescriber_or_ml_stepper(
+                radiation_input_generator: Optional[Stepper] = self._get_stepper(
                     radiation_input_generator_config, "radiation_inputs"
                 )
             else:

--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -236,19 +236,11 @@ def to_fv3config(dict_: dict,) -> dict:
         fv3config APIs.
     """
     user_config = HighLevelConfig.from_dict(dict_)
-
-    n_postphysics_configs = sum(
-        c is not None
-        for c in [
-            user_config.nudging,
-            user_config.scikit_learn,
-            user_config.bias_correction,
-        ]
-    )
-    if n_postphysics_configs > 1:
+    if user_config.nudging and (
+        user_config.scikit_learn or user_config.bias_correction
+    ):
         raise NotImplementedError(
-            "Only one of (bias correction, nudging, or machine learning) "
-            "postphysics updates can be run at the same time."
+            "Nudging cannot be run with other postphysics updates."
         )
 
     return user_config.to_fv3config()

--- a/workflows/prognostic_c48_run/tests/test_interval.py
+++ b/workflows/prognostic_c48_run/tests/test_interval.py
@@ -23,10 +23,11 @@ START_TIME = cftime.DatetimeJulian(2020, 1, 1, 0, 0, 0)
 
 
 @pytest.mark.parametrize(
-    "interval, time_checks",
+    "interval, offset, time_checks",
     [
         (
             3600,
+            0,
             {
                 START_TIME + datetime.timedelta(seconds=1800): False,
                 START_TIME + datetime.timedelta(seconds=3600): True,
@@ -34,17 +35,34 @@ START_TIME = cftime.DatetimeJulian(2020, 1, 1, 0, 0, 0)
         ),
         (
             10,
+            0,
             {
                 START_TIME + datetime.timedelta(seconds=5): False,
                 START_TIME + datetime.timedelta(seconds=1800): True,
                 START_TIME + datetime.timedelta(seconds=3600): True,
             },
         ),
+        (
+            3600,
+            900,
+            {
+                START_TIME + datetime.timedelta(seconds=4500): True,
+                START_TIME + datetime.timedelta(seconds=3600): False,
+            },
+        ),
+        (
+            3600,
+            -900,
+            {
+                START_TIME + datetime.timedelta(seconds=2700): True,
+                START_TIME + datetime.timedelta(seconds=3600): False,
+            },
+        ),
     ],
 )
-def test_needs_update(interval, time_checks):
+def test_needs_update(interval, offset, time_checks):
     interval_stepper = IntervalStepper(
-        apply_interval_seconds=interval, stepper=MockStepper()
+        apply_interval_seconds=interval, stepper=MockStepper(), offset_seconds=offset
     )
     # The first time checked becomes the start time for the IntervalStepper
     assert interval_stepper._need_to_update(START_TIME) is False


### PR DESCRIPTION
These changes allow for multiple steppers (e.g. `PureMLStepper`, `Prescriber`, etc)  to be used in the postphysics step. Currently, the `prepare_config` step does not allow user configs to contain more than one of [`bias_correction`, `nudging`, `scikit_learn`] entries. This behavior was blocking the training data generation for hybrid reservoir models, since both the interval prescriber and ML corrections need to be called in the postphysics.

Instead of disallowing any combination of postphysics steppers, I changed the prepare_config check to complain if nudging was included with another stepper.

I refactors the code in `_get_postphysics_stepper` to use the same method `_get_stepper` as `_get_prephysics_stepper` and to allow for a `CombinedStepper` to be returned.

I also added an `offset_seconds` option to the `IntervalConfig` that can be taken into account when the  `IntervalStepper` is called. The wrapper time updates in the middle of the loop (before postphysics) but the set of saved times in diagnostic files is calculated starting on the initial time. i.e. if no interval offset is specified, the reference fields are prescribed every HH:15 but the diagnostics will be saved on HH:00, so the timepoints that are needed for training are not saved. Setting the offset to -timestep in the interval allows the prescribed outputs to be applied and saved on the desired output time interval.


- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
