### PR TITLE
Fix hybrid model input concatenation

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -70,8 +70,8 @@ class HybridReservoirComputingModel(Predictor):
     def reset_state(self):
         self.reservoir_model.reset_state()
 
-    def increment_state(self):
-        self.reservoir_model.increment_state()
+    def increment_state(self, prediction_with_overlap):
+        self.reservoir_model.increment_state(prediction_with_overlap)
 
     def synchronize(self, synchronization_time_series):
         self.reservoir_model.synchronize(synchronization_time_series)

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -38,8 +38,8 @@ class HybridReservoirComputingModel(Predictor):
         output_variables: Iterable[Hashable],
         reservoir: Reservoir,
         readout: ReservoirComputingReadout,
+        rank_divider: RankDivider,
         square_half_hidden_state: bool = False,
-        rank_divider: Optional[RankDivider] = None,
         autoencoder: Optional[ReloadableTransfomer] = None,
     ):
         self.reservoir_model = ReservoirComputingModel(
@@ -73,10 +73,6 @@ class HybridReservoirComputingModel(Predictor):
     def _concatenate_readout_inputs(self, hidden_state_input, hybrid_input):
         if self.square_half_hidden_state is True:
             hidden_state_input = square_even_terms(hidden_state_input, axis=0)
-
-        if self.rank_divider is None:
-            raise ValueError("Prediction currently require rank_divider to be set")
-
         hybrid_input = self.rank_divider.flatten_subdomains_to_columns(
             hybrid_input, with_overlap=False
         )
@@ -129,8 +125,8 @@ class ReservoirComputingModel(Predictor):
         output_variables: Iterable[Hashable],
         reservoir: Reservoir,
         readout: ReservoirComputingReadout,
+        rank_divider: RankDivider,
         square_half_hidden_state: bool = False,
-        rank_divider: Optional[RankDivider] = None,
         autoencoder: Optional[ReloadableTransfomer] = None,
     ):
         """_summary_

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -118,7 +118,7 @@ def train_reservoir_model(
         )
         hybrid_time_series: Optional[np.ndarray]
         if hyperparameters.hybrid_variables is not None:
-            hybrid_time_series, _ = _process_batch_Xy_data(
+            _, hybrid_time_series = _process_batch_Xy_data(
                 variables=hyperparameters.hybrid_variables,
                 batch_data=batch_data,
                 rank_divider=rank_divider,

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -238,3 +238,50 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
         prediction1 = loaded_hybrid_predictor.predict(hybrid_input[i])
 
     np.testing.assert_array_almost_equal(prediction0, prediction1)
+
+
+def test_HybridReservoirComputingModel_concat_readout_inputs():
+    # TODO: Complex test, will be simplified in future when the model is refactored
+    input_size = 4
+    state_size = 3
+    hyperparameters = ReservoirHyperparameters(
+        state_size=state_size,
+        adjacency_matrix_sparsity=0.9,
+        spectral_radius=1.0,
+        input_coupling_sparsity=0,
+    )
+    rank_divider = RankDivider([2, 2], ["x", "y", "z"], [2, 2, 1], 0)
+
+    reservoir = Reservoir(hyperparameters, input_size=rank_divider.n_subdomain_features)
+
+    readout = ReservoirComputingReadout(
+        coefficients=np.random.rand(
+            state_size + rank_divider.n_subdomain_features, input_size
+        ),
+        intercepts=np.random.rand(input_size),
+    )
+    hybrid_predictor = HybridReservoirComputingModel(
+        input_variables=["a", "b"],
+        hybrid_variables=["c"],
+        output_variables=["a", "b"],
+        reservoir=reservoir,
+        readout=readout,
+        rank_divider=rank_divider,
+    )
+    hybrid_predictor.reset_state()
+
+    # hidden state of each subdomain is constant array of its index
+    hybrid_predictor.reservoir_model.reservoir.state = np.array(
+        [np.arange(rank_divider.n_subdomains) for zfeature in range(state_size)]
+    )
+
+    # partitioner indexing goes (0,0) -> 0, (1,0)-> 1, etc.
+    hybrid_inputs = np.array([[0, -2], [-1, -3]])
+
+    flattened_readout_input = hybrid_predictor._concatenate_readout_inputs(
+        hybrid_predictor.reservoir_model.reservoir.state, hybrid_inputs
+    )
+    np.testing.assert_array_equal(
+        flattened_readout_input,
+        np.array([0, 0, 0, 0, 1, 1, 1, -1, 2, 2, 2, -2, 3, 3, 3, -3]),
+    )

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -10,6 +10,9 @@ from fv3fit.reservoir import (
     HybridReservoirComputingModel,
 )
 
+# 4x4 domain divided into 1 cell each subdomain
+default_rank_divider = RankDivider([2, 2], ["x", "y", "z"], [2, 2, 1], 0)
+
 
 class MultiOutputMeanRegressor:
     def __init__(self, n_outputs: int):
@@ -45,14 +48,13 @@ def test_dump_load_optional_attrs(tmpdir):
         coefficients=sparse.coo_matrix(np.random.rand(input_size, 100)),
         intercepts=np.random.rand(input_size),
     )
-    rank_divider = RankDivider([2, 2], ["x", "y", "z"], [2, 2, 2], 2)
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
         square_half_hidden_state=False,
-        rank_divider=rank_divider,
+        rank_divider=default_rank_divider,
     )
     output_path = f"{str(tmpdir)}/predictor"
     predictor.dump(output_path)
@@ -80,6 +82,7 @@ def test_dump_load_preserves_matrices(tmpdir):
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
+        rank_divider=default_rank_divider,
         square_half_hidden_state=False,
     )
     output_path = f"{str(tmpdir)}/predictor"
@@ -118,6 +121,7 @@ def test_prediction_shape():
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
+        rank_divider=default_rank_divider,
     )
     # ReservoirComputingModel.predict reshapes the prediction to remove
     # the first dim of length 1 (sklearn regressors predict 2D arrays)
@@ -125,7 +129,8 @@ def test_prediction_shape():
 
 
 def test_ReservoirComputingModel_state_increment():
-    input_size = 2
+    rank_divider = RankDivider([1, 1], ["x", "y", "z"], [2, 2, 1], 0)
+    input_size = rank_divider.n_subdomain_features
     state_size = 3
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
@@ -143,15 +148,18 @@ def test_ReservoirComputingModel_state_increment():
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
+        rank_divider=rank_divider,
     )
 
-    input = np.array([0.5, 0.5])
+    input = 0.25 * np.ones((input_size, 1))
     predictor.reset_state()
     predictor.reservoir.increment_state(input)
     state_before_prediction = predictor.reservoir.state
     prediction = predictor.predict()
     predictor.increment_state(prediction)
-    np.testing.assert_array_almost_equal(prediction, np.tanh(np.array([1.0, 1.0])))
+    # TODO: Need to update the expected prediction shape to be in original dims
+    # after those changes are made to the ReservoirModel input/output
+    np.testing.assert_array_almost_equal(prediction, np.tanh(np.ones(input_size)))
     assert not np.allclose(state_before_prediction, predictor.reservoir.state)
 
 
@@ -175,6 +183,7 @@ def test_prediction_after_load(tmpdir):
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
+        rank_divider=default_rank_divider,
     )
     predictor.reset_state()
 
@@ -197,8 +206,8 @@ def test_prediction_after_load(tmpdir):
 
 def test_HybridReservoirComputingModel_dump_load(tmpdir):
     input_size = 15
-    hybrid_input_size = 4
     state_size = 1000
+    rank_divider = default_rank_divider
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
         adjacency_matrix_sparsity=0.9,
@@ -206,9 +215,13 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
         input_coupling_sparsity=0,
     )
     reservoir = Reservoir(hyperparameters, input_size=input_size)
-
+    # TODO: If removing the large block diagonal form of the readout,
+    # this needs to be updated
+    n_total_inputs = (
+        state_size + rank_divider.n_subdomain_features
+    ) * rank_divider.n_subdomains
     readout = ReservoirComputingReadout(
-        coefficients=np.random.rand(state_size + hybrid_input_size, input_size),
+        coefficients=np.random.rand(n_total_inputs, input_size),
         intercepts=np.random.rand(input_size),
     )
     hybrid_predictor = HybridReservoirComputingModel(
@@ -217,16 +230,18 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
+        rank_divider=rank_divider,
     )
     hybrid_predictor.reset_state()
-    ts_sync = [np.ones(input_size) for i in range(20)]
+    ts_sync = [
+        np.ones((input_size, hybrid_predictor.rank_divider.n_subdomains))
+        for i in range(20)
+    ]
 
     hybrid_predictor.synchronize(ts_sync)
 
-    n_predict = 7
-    hybrid_input = np.random.rand(n_predict, hybrid_input_size)
-    for i in range(n_predict):
-        prediction0 = hybrid_predictor.predict(hybrid_input[i])
+    hybrid_input = np.random.rand(*rank_divider.subdomain_layout)
+    prediction0 = hybrid_predictor.predict(hybrid_input)
 
     output_path = f"{str(tmpdir)}/predictor"
     hybrid_predictor.dump(output_path)
@@ -234,8 +249,7 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
     loaded_hybrid_predictor.reset_state()
 
     loaded_hybrid_predictor.synchronize(ts_sync)
-    for i in range(n_predict):
-        prediction1 = loaded_hybrid_predictor.predict(hybrid_input[i])
+    prediction1 = loaded_hybrid_predictor.predict(hybrid_input)
 
     np.testing.assert_array_almost_equal(prediction0, prediction1)
 
@@ -250,14 +264,12 @@ def test_HybridReservoirComputingModel_concat_readout_inputs():
         spectral_radius=1.0,
         input_coupling_sparsity=0,
     )
-    rank_divider = RankDivider([2, 2], ["x", "y", "z"], [2, 2, 1], 0)
+    rank_divider = default_rank_divider
 
     reservoir = Reservoir(hyperparameters, input_size=rank_divider.n_subdomain_features)
-
+    n_hybrid_inputs = rank_divider.n_subdomain_features * rank_divider.n_subdomains
     readout = ReservoirComputingReadout(
-        coefficients=np.random.rand(
-            state_size + rank_divider.n_subdomain_features, input_size
-        ),
+        coefficients=np.random.rand(state_size + n_hybrid_inputs, input_size),
         intercepts=np.random.rand(input_size),
     )
     hybrid_predictor = HybridReservoirComputingModel(


### PR DESCRIPTION
This PR fixes a bug in the hybrid reservoir model predict method.
Previously,  the subdomain inputs the hidden states were flattened before being concatenated with the flattened hybrid inputs. This meant that the hidden state and hybrid state for each subdomain were not contiguous in the inputs being provided to the readout. These changes fix the bug by concatenating the hidden states and hybrid state along the subdomain axis before flattening.

Other updates:
- made the `rank_divider` a required arg for initializing reservoir models. This simplifies some of the logic and there's no real use case where we don't include this in the reservoir model.
- changes the hybrid inputs to exclude the overlapping cells surrounding each subdomain- this helps decrease memory usage
- Fixes a bug with the hybrid model's `increment_state` method where it was missing the input arg.

 
 

- [x] Tests added

Resolves   https://github.com/ai2cm/fv3net/issues/2259  [JIRA-TAG]

Coverage reports (updated automatically):
