### PR TITLE
Use xy dims only in RankDivider

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -28,11 +28,9 @@ class RankDivider:
         Args:
             subdomain_layout: layout describing subdomain grid within the rank
                 ex. [2,2] means the rank is divided into 4 subdomains
-            rank_dims: order of spatial dimensions in data. Do not include time.
-                If z is the last dimension, it can be omitted.
-            rank_extent: Shape of full data. This includes any halo cells from
-                overlap into neighboring ranks. If z is the last dimension,
-                it can be omitted.
+            rank_dims: order of spatial xy dimensions in data. Do not include time or z.
+            rank_extent: Shape of full xy data. This includes any halo cells from
+                overlap into neighboring ranks.
             overlap: number of cells surrounding each subdomain to include when
                 taking subdomain data.
 

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -159,8 +159,9 @@ class RankDivider:
             tensor.size
             / (np.prod(self.get_subdomain_extent(with_overlap=with_overlap)))
         )
+        subdomain_xy_shape = self.get_subdomain_extent(with_overlap=with_overlap)
         unstacked_shape = (
-            *self.get_subdomain_extent(with_overlap=with_overlap),
+            *subdomain_xy_shape,
             vertical_dim_size,
         )
         expected_stacked_size = np.prod(unstacked_shape)
@@ -210,6 +211,11 @@ class RankDivider:
         return cls(**metadata)
 
     def merge_subdomains(self, flat_prediction: np.ndarray) -> np.ndarray:
+        """Reshapes a 1D array consisting of concatenated flattened subdomain readouts
+        predictions into a 3D arrays for each subdomain, then merges those 3D subdomain
+        arrays into a single 3D array for the entire domain.
+        """
+
         # raw prediction from readout is a long 1D array consisting of concatenated
         # flattened subdomain predictions
 

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -123,7 +123,7 @@ class HybridDatasetAdapter:
         processed_inputs = self._input_data_to_array(inputs)  # x, y, feature dims
         prediction = self.model.predict(processed_inputs)
         unstacked_arr = self.model.rank_divider.merge_subdomains(prediction)
-        return self._output_array_to_ds(unstacked_arr)
+        return self._output_array_to_ds(unstacked_arr, dims=list(inputs.dims))
 
     def increment_state(self, inputs: xr.Dataset):
         processed_inputs = self._input_data_to_array(inputs)
@@ -156,6 +156,7 @@ class HybridDatasetAdapter:
         return joined_feature_inputs
 
     def _input_data_to_array(self, inputs: xr.Dataset):
+
         if self._input_feature_sizes is None:
             self._input_feature_sizes = [
                 inputs[key].shape[-1] for key in self.model.input_variables
@@ -168,13 +169,12 @@ class HybridDatasetAdapter:
 
         return arr
 
-    def _output_array_to_ds(self, outputs: np.ndarray):
+    def _output_array_to_ds(self, outputs: np.ndarray, dims: Sequence[str]):
         if self.model.autoencoder is not None:
             var_arrays = self._decode_output_variables(outputs, self.model.autoencoder)
         else:
             var_arrays = self._separate_output_from_stacked_array(outputs)
 
-        dims = self.model.rank_divider.rank_dims
         ds = xr.Dataset(
             {
                 var: (dims, var_arrays[i])
@@ -191,7 +191,7 @@ class HybridDatasetAdapter:
         feature_size = encoded_output.shape[-1]
         encoded_output = encoded_output.reshape(-1, feature_size)
         decoded = autoencoder.decode(encoded_output)
-        spatial_shape = list(self.model.rank_divider._rank_extent_without_overlap[:-1])
+        spatial_shape = list(self.model.rank_divider._rank_extent_without_overlap)
         var_arrays = [arr.reshape(spatial_shape + [-1]) for arr in decoded]
         return var_arrays
 

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -91,7 +91,7 @@ def train_reservoir_model(
     # subdomain+halo are are flattened into feature dimension
     reservoir = Reservoir(
         hyperparameters=hyperparameters.reservoir_hyperparameters,
-        input_size=rank_divider.n_subdomain_features,
+        input_size=rank_divider.subdomain_size_with_overlap * autoencoder.n_latent_dims,
     )
 
     # One readout is trained per subdomain when iterating over batches,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -79,14 +79,13 @@ def train_reservoir_model(
     subdomain_config = hyperparameters.subdomain
 
     # sample_X[0] is the first data variable, shape elements 1:-1 are the x,y shape
-    rank_extent = [*sample_X[0].shape[1:-1], autoencoder.n_latent_dims]
+    rank_extent = sample_X[0].shape[1:-1]
     rank_divider = TimeSeriesRankDivider(
         subdomain_layout=subdomain_config.layout,
         rank_dims=subdomain_config.rank_dims,
         rank_extent=rank_extent,
         overlap=subdomain_config.overlap,
     )
-
     # First data dim is time, the rest of the elements of each
     # subdomain+halo are are flattened into feature dimension
     reservoir = Reservoir(

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -27,15 +27,15 @@ def test_slice_along_axis(data, ax, sl, expected):
 default_rank_divider_kwargs = {
     "layout": [2, 2],
     "overlap": 1,
-    "rank_dims": ["x", "y", "z"],
-    "rank_extent": [6, 6, 7],
+    "rank_dims": ["x", "y"],
+    "rank_extent": [6, 6],
 }
 
 
 def test_assure_same_dims():
     nt, nx, ny, nz = 5, 4, 4, 6
     arr_3d = np.ones((nt, nx, ny, nz))
-    arr_2d = np.ones((nt, nx, ny,))
+    arr_2d = np.ones((nt, nx, ny))
     data = [arr_3d, arr_2d]
     assert assure_same_dims(data)[0].shape == (nt, nx, ny, nz)
     assert assure_same_dims(data)[1].shape == (nt, nx, ny, 1)
@@ -44,26 +44,31 @@ def test_assure_same_dims():
 def test_assure_same_dims_incompatible_shapes():
     nt, nx, ny, nz = 5, 4, 4, 6
     arr_3d = np.ones((nt, nx, ny, nz, 2))
-    arr_2d = np.ones((nt, nx, ny,))
+    arr_2d = np.ones((nt, nx, ny))
     data = [arr_3d, arr_2d]
     with pytest.raises(ValueError):
         assure_same_dims(data)
 
 
 @pytest.mark.parametrize(
-    "layout, rank_extent, overlap, expected_with_overlap, expected_without_overlap",
+    "layout, rank_dims, rank_extent, \
+        overlap, expected_with_overlap, expected_without_overlap",
     [
-        [(2, 2), (6, 6, 2), 0, (3, 3, 2), (3, 3, 2)],
-        [(2, 2), (6, 6, 2), 1, (4, 4, 2), (2, 2, 2)],
-        [(2, 2), (10, 10, 2), 2, (7, 7, 2), (3, 3, 2)],
+        [(2, 2), ["x", "y"], (6, 6), 0, (3, 3), (3, 3)],
+        [(2, 2), ["x", "y"], (6, 6), 1, (4, 4), (2, 2)],
     ],
 )
 def test_RankDivider_get_subdomain_extent(
-    layout, rank_extent, overlap, expected_with_overlap, expected_without_overlap
+    layout,
+    rank_dims,
+    rank_extent,
+    overlap,
+    expected_with_overlap,
+    expected_without_overlap,
 ):
     divider = RankDivider(
         subdomain_layout=layout,
-        rank_dims=["x", "y", "z"],
+        rank_dims=rank_dims,
         rank_extent=rank_extent,
         overlap=overlap,
     )
@@ -72,45 +77,21 @@ def test_RankDivider_get_subdomain_extent(
 
 
 def test_RankDivider_subdomain_slice():
-    nz = 2
     divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[6, 6, nz],
-        overlap=1,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[6, 6], overlap=1,
     )
-    z_slice = slice(0, nz)
 
-    assert divider.subdomain_slice(0, with_overlap=True) == (
-        slice(0, 4),
-        slice(0, 4),
-        z_slice,
-    )
-    assert divider.subdomain_slice(0, with_overlap=False) == (
-        slice(1, 3),
-        slice(1, 3),
-        z_slice,
-    )
-    assert divider.subdomain_slice(3, with_overlap=True) == (
-        slice(2, 6),
-        slice(2, 6),
-        z_slice,
-    )
-    assert divider.subdomain_slice(3, with_overlap=False) == (
-        slice(3, 5),
-        slice(3, 5),
-        z_slice,
-    )
+    assert divider.subdomain_slice(0, with_overlap=True) == (slice(0, 4), slice(0, 4))
+    assert divider.subdomain_slice(0, with_overlap=False) == (slice(1, 3), slice(1, 3))
+    assert divider.subdomain_slice(3, with_overlap=True) == (slice(2, 6), slice(2, 6))
+    assert divider.subdomain_slice(3, with_overlap=False) == (slice(3, 5), slice(3, 5))
 
 
 def test_TimeSeriesRankDivider_subdomain_tensor_slice_overlap():
     xy_arr = np.pad(np.arange(1, 5).reshape(2, 2), pad_width=1)
     arr = np.reshape(xy_arr, (1, 4, 4, 1))
     divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[4, 4, 1],
-        overlap=1,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[4, 4], overlap=1,
     )
     bottom_right_with_overlap = divider.get_subdomain_tensor_slice(
         arr, 3, with_overlap=True,
@@ -130,10 +111,7 @@ def test_RankDivider_subdomain_tensor_slice_overlap():
     xy_arr = np.pad(np.arange(1, 5).reshape(2, 2), pad_width=1)
     arr = np.reshape(xy_arr, (4, 4, 1))
     divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[4, 4, 1],
-        overlap=1,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[4, 4], overlap=1,
     )
     bottom_right_with_overlap = divider.get_subdomain_tensor_slice(
         arr, 3, with_overlap=True,
@@ -150,16 +128,13 @@ def test_RankDivider_subdomain_tensor_slice_overlap():
 
 def test_TimeSeriesRankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
     divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[2, 2, 1],
-        overlap=0,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[2, 2], overlap=0,
     )
     arr = np.arange(1, 5).reshape(1, 2, 2, 1)
     subdomain_values = []
     for s in range(divider.n_subdomains):
         subdomain_values.append(
-            divider.get_subdomain_tensor_slice(arr, s, with_overlap=False,)
+            divider.get_subdomain_tensor_slice(arr, s, with_overlap=False)
             .flatten()
             .item()
         )
@@ -169,16 +144,13 @@ def test_TimeSeriesRankDivider_get_subdomain_tensor_slice_covers_all_subdomains(
 
 def test_RankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
     divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[2, 2, 1],
-        overlap=0,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[2, 2], overlap=0,
     )
     arr = np.arange(1, 5).reshape(2, 2, 1)
     subdomain_values = []
     for s in range(divider.n_subdomains):
         subdomain_values.append(
-            divider.get_subdomain_tensor_slice(arr, s, with_overlap=False,)
+            divider.get_subdomain_tensor_slice(arr, s, with_overlap=False)
             .flatten()
             .item()
         )
@@ -188,17 +160,17 @@ def test_RankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
 @pytest.mark.parametrize(
     "data_extent, overlap, with_overlap, ",
     [
-        ([5, 6, 6, 1], 1, True),
-        ([5, 6, 6, 2], 1, True),
-        ([5, 6, 6, 2], 1, False),
-        ([5, 6, 6, 2], 0, True),
-        ([1, 4, 4, 3], 0, False),
+        ([5, 6, 6], 1, True),
+        ([5, 6, 6], 1, True),
+        ([5, 6, 6], 1, False),
+        ([5, 6, 6], 0, True),
+        ([1, 4, 4], 0, False),
     ],
 )
 def test_TimeSeriesRankDivider_unstack_subdomain(data_extent, overlap, with_overlap):
     divider = TimeSeriesRankDivider(
         subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
+        rank_dims=["x", "y"],
         rank_extent=data_extent[1:],
         overlap=overlap,
     )
@@ -209,39 +181,43 @@ def test_TimeSeriesRankDivider_unstack_subdomain(data_extent, overlap, with_over
     stacked = stack_data(subdomain_arr, keep_first_dim=True)
     assert len(stacked.shape) == 2
     np.testing.assert_array_equal(
-        divider.unstack_subdomain(stacked, with_overlap=with_overlap,), subdomain_arr,
+        divider.unstack_subdomain(stacked, with_overlap=with_overlap), subdomain_arr,
     )
 
 
 @pytest.mark.parametrize(
-    "data_extent, overlap, with_overlap, ",
-    [([6, 6, 2], 1, True), ([6, 6, 1], 1, True), ([4, 4, 3], 0, False)],
+    "data_extent, overlap, with_overlap, nz ",
+    [
+        ([6, 6], 1, True, 2),
+        ([6, 6], 1, True, 2),
+        ([4, 4], 0, False, 2),
+        ([6, 6], 1, True, 1),
+    ],
 )
-def test_RankDivider_unstack_subdomain(data_extent, overlap, with_overlap):
+def test_RankDivider_unstack_subdomain(data_extent, overlap, with_overlap, nz):
     divider = RankDivider(
         subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
+        rank_dims=["x", "y"],
         rank_extent=data_extent,
         overlap=overlap,
     )
-    data_arr = np.arange(np.prod(data_extent)).reshape(*data_extent)
+    xy_shape = data_extent[:2]
+    data_shape = (*xy_shape, nz) if nz > 1 else xy_shape
+    data_arr = np.random.rand(*data_shape)
     subdomain_arr = divider.get_subdomain_tensor_slice(
         data_arr, 0, with_overlap=with_overlap,
     )
     stacked = stack_data(subdomain_arr, keep_first_dim=False)
     assert len(stacked.shape) == 1
     np.testing.assert_array_equal(
-        divider.unstack_subdomain(stacked, with_overlap=with_overlap,), subdomain_arr,
+        divider.unstack_subdomain(stacked, with_overlap=with_overlap), subdomain_arr,
     )
 
 
 def test_TimeSeriesRankDivider_flatten_subdomains_to_columns():
-    nx, ny, nz = 6, 6, 2
+    nx, ny = 6, 6
     divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[nx, ny, nz],
-        overlap=1,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[nx, ny], overlap=1,
     )
     input = np.array(
         [[0, 1, 10, 11], [2, 3, 12, 13], [20, 21, 30, 31], [22, 23, 32, 33]]
@@ -281,12 +257,9 @@ def test_TimeSeriesRankDivider_flatten_subdomains_to_columns():
 
 
 def test_RankDivider_flatten_subdomains_to_columns():
-    nx, ny, nz = 6, 6, 2
+    nx, ny = 6, 6
     divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[nx, ny, nz],
-        overlap=1,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[nx, ny], overlap=1,
     )
     input = np.array(
         [[0, 1, 10, 11], [2, 3, 12, 13], [20, 21, 30, 31], [22, 23, 32, 33]]
@@ -325,19 +298,14 @@ def test_RankDivider_flatten_subdomains_to_columns():
 
 @pytest.mark.parametrize(
     "rank_extent,  overlap, expected_extent",
-    [
-        ([8, 8, 5], 1, [6, 6, 5]),
-        ([8, 8, 2], 3, [2, 2, 2]),
-        ([8, 8, 5], 0, [8, 8, 5]),
-        ([8, 8, 2], 0, [8, 8, 2]),
-    ],
+    [([8, 8], 1, [6, 6]), ([8, 8], 3, [2, 2]), ([8, 8], 0, [8, 8])],
 )
 def test_RankDivider__rank_extent_without_overlap(
     rank_extent, overlap, expected_extent
 ):
     divider = RankDivider(
         subdomain_layout=[2, 2],
-        rank_dims=["x", "y", "z"],
+        rank_dims=["x", "y"],
         rank_extent=rank_extent,
         overlap=overlap,
     )
@@ -346,12 +314,9 @@ def test_RankDivider__rank_extent_without_overlap(
 
 
 def test_RankDivider_subdomain_xy_size_without_overlap():
-    nx, ny, nz = 8, 8, 2
+    nx, ny = 8, 8
     divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=[nx, ny, nz],
-        overlap=2,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[nx, ny], overlap=2,
     )
     assert divider.subdomain_xy_size_without_overlap == 2
 
@@ -361,10 +326,7 @@ def test_RankDivider_merge_subdomains():
     horizontal_array = np.arange(16).reshape(4, 4)
     data_orig = np.stack([horizontal_array, -1.0 * horizontal_array], axis=-1)
     rank_divider = RankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y", "z"],
-        rank_extent=(4, 4, 2),
-        overlap=0,
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=(4, 4), overlap=0,
     )
 
     # 'prediction' will just be the subdomains reshaped into columns and

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -37,11 +37,13 @@ def get_initialized_hybrid_model():
     # expects rank size (including halos) in latent space
     divider = RankDivider((2, 2), ["x", "y"], [8, 8], 2)
     autoencoder = DoNothingAutoencoder(6)
-    input_size = 6 * 6 * autoencoder.n_latent_dims
+    input_size = 6 * 6 * autoencoder.n_latent_dims  # overlap subdomain in latent space
     hybrid_input_size_per_subdomain = (
         divider.subdomain_xy_size_without_overlap ** 2 * autoencoder.n_latent_dims
+    )  # no overlap subdomain in latent space
+    output_size = (
+        hybrid_input_size_per_subdomain  # no overlap subdomain in latent space
     )
-    output_size = hybrid_input_size_per_subdomain
 
     state_size = 25
     hyperparameters = ReservoirHyperparameters(

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -45,7 +45,7 @@ def test_dump_load_optional_attrs(tmpdir):
         coefficients=sparse.coo_matrix(np.random.rand(input_size, 100)),
         intercepts=np.random.rand(input_size),
     )
-    rank_divider = RankDivider([2, 2], ["x", "y", "z"], [2, 2, 2], 2)
+    rank_divider = RankDivider([2, 2], ["x", "y"], [2, 2], 2)
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],
         output_variables=["a", "b"],

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -40,7 +40,7 @@ def test_train_reservoir():  # nx, ny, n_feature, n_sample):
 
     n_features = train_dataset["var_in_3d"].shape[-1] + 1
     subdomain_config = CubedsphereSubdomainConfig(
-        layout=[2, 2], overlap=2, rank_dims=["x", "y", "z"],
+        layout=[2, 2], overlap=2, rank_dims=["x", "y"],
     )
     reservoir_config = ReservoirHyperparameters(
         state_size=100,


### PR DESCRIPTION
Since the `RankDivider` is only concerned with dividing/reconstituting along horizontal x and y dims, it shouldn't require information about the z dimension size. This PR updates the `RankDivider` so that it only accepts rank extent information along x and y dimensions. In instances where the object is used to reshape arrays into (x, y, z) dims, the z dimension size can be inferred from the input array. An error will be raised upon initialization if z information is provided.

   
Resolves https://github.com/ai2cm/fv3net/issues/2253

Coverage reports (updated automatically):
