### PR TITLE
Add sample dimension enforcement to autoencoder

### DIFF
--- a/external/fv3fit/tests/reservoir/test_autoencoder.py
+++ b/external/fv3fit/tests/reservoir/test_autoencoder.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from fv3fit.reservoir.transformers.autoencoder import (
     Autoencoder,
     build_concat_and_scale_only_autoencoder,
@@ -33,3 +34,18 @@ def test_concat_and_scale_only_autoencoder_dump_load(tmpdir):
     loaded_model = Autoencoder.load(output_path)
     loaded_encoded = loaded_model.encode(test_inputs)
     np.testing.assert_array_equal(encoded, loaded_encoded)
+
+
+def test_autoencoder_sample_dim_handling():
+    model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
+    res = model.encode([np.array([10, 10]), np.array([3, 3])])
+    assert res.shape == (1, 4)
+
+    res = model.encode([np.array([[10, 10]]), np.array([[3, 3]])])
+    assert res.shape == (1, 4)
+
+
+def test_autoencoder_more_than_2d():
+    model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
+    with pytest.raises(ValueError):
+        model.encode([np.array([[[10, 10]]]), np.array([[[3, 3]]])])


### PR DESCRIPTION
The issue #2263 shows the autoencoder fails with 1D input. This PR brings the `Autoencoder` in line with the `SkTransformer` handling of 1D and 2D inputs to the encoding by adding a sample dimension to all variables, or failing for unrecognized dimension numbers.

Resolves #2263 