### PR TITLE
Move encode/decode into base models

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/_reshaping.py
+++ b/external/fv3fit/fv3fit/reservoir/_reshaping.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tensorflow as tf
 
 
 def flatten_2d_keeping_columns_contiguous(arr: np.ndarray):
@@ -34,3 +35,9 @@ def split_1d_samples_into_2d_rows(
         return np.reshape(arr, (time_dim_size, n_rows, -1), order="C")
     else:
         return np.reshape(arr, (n_rows, -1), order="C")
+
+
+def stack_array_preserving_last_dim(data):
+    original_z_dim = data.shape[-1]
+    reshaped = tf.reshape(data, shape=(-1, original_z_dim))
+    return reshaped

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -2,7 +2,6 @@ import fsspec
 import numpy as np
 import tensorflow as tf
 from typing import Sequence, Iterable
-import xarray as xr
 import yaml
 from ._reshaping import stack_data, split_1d_samples_into_2d_rows
 import pace.util
@@ -15,22 +14,6 @@ def slice_along_axis(arr: np.ndarray, inds: slice, axis: int = 0):
     sl = [slice(None)] * arr.ndim
     sl[axis] = inds
     return arr[tuple(sl)]
-
-
-def _transpose_xy_dims(ds: xr.Dataset, rank_dims: Sequence[str]):
-    # Useful for transposing the x, y dims in a dataset to match those in
-    # RankDivider.rank_dims, and leaves other dims in the same order
-    # relative to x,y. Dims after the first occurence of one of the rank_dims
-    # are assumed to be feature dims.
-    # e.g. (time, y, x, z) -> (time, x, y, z) for rank_dims=(x, y)
-    leading_non_xy_dims = []
-    for dim in ds.dims:
-        if dim not in rank_dims:
-            leading_non_xy_dims.append(dim)
-        if dim in rank_dims:
-            break
-    ordered_dims = (*leading_non_xy_dims, *rank_dims)
-    return ds.transpose(*ordered_dims, ...)
 
 
 class RankDivider:

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -2,6 +2,7 @@ import fsspec
 import numpy as np
 import tensorflow as tf
 from typing import Sequence, Iterable
+import xarray as xr
 import yaml
 from ._reshaping import stack_data, split_1d_samples_into_2d_rows
 import pace.util
@@ -14,6 +15,22 @@ def slice_along_axis(arr: np.ndarray, inds: slice, axis: int = 0):
     sl = [slice(None)] * arr.ndim
     sl[axis] = inds
     return arr[tuple(sl)]
+
+
+def _transpose_xy_dims(ds: xr.Dataset, rank_dims: Sequence[str]):
+    # Useful for transposing the x, y dims in a dataset to match those in
+    # RankDivider.rank_dims, and leaves other dims in the same order
+    # relative to x,y. Dims after the first occurence of one of the rank_dims
+    # are assumed to be feature dims.
+    # e.g. (time, y, x, z) -> (time, x, y, z) for rank_dims=(x, y)
+    leading_non_xy_dims = []
+    for dim in ds.dims:
+        if dim not in rank_dims:
+            leading_non_xy_dims.append(dim)
+        if dim in rank_dims:
+            break
+    ordered_dims = (*leading_non_xy_dims, *rank_dims)
+    return ds.transpose(*ordered_dims, ...)
 
 
 class RankDivider:

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -65,16 +65,14 @@ class RankDivider:
         self._partitioner = pace.util.TilePartitioner(subdomain_layout)
 
         # dimensions of rank data without the halo points. Useful for slice calculation.
-        self._rank_extent_without_overlap = self._get_rank_extent_without_overlap(
+        self.rank_extent_without_overlap = self._get_rank_extent_without_overlap(
             rank_extent, overlap
         )
 
     @property
     def subdomain_xy_size_without_overlap(self):
         # length of one side of subdomain along x/y axes
-        return (
-            self._rank_extent_without_overlap[self._x_ind] // self.subdomain_layout[0]
-        )
+        return self.rank_extent_without_overlap[self._x_ind] // self.subdomain_layout[0]
 
     @property
     def subdomain_size_with_overlap(self):
@@ -98,7 +96,7 @@ class RankDivider:
             self._partitioner.subtile_slice(
                 rank=subdomain_index,
                 global_dims=self.rank_dims,
-                global_extent=self._rank_extent_without_overlap,
+                global_extent=self.rank_extent_without_overlap,
             )
         )
         x_slice_ = slice_[self._x_ind]

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -12,7 +12,7 @@ from .reservoir import Reservoir
 from .domain import RankDivider
 from fv3fit._shared import io
 from .utils import square_even_terms
-from .transformers import ReloadableTransfomer
+from .transformers import ReloadableTransfomer, encode_columns, decode_columns
 from ._reshaping import flatten_2d_keeping_columns_contiguous
 
 
@@ -44,8 +44,8 @@ class HybridReservoirComputingModel(Predictor):
         reservoir: Reservoir,
         readout: ReservoirComputingReadout,
         rank_divider: RankDivider,
+        autoencoder: ReloadableTransfomer,
         square_half_hidden_state: bool = False,
-        autoencoder: Optional[ReloadableTransfomer] = None,
     ):
         self.reservoir_model = ReservoirComputingModel(
             input_variables=input_variables,
@@ -64,24 +64,33 @@ class HybridReservoirComputingModel(Predictor):
         self.rank_divider = rank_divider
         self.autoencoder = autoencoder
 
-    def predict(self, hybrid_input: np.ndarray):
+    def predict(self, hybrid_input: Sequence[np.ndarray]):
         # hybrid input is assumed to be in original spatial xy dims
         # (x, y, feature) and does not include overlaps.
-        # TODO: The encoding will be moved into this model
-
-        flattened_readout_input = self._concatenate_readout_inputs(
-            self.reservoir_model.reservoir.state, hybrid_input
+        encoded_hybrid_input = encode_columns(
+            input_arrs=hybrid_input, transformer=self.autoencoder
         )
-        prediction = self.readout.predict(flattened_readout_input).reshape(-1)
-        return prediction
+        flat_encoded_hybrid_input = self.rank_divider.flatten_subdomains_to_columns(
+            encoded_hybrid_input, with_overlap=False
+        )
+        flattened_readout_input = self._concatenate_readout_inputs(
+            self.reservoir_model.reservoir.state, flat_encoded_hybrid_input
+        )
+        flat_prediction = self.readout.predict(flattened_readout_input).reshape(-1)
+        prediction = self.rank_divider.merge_subdomains(flat_prediction)
+        decoded_prediction = decode_columns(
+            encoded_output=prediction,
+            transformer=self.autoencoder,
+            xy_shape=self.rank_divider.rank_extent_without_overlap,
+        )
+        return decoded_prediction
 
-    def _concatenate_readout_inputs(self, hidden_state_input, hybrid_input):
+    def _concatenate_readout_inputs(self, hidden_state_input, flat_hybrid_input):
+        # hybrid input is flattened prior to being input to this step
         if self.square_half_hidden_state is True:
             hidden_state_input = square_even_terms(hidden_state_input, axis=0)
-        hybrid_input = self.rank_divider.flatten_subdomains_to_columns(
-            hybrid_input, with_overlap=False
-        )
-        readout_input = np.concatenate([hidden_state_input, hybrid_input], axis=0)
+
+        readout_input = np.concatenate([hidden_state_input, flat_hybrid_input], axis=0)
         flattened_readout_input = flatten_2d_keeping_columns_contiguous(readout_input)
         return flattened_readout_input
 
@@ -122,19 +131,17 @@ class HybridDatasetAdapter:
         self._input_feature_sizes: Optional[Sequence] = None
 
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
-        # TODO: centralize stacking logic for encoding decoding
         # TODO: potentially use in train.py instead of special functions there
-        processed_inputs = self._input_data_to_encoded_array(
-            inputs
-        )  # x, y, feature dims
-        prediction = self.model.predict(processed_inputs)
-        unstacked_arr = self.model.rank_divider.merge_subdomains(prediction)
-        return self._output_array_to_ds(unstacked_arr, dims=list(inputs.dims))
+        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
+
+        prediction_arr = self.model.predict(xy_input_arrs)
+        return self._output_array_to_ds(prediction_arr, dims=list(inputs.dims))
 
     def increment_state(self, inputs: xr.Dataset):
-        processed_inputs = self._input_data_to_encoded_array(inputs)
+        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
+        encoded_xy_input_arrs = encode_columns(xy_input_arrs, self.model.autoencoder)
         subdomains = self.model.rank_divider.flatten_subdomains_to_columns(
-            processed_inputs, with_overlap=True
+            encoded_xy_input_arrs, with_overlap=True
         )
         self.model.increment_state(subdomains)
 
@@ -153,76 +160,28 @@ class HybridDatasetAdapter:
         ]
         return input_arrs
 
-    def _encode_input_variables(self, inputs: xr.Dataset, autoencoder):
-        input_arrs = [
-            inputs[variable].values for variable in self.model.input_variables
-        ]
-
-        sample_dims_shape = list(input_arrs[0].shape[:-1])
-        feature_len = input_arrs[0].shape[-1]
-        stacked_sample_arrs = np.array(
-            [arr.reshape(-1, feature_len) for arr in input_arrs]
-        )
-        encoded = autoencoder.encode(stacked_sample_arrs)
-        encoded_shape = sample_dims_shape + [encoded.shape[-1]]
-        return encoded.reshape(encoded_shape)
-
-    def _join_input_variables(self, inputs: xr.Dataset):
-        input_arrs = [inputs[variable] for variable in self.model.input_variables]
-        joined_feature_inputs = np.concatenate(input_arrs, axis=-1)
-
-        return joined_feature_inputs
-
-    def _input_data_to_encoded_array(self, inputs: xr.Dataset):
-        if self._input_feature_sizes is None:
-            self._input_feature_sizes = [
-                inputs[key].shape[-1] for key in self.model.input_variables
-            ]
-
-        if self.model.autoencoder is not None:
-            arr = self._encode_input_variables(inputs, self.model.autoencoder)
-        else:
-            arr = self._join_input_variables(inputs)
-
-        return arr
-
-    def _output_array_to_ds(self, outputs: np.ndarray, dims: Sequence[str]):
-        if self.model.autoencoder is not None:
-            var_arrays = self._decode_output_variables(outputs, self.model.autoencoder)
-        else:
-            var_arrays = self._separate_output_from_stacked_array(outputs)
-
+    def _output_array_to_ds(
+        self, outputs: Sequence[np.ndarray], dims: Sequence[str]
+    ) -> xr.Dataset:
         ds = xr.Dataset(
             {
-                var: (dims, var_arrays[i])
+                var: (dims, outputs[i])
                 for i, var in enumerate(self.model.output_variables)
             }
         )
-
         return ds
 
-    def _decode_output_variables(self, encoded_output: np.ndarray, autoencoder):
-        if encoded_output.ndim > 3:
-            raise ValueError("Unexpected dimension size in decoding operation.")
-
-        feature_size = encoded_output.shape[-1]
-        encoded_output = encoded_output.reshape(-1, feature_size)
-        decoded = autoencoder.decode(encoded_output)
-        spatial_shape = list(self.model.rank_divider._rank_extent_without_overlap)
-        var_arrays = [arr.reshape(spatial_shape + [-1]) for arr in decoded]
-        return var_arrays
-
-    def _separate_output_from_stacked_array(self, outputs: np.ndarray):
-
+    def _separate_output_from_stacked_array(
+        self, outputs: np.ndarray
+    ) -> Sequence[np.ndarray]:
         if self._input_feature_sizes is None:
             raise ValueError(
                 "Cannot separate stacked array if input feature sizes is None."
             )
-
         divider = self.model.rank_divider
         split_indices = np.cumsum(self._input_feature_sizes)[:-1]
         var_arrays = np.split(outputs, split_indices, axis=-1)
-        spatial_shape = list(divider._rank_extent_without_overlap[:-1])
+        spatial_shape = list(divider.rank_extent_without_overlap[:-1])
         var_arrays = [arr.reshape(spatial_shape + [-1]) for arr in var_arrays]
 
         return var_arrays
@@ -243,8 +202,8 @@ class ReservoirComputingModel(Predictor):
         reservoir: Reservoir,
         readout: ReservoirComputingReadout,
         rank_divider: RankDivider,
+        autoencoder: ReloadableTransfomer,
         square_half_hidden_state: bool = False,
-        autoencoder: Optional[ReloadableTransfomer] = None,
     ):
         """_summary_
 
@@ -278,8 +237,14 @@ class ReservoirComputingModel(Predictor):
     def predict(self):
         # Returns raw readout prediction of latent state.
         readout_input = self.process_state_to_readout_input()
-        prediction = self.readout.predict(readout_input).reshape(-1)
-        return prediction
+        flat_prediction = self.readout.predict(readout_input).reshape(-1)
+        prediction = self.rank_divider.merge_subdomains(flat_prediction)
+        decoded_prediction = decode_columns(
+            encoded_output=prediction,
+            transformer=self.autoencoder,
+            xy_shape=self.rank_divider.rank_extent_without_overlap,
+        )
+        return decoded_prediction
 
     def reset_state(self):
         input_shape = (
@@ -327,16 +292,10 @@ class ReservoirComputingModel(Predictor):
 
         rank_divider = RankDivider.load(os.path.join(path, cls._RANK_DIVIDER_NAME))
 
-        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
-        autoencoder: Optional[ReloadableTransfomer]
-        if fs.exists(os.path.join(path, cls._AUTOENCODER_SUBDIR)):
-            autoencoder = cast(
-                ReloadableTransfomer,
-                fv3fit.load(os.path.join(path, cls._AUTOENCODER_SUBDIR)),
-            )
-        else:
-            autoencoder = None
-
+        autoencoder = cast(
+            ReloadableTransfomer,
+            fv3fit.load(os.path.join(path, cls._AUTOENCODER_SUBDIR)),
+        )
         return cls(
             input_variables=metadata["input_variables"],
             output_variables=metadata["output_variables"],

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -4,7 +4,7 @@ import fv3fit
 from fv3fit.reservoir.readout import BatchLinearRegressor
 import numpy as np
 import tensorflow as tf
-from typing import Optional, Mapping, Tuple, List, Iterable, Union, Sequence
+from typing import Optional, Mapping, Tuple, List, Iterable, Union
 from .. import Predictor
 from .utils import square_even_terms
 from .transformers.autoencoder import build_concat_and_scale_only_autoencoder
@@ -19,8 +19,8 @@ from . import (
 )
 from .readout import combine_readouts
 from .domain import TimeSeriesRankDivider, assure_same_dims
-from ._reshaping import stack_data
-from fv3fit.reservoir.transformers import ReloadableTransfomer
+from ._reshaping import stack_data, stack_array_preserving_last_dim
+from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -28,25 +28,6 @@ logger.setLevel(logging.INFO)
 
 def _add_input_noise(arr: np.ndarray, stddev: float) -> np.ndarray:
     return arr + np.random.normal(loc=0, scale=stddev, size=arr.shape)
-
-
-def _stack_array_preserving_last_dim(data):
-    original_z_dim = data.shape[-1]
-    reshaped = tf.reshape(data, shape=(-1, original_z_dim))
-    return reshaped
-
-
-def _encode_columns(
-    data: Sequence[tf.Tensor], transformer: ReloadableTransfomer
-) -> np.ndarray:
-    # reduce a sequnence of N x M x Vi dim data over i variables
-    # to a single N x M x Z dim array, where Vi is original number of features
-    # (usually vertical levels) of each variable and Z << V is a smaller number
-    # of latent dimensions
-    original_sample_shape = data[0].shape[:-1]
-    reshaped = [_stack_array_preserving_last_dim(var) for var in data]
-    encoded_reshaped = transformer.encode(reshaped)
-    return encoded_reshaped.reshape(*original_sample_shape, -1)
 
 
 def _get_ordered_X(X_mapping, variables):
@@ -70,7 +51,7 @@ def train_reservoir_model(
         )  # type: ignore
     else:
         sample_X_stacked = [
-            _stack_array_preserving_last_dim(arr).numpy() for arr in sample_X
+            stack_array_preserving_last_dim(arr).numpy() for arr in sample_X
         ]
         autoencoder = build_concat_and_scale_only_autoencoder(
             variables=hyperparameters.input_variables, X=sample_X_stacked
@@ -194,7 +175,7 @@ def _process_batch_Xy_data(
 
     # Concatenate features, normalize and optionally convert data
     # to latent representation
-    batch_data_encoded = _encode_columns(batch_X, autoencoder)
+    batch_data_encoded = encode_columns(batch_X, autoencoder)
     # Divide into subdomains and flatten each subdomain by stacking
     # x/y/encoded-feature dims into a single subdomain-feature dimension.
     # Dimensions of a single subdomain's data become [time, subdomain-feature]

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -1,6 +1,6 @@
 from .autoencoder import Autoencoder
 from .sk_transformer import SkTransformer
-from .transformer import encode_columns
+from .transformer import encode_columns, DoNothingAutoencoder
 from typing import Union
 
 ReloadableTransfomer = Union[Autoencoder, SkTransformer]

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -1,6 +1,6 @@
 from .autoencoder import Autoencoder
 from .sk_transformer import SkTransformer
-from .transformer import encode_columns, DoNothingAutoencoder
+from .transformer import encode_columns, DoNothingAutoencoder, decode_columns
 from typing import Union
 
 ReloadableTransfomer = Union[Autoencoder, SkTransformer]

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -1,6 +1,6 @@
 from .autoencoder import Autoencoder
 from .sk_transformer import SkTransformer
-
+from .transformer import encode_columns
 from typing import Union
 
 ReloadableTransfomer = Union[Autoencoder, SkTransformer]

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -3,6 +3,8 @@ import numpy as np
 import tensorflow as tf
 from typing import Union, Sequence
 
+from fv3fit.reservoir._reshaping import stack_array_preserving_last_dim
+
 
 ArrayLike = Union[np.ndarray, tf.Tensor]
 
@@ -20,3 +22,14 @@ class Transformer(abc.ABC):
     @abc.abstractmethod
     def decode(self, x: ArrayLike) -> Sequence[ArrayLike]:
         pass
+
+
+def encode_columns(data: Sequence[tf.Tensor], transformer: Transformer) -> np.ndarray:
+    # reduce a sequnence of N x M x Vi dim data over i variables
+    # to a single N x M x Z dim array, where Vi is original number of features
+    # (usually vertical levels) of each variable and Z << V is a smaller number
+    # of latent dimensions
+    original_sample_shape = data[0].shape[:-1]
+    reshaped = [stack_array_preserving_last_dim(var) for var in data]
+    encoded_reshaped = transformer.encode(reshaped)
+    return encoded_reshaped.reshape(*original_sample_shape, -1)

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -1,12 +1,10 @@
 import numpy as np
 import pytest
-import xarray as xr
 from fv3fit.reservoir.domain import (
     slice_along_axis,
     RankDivider,
     TimeSeriesRankDivider,
     assure_same_dims,
-    _transpose_xy_dims,
 )
 from fv3fit.reservoir._reshaping import stack_data
 
@@ -344,15 +342,3 @@ def test_RankDivider_merge_subdomains():
 
     merged = rank_divider.merge_subdomains(prediction)
     np.testing.assert_array_equal(merged, data_orig)
-
-
-@pytest.mark.parametrize(
-    "original_dims, reordered_dims",
-    [
-        (["time", "x", "y", "z"], ["time", "x", "y", "z"]),
-        (["time", "y", "x", "z"], ["time", "x", "y", "z"]),
-    ],
-)
-def test__transpose_xy_dims(original_dims, reordered_dims):
-    da = xr.DataArray(np.random.rand(5, 7, 7, 8), dims=original_dims)
-    assert list(_transpose_xy_dims(da, rank_dims=["x", "y"]).dims) == reordered_dims

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -312,7 +312,7 @@ def test_RankDivider__rank_extent_without_overlap(
         overlap=overlap,
     )
 
-    assert divider._rank_extent_without_overlap == expected_extent
+    assert divider.rank_extent_without_overlap == expected_extent
 
 
 def test_RankDivider_subdomain_xy_size_without_overlap():

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pytest
+import xarray as xr
 from fv3fit.reservoir.domain import (
     slice_along_axis,
     RankDivider,
     TimeSeriesRankDivider,
     assure_same_dims,
+    _transpose_xy_dims,
 )
 from fv3fit.reservoir._reshaping import stack_data
 
@@ -380,3 +382,15 @@ def test_RankDivider_merge_subdomains():
 
     merged = rank_divider.merge_subdomains(prediction)
     np.testing.assert_array_equal(merged, data_orig)
+
+
+@pytest.mark.parametrize(
+    "original_dims, reordered_dims",
+    [
+        (["time", "x", "y", "z"], ["time", "x", "y", "z"]),
+        (["time", "y", "x", "z"], ["time", "x", "y", "z"]),
+    ],
+)
+def test__transpose_xy_dims(original_dims, reordered_dims):
+    da = xr.DataArray(np.random.rand(5, 7, 7, 8), dims=original_dims)
+    assert list(_transpose_xy_dims(da, rank_dims=["x", "y"]).dims) == reordered_dims

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from fv3fit.reservoir.transformers.transformer import Transformer
+from fv3fit.reservoir.transformers.transformer import DoNothingAutoencoder
 from fv3fit.reservoir.domain import RankDivider
 from fv3fit.reservoir.readout import ReservoirComputingReadout
 from fv3fit.reservoir import (
@@ -23,27 +23,6 @@ from fv3fit.reservoir.model import HybridDatasetAdapter, _transpose_xy_dims
 def test__transpose_xy_dims(original_dims, reordered_dims):
     da = xr.DataArray(np.random.rand(5, 7, 7, 8), dims=original_dims)
     assert list(_transpose_xy_dims(da, rank_dims=["x", "y"]).dims) == reordered_dims
-
-
-class DoNothingAutoencoder(Transformer):
-    def __init__(self, latent_dim_len):
-        self._latent_dim_len = latent_dim_len
-        self._array_feature_sizes = None
-
-    @property
-    def n_latent_dims(self):
-        return self._latent_dim_len
-
-    def encode(self, x):
-        self._array_feature_sizes = [arr.shape[-1] for arr in x]
-        return np.concatenate(x, -1)
-
-    def decode(self, latent_x):
-        if self._array_feature_sizes is None:
-            raise ValueError("Must encode data before decoding.")
-
-        split_indices = np.cumsum(self._array_feature_sizes)[:-1]
-        return np.split(latent_x, split_indices, axis=-1)
 
 
 def get_initialized_hybrid_model():

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import xarray as xr
 
 from fv3fit.reservoir.transformers.transformer import Transformer
@@ -9,7 +10,19 @@ from fv3fit.reservoir import (
     ReservoirHyperparameters,
     HybridReservoirComputingModel,
 )
-from fv3fit.reservoir.model import HybridDatasetAdapter
+from fv3fit.reservoir.model import HybridDatasetAdapter, _transpose_xy_dims
+
+
+@pytest.mark.parametrize(
+    "original_dims, reordered_dims",
+    [
+        (["time", "x", "y", "z"], ["time", "x", "y", "z"]),
+        (["time", "y", "x", "z"], ["time", "x", "y", "z"]),
+    ],
+)
+def test__transpose_xy_dims(original_dims, reordered_dims):
+    da = xr.DataArray(np.random.rand(5, 7, 7, 8), dims=original_dims)
+    assert list(_transpose_xy_dims(da, rank_dims=["x", "y"]).dims) == reordered_dims
 
 
 class DoNothingAutoencoder(Transformer):

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -1,6 +1,9 @@
 from fv3fit.reservoir.domain import RankDivider
 from fv3fit.reservoir.readout import ReservoirComputingReadout
+from fv3fit.reservoir.transformers import DoNothingAutoencoder
 import numpy as np
+import pytest
+
 from scipy import sparse
 
 from fv3fit.reservoir import (
@@ -56,6 +59,7 @@ def test_dump_load_optional_attrs(tmpdir):
         readout=readout,
         square_half_hidden_state=False,
         rank_divider=rank_divider,
+        autoencoder=DoNothingAutoencoder(1),
     )
     output_path = f"{str(tmpdir)}/predictor"
     predictor.dump(output_path)
@@ -85,6 +89,7 @@ def test_dump_load_preserves_matrices(tmpdir):
         readout=readout,
         rank_divider=default_rank_divider,
         square_half_hidden_state=False,
+        autoencoder=DoNothingAutoencoder(1),
     )
     output_path = f"{str(tmpdir)}/predictor"
     predictor.dump(output_path)
@@ -102,8 +107,14 @@ def test_dump_load_preserves_matrices(tmpdir):
     )
 
 
-def test_prediction_shape():
-    input_size = 15
+@pytest.mark.parametrize("nz, nvars", [(1, 1), (3, 1), (3, 3), (1, 3)])
+def test_prediction_shape(nz, nvars):
+    input_size = (
+        default_rank_divider.subdomain_xy_size_without_overlap ** 2
+        * default_rank_divider.n_subdomains
+        * nz
+    )
+    combined_inputs_size = input_size * nvars
     state_size = 1000
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
@@ -111,22 +122,30 @@ def test_prediction_shape():
         spectral_radius=1.0,
         input_coupling_sparsity=0,
     )
-    reservoir = Reservoir(hyperparameters, input_size=input_size)
-    reservoir.reset_state(input_shape=(input_size,))
+    reservoir = Reservoir(hyperparameters, input_size=combined_inputs_size)
+    reservoir.reset_state(input_shape=(combined_inputs_size,))
     readout = ReservoirComputingReadout(
-        coefficients=np.random.rand(state_size, input_size),
-        intercepts=np.random.rand(input_size),
+        coefficients=np.random.rand(state_size, combined_inputs_size),
+        intercepts=np.random.rand(combined_inputs_size),
     )
+    transformer = DoNothingAutoencoder(nz)
+    transformer.encode([np.ones((input_size, nz)) for v in range(nvars)])
+    variables = [f"var{i}" for i in range(nvars)]
     predictor = ReservoirComputingModel(
-        input_variables=["a", "b"],
-        output_variables=["a", "b"],
+        input_variables=variables,
+        output_variables=variables,
         reservoir=reservoir,
         readout=readout,
         rank_divider=default_rank_divider,
+        autoencoder=transformer,
     )
     # ReservoirComputingModel.predict reshapes the prediction to remove
     # the first dim of length 1 (sklearn regressors predict 2D arrays)
-    assert predictor.predict().shape == (input_size,)
+    for v in range(nvars):
+        assert predictor.predict()[v].shape == (
+            *predictor.rank_divider.rank_extent_without_overlap,
+            nz,
+        )
 
 
 def test_ReservoirComputingModel_state_increment():
@@ -144,28 +163,39 @@ def test_ReservoirComputingModel_state_increment():
     reservoir.W_res = sparse.coo_matrix(np.ones(reservoir.W_res.shape))
 
     readout = MultiOutputMeanRegressor(n_outputs=input_size)
+
+    input = 0.25 * np.ones((input_size, 1))
+
+    transformer = DoNothingAutoencoder(1)
+    transformer.encode(input)
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
         rank_divider=rank_divider,
+        autoencoder=transformer,
     )
 
-    input = 0.25 * np.ones((input_size, 1))
     predictor.reset_state()
     predictor.reservoir.increment_state(input)
     state_before_prediction = predictor.reservoir.state
-    prediction = predictor.predict()
-    predictor.increment_state(prediction)
+    encoded_prediction = predictor.autoencoder.encode(predictor.predict())
+    flattened_encoded_prediction = encoded_prediction.reshape(-1)
+    predictor.increment_state(flattened_encoded_prediction)
     # TODO: Need to update the expected prediction shape to be in original dims
     # after those changes are made to the ReservoirModel input/output
-    np.testing.assert_array_almost_equal(prediction, np.tanh(np.ones(input_size)))
+    np.testing.assert_array_almost_equal(
+        flattened_encoded_prediction, np.tanh(np.ones(input_size))
+    )
     assert not np.allclose(state_before_prediction, predictor.reservoir.state)
 
 
 def test_prediction_after_load(tmpdir):
-    input_size = 15
+    input_size = (
+        default_rank_divider.subdomain_xy_size_without_overlap ** 2
+        * default_rank_divider.n_subdomains
+    )
     state_size = 1000
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
@@ -179,16 +209,20 @@ def test_prediction_after_load(tmpdir):
         coefficients=np.random.rand(state_size, input_size),
         intercepts=np.random.rand(input_size),
     )
+
+    transformer = DoNothingAutoencoder(1)
+    transformer.encode([np.ones((input_size, 1))])
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],
         output_variables=["a", "b"],
         reservoir=reservoir,
         readout=readout,
         rank_divider=default_rank_divider,
+        autoencoder=transformer,
     )
     predictor.reset_state()
 
-    ts_sync = [np.ones(input_size) for i in range(20)]
+    ts_sync = [np.ones((input_size, 1)) for i in range(20)]
     predictor.synchronize(ts_sync)
     for i in range(10):
         prediction0 = predictor.predict()
@@ -201,14 +235,16 @@ def test_prediction_after_load(tmpdir):
     loaded_predictor.synchronize(ts_sync)
     for i in range(10):
         prediction1 = loaded_predictor.predict()
-
-    np.testing.assert_array_almost_equal(prediction0, prediction1)
+    np.testing.assert_array_almost_equal(prediction0[0], prediction1[0])
 
 
 def test_HybridReservoirComputingModel_dump_load(tmpdir):
-    input_size = 15
     state_size = 1000
     rank_divider = default_rank_divider
+    input_size = (
+        rank_divider.subdomain_xy_size_without_overlap ** 2 * rank_divider.n_subdomains
+    )
+
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
         adjacency_matrix_sparsity=0.9,
@@ -232,6 +268,7 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
         reservoir=reservoir,
         readout=readout,
         rank_divider=rank_divider,
+        autoencoder=DoNothingAutoencoder(1),
     )
     hybrid_predictor.reset_state()
     ts_sync = [
@@ -241,7 +278,9 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
 
     hybrid_predictor.synchronize(ts_sync)
 
-    hybrid_input = np.random.rand(*rank_divider.subdomain_layout)
+    hybrid_input = [
+        np.random.rand(*rank_divider.rank_extent),
+    ]
     prediction0 = hybrid_predictor.predict(hybrid_input)
 
     output_path = f"{str(tmpdir)}/predictor"
@@ -284,6 +323,7 @@ def test_HybridReservoirComputingModel_concat_readout_inputs():
         reservoir=reservoir,
         readout=readout,
         rank_divider=rank_divider,
+        autoencoder=DoNothingAutoencoder(1),
     )
     hybrid_predictor.reset_state()
 
@@ -294,9 +334,11 @@ def test_HybridReservoirComputingModel_concat_readout_inputs():
 
     # partitioner indexing goes (0,0) -> 0, (1,0)-> 1, etc.
     hybrid_inputs = np.array([[0, -2], [-1, -3]])
-
+    flat_hybrid_inputs = hybrid_predictor.rank_divider.flatten_subdomains_to_columns(
+        hybrid_inputs, with_overlap=False
+    )
     flattened_readout_input = hybrid_predictor._concatenate_readout_inputs(
-        hybrid_predictor.reservoir_model.reservoir.state, hybrid_inputs
+        hybrid_predictor.reservoir_model.reservoir.state, flat_hybrid_inputs
     )
     np.testing.assert_array_equal(
         flattened_readout_input,

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from fv3fit.reservoir.transformers.transformer import (
+    encode_columns,
+    DoNothingAutoencoder,
+    decode_columns,
+)
+
+
+@pytest.mark.parametrize(
+    "nt, nx, ny, nz, nvars",
+    [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],
+)
+def test_encode_columns(nt, nx, ny, nz, nvars):
+    shape = tuple([y for y in [nt, nx, ny, nz] if y is not None])
+    expected_shape = (*shape[:-1], nz * nvars) if nz is not None else shape
+    transformer = DoNothingAutoencoder(nz)
+    data_arrs = [np.random.rand(*shape) for var in range(nvars)]
+
+    encoded = encode_columns(data_arrs, transformer=transformer)
+
+    assert encoded.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "nx, ny, nz, nvars", [(4, 4, 3, 2), (2, 2, 1, 1), (2, 2, 1, 2)]
+)
+def test_decode_columns(nx, ny, nz, nvars):
+    expected_shapes = [
+        tuple([y for y in [nx, ny, nz] if y is not None]) for var in range(nvars)
+    ]
+
+    encoded_input_shape = (
+        (*expected_shapes[0][:-1], nz * nvars) if nz is not None else expected_shapes[0]
+    )
+    transformer = DoNothingAutoencoder(nz * nvars)
+
+    # need to call encode before decode
+    data_arrs = [np.random.rand(*shape) for shape in expected_shapes]
+    transformer.encode(data_arrs)
+
+    encoded_input = np.random.rand(*encoded_input_shape)
+    # pdb.set_trace()
+    decoded = decode_columns(encoded_input, transformer=transformer, xy_shape=(nx, ny))
+
+    assert len(expected_shapes) == len(decoded)
+    for expected_shape, decoded_output in zip(expected_shapes, decoded):
+        assert expected_shape == decoded_output.shape

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -8,6 +8,17 @@ from fv3fit.reservoir.transformers.transformer import (
 )
 
 
+@pytest.mark.parametrize("nz, nvars", [(2, 2), (2, 1), (1, 2), (1, 1)])
+def test_DoNothingAutoencoder(nz, nvars):
+    nx = 5
+    transformer = DoNothingAutoencoder(nz)
+    data = [np.ones((nx, nz)) for var in range(nvars)]
+    transformer.encode(data)
+    assert transformer.original_feature_sizes == [nz for var in range(nvars)]
+    encoded_data = np.ones(nz * nvars)
+    assert len(transformer.decode(encoded_data)) == len(data)
+
+
 @pytest.mark.parametrize(
     "nt, nx, ny, nz, nvars",
     [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],


### PR DESCRIPTION


Refactored public API:
-  This PR moves array reshaping and encoding/decoding of inputs and outputs into the base reservoir models. Previously these were done by the hybrid adapter. Having the base models handle these operations makes offline predictions easier and simplifies the public API for the base models. Input into the hybrid model `predict` method is assumed to be in the native (x,y,z) format instead of a flattened array. Now, `predict` returns np arrays for each variable in the native (x, y, z) coords.
- Made the `autoencoder` a required arg instead of optional to the reservoir models. All models trained using the training code have an autoencoder by default.
  
Significant internal changes:
- Refactored above functionality out of the hybrid adapter, now it handles converting xr datasets to arrays but otherwise relies on its base model to handle reshaping and encoding/decoding.
- Moved the `DoNothingAutoencoder` to `reservoir.transformers.transformer` since it is a generally useful class for tests and even training (if you do not want to standardize inputs). Added dump/load methods to it.

Updated tests to expect the new 
- [x] Tests added
