### PR TITLE
Simplify rankdividers

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/_reshaping.py
+++ b/external/fv3fit/fv3fit/reservoir/_reshaping.py
@@ -14,27 +14,11 @@ def concat_inputs_along_subdomain_features(a, b):
     return np.concatenate([a, b], axis=1)
 
 
-def stack_data(tensor, keep_first_dim: bool):
-    # Used to reshape a subdomains into a flat columns.
-    # Option to keep first dim, used in the case where time is the first dimension
-    if keep_first_dim is True:
-        n_samples = tensor.shape[0]
-        return np.reshape(tensor, (n_samples, -1))
-    else:
-        return np.reshape(tensor, -1)
-
-
-def split_1d_samples_into_2d_rows(
-    arr: np.ndarray, n_rows: int, keep_first_dim_shape: bool
-) -> np.ndarray:
+def split_1d_samples_into_2d_rows(arr: np.ndarray, n_rows: int) -> np.ndarray:
     # Consecutive chunks of 1d array form rows of 2d array
     # ex. 1d to 2d reshaping (8,) -> (2,4) for n_rows=2
     # [1,2,3,4,5,6,7,8] -> [[1,2,3,4], [5,6,7,8]]
-    if keep_first_dim_shape is True:
-        time_dim_size = arr.shape[0]
-        return np.reshape(arr, (time_dim_size, n_rows, -1), order="C")
-    else:
-        return np.reshape(arr, (n_rows, -1), order="C")
+    return np.reshape(arr, (n_rows, -1), order="C")
 
 
 def stack_array_preserving_last_dim(data):

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 from typing import Sequence, Iterable
 import yaml
-from ._reshaping import stack_data, split_1d_samples_into_2d_rows
+from ._reshaping import split_1d_samples_into_2d_rows
 import pace.util
 
 
@@ -183,9 +183,7 @@ class RankDivider:
             subdomain_data = self.get_subdomain_tensor_slice(
                 data, subdomain_index=s, with_overlap=with_overlap,
             )
-            subdomains_to_columns.append(
-                stack_data(subdomain_data, keep_first_dim=False)
-            )
+            subdomains_to_columns.append(np.reshape(subdomain_data, -1))
 
         # Concatentate subdomain data arrays along a new subdomain axis.
         # Dimensions are now [time, feature, submdomain]
@@ -219,7 +217,7 @@ class RankDivider:
 
         # separate the prediction into its constituent subdomains
         subdomain_rows = split_1d_samples_into_2d_rows(
-            flat_prediction, n_rows=self.n_subdomains, keep_first_dim_shape=False,
+            flat_prediction, n_rows=self.n_subdomains
         )
         subdomain_2d_predictions = []
 

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -18,12 +18,10 @@ from . import (
     ReservoirComputingReadout,
 )
 from .readout import combine_readouts
-from .domain import TimeSeriesRankDivider, RankDivider, assure_same_dims
+from .domain import RankDivider, assure_same_dims
 from ._reshaping import stack_data
 from fv3fit.reservoir.transformers import ReloadableTransfomer
 
-import time
-import pdb 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -83,13 +81,7 @@ def train_reservoir_model(
 
     # sample_X[0] is the first data variable, shape elements 1:-1 are the x,y shape
     rank_extent = sample_X[0].shape[1:-1]
-    rank_divider = TimeSeriesRankDivider(
-        subdomain_layout=subdomain_config.layout,
-        rank_dims=subdomain_config.rank_dims,
-        rank_extent=rank_extent,
-        overlap=subdomain_config.overlap,
-    )
-    rank_divider_spatial_only = RankDivider(
+    rank_divider = RankDivider(
         subdomain_layout=subdomain_config.layout,
         rank_dims=subdomain_config.rank_dims,
         rank_extent=rank_extent,
@@ -109,23 +101,12 @@ def train_reservoir_model(
         for r in range(rank_divider.n_subdomains)
     ]
     for b, batch_data in enumerate(train_batches):
-        t0 = time.time()
         time_series_with_overlap, time_series_without_overlap = _process_batch_Xy_data(
             variables=hyperparameters.input_variables,
             batch_data=batch_data,
             rank_divider=rank_divider,
             autoencoder=autoencoder,
         )
-        print(f"TimeSeriesRankDivider processing time: {time.time()-t0} s")
-
-        t1 = time.time()
-        _time_series_with_overlap, _time_series_without_overlap = _process_batch_Xy_data_time_loop(
-            variables=hyperparameters.input_variables,
-            batch_data=batch_data,
-            rank_divider=rank_divider_spatial_only,
-            autoencoder=autoencoder,
-        )
-        print(f"RankDivider processing time: {time.time()-t1} s")
 
         if b < hyperparameters.n_batches_burn:
             logger.info(f"Synchronizing on batch {b+1}")
@@ -199,12 +180,13 @@ def train_reservoir_model(
         )
     return model
 
-def _process_batch_Xy_data_time_loop(
+
+def _process_batch_Xy_data(
     variables: Iterable[str],
     batch_data: Mapping[str, tf.Tensor],
     rank_divider: RankDivider,
     autoencoder: ReloadableTransfomer,
-) -> Tuple[np.ndarray, np.ndarray]:    
+) -> Tuple[np.ndarray, np.ndarray]:
     """ Convert physical state to corresponding reservoir hidden state,
     and reshape data into the format used in training.
     """
@@ -240,54 +222,13 @@ def _process_batch_Xy_data_time_loop(
         X_reshaped = np.stack(X_subdomains_as_columns, axis=-1)
         Y_reshaped = np.stack(Y_subdomains_as_columns, axis=-1)
 
-
         time_series_X_reshaped.append(X_reshaped)
         time_series_Y_reshaped.append(Y_reshaped)
-    
+
     return (
         np.stack(time_series_X_reshaped, axis=0),
-        np.stack(time_series_Y_reshaped, axis=0)
+        np.stack(time_series_Y_reshaped, axis=0),
     )
-
-def _process_batch_Xy_data(
-    variables: Iterable[str],
-    batch_data: Mapping[str, tf.Tensor],
-    rank_divider: TimeSeriesRankDivider,
-    autoencoder: ReloadableTransfomer,
-) -> Tuple[np.ndarray, np.ndarray]:
-    """ Convert physical state to corresponding reservoir hidden state,
-    and reshape data into the format used in training.
-    """
-    batch_X = _get_ordered_X(batch_data, variables)
-
-    # Concatenate features, normalize and optionally convert data
-    # to latent representation
-    batch_data_encoded = _encode_columns(batch_X, autoencoder)
-    # Divide into subdomains and flatten each subdomain by stacking
-    # x/y/encoded-feature dims into a single subdomain-feature dimension.
-    # Dimensions of a single subdomain's data become [time, subdomain-feature]
-    X_subdomains_as_columns, Y_subdomains_as_columns = [], []
-    for s in range(rank_divider.n_subdomains):
-        X_subdomain_data = rank_divider.get_subdomain_tensor_slice(
-            batch_data_encoded, subdomain_index=s, with_overlap=True,
-        )
-        X_subdomains_as_columns.append(
-            stack_data(X_subdomain_data, keep_first_dim=True)
-        )
-
-        # Prediction does not include overlap
-        Y_subdomain_data = rank_divider.get_subdomain_tensor_slice(
-            batch_data_encoded, subdomain_index=s, with_overlap=False,
-        )
-        Y_subdomains_as_columns.append(
-            stack_data(Y_subdomain_data, keep_first_dim=True)
-        )
-
-    # Concatentate subdomain data arrays along a new subdomain axis.
-    # Dimensions are now [time, subdomain-feature, subdomain]
-    X_reshaped = np.stack(X_subdomains_as_columns, axis=-1)
-    Y_reshaped = np.stack(Y_subdomains_as_columns, axis=-1)
-    return X_reshaped, Y_reshaped
 
 
 def _get_reservoir_state_time_series(

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -6,7 +6,7 @@ import numpy as np
 import tensorflow as tf
 from typing import Optional, List, Union
 from .. import Predictor
-from .utils import square_even_terms, process_batch_Xy_data
+from .utils import square_even_terms, process_batch_Xy_data, get_ordered_X
 from .transformers.autoencoder import build_concat_and_scale_only_autoencoder
 from .._shared import register_training_function
 from ._reshaping import concat_inputs_along_subdomain_features
@@ -18,7 +18,7 @@ from . import (
     ReservoirComputingReadout,
 )
 from .readout import combine_readouts
-from .domain import RankDivider, assure_same_dims
+from .domain import RankDivider
 from ._reshaping import stack_array_preserving_last_dim
 from fv3fit.reservoir.transformers import ReloadableTransfomer
 
@@ -31,11 +31,6 @@ def _add_input_noise(arr: np.ndarray, stddev: float) -> np.ndarray:
     return arr + np.random.normal(loc=0, scale=stddev, size=arr.shape)
 
 
-def _get_ordered_X(X_mapping, variables):
-    ordered_tensors = [X_mapping[v] for v in variables]
-    return assure_same_dims(ordered_tensors)
-
-
 @register_training_function("reservoir", ReservoirTrainingConfig)
 def train_reservoir_model(
     hyperparameters: ReservoirTrainingConfig,
@@ -44,7 +39,7 @@ def train_reservoir_model(
 ) -> Predictor:
 
     sample_batch = next(iter(train_batches))
-    sample_X = _get_ordered_X(sample_batch, hyperparameters.input_variables)
+    sample_X = get_ordered_X(sample_batch, hyperparameters.input_variables)
 
     if hyperparameters.autoencoder_path is not None:
         autoencoder: ReloadableTransfomer = fv3fit.load(

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -1,4 +1,9 @@
 import numpy as np
+import tensorflow as tf
+from typing import Iterable, Mapping, Tuple
+from fv3fit.reservoir._reshaping import stack_data
+from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
+from fv3fit.reservoir.domain import RankDivider, assure_same_dims
 
 
 def _square_evens(v: np.ndarray) -> np.ndarray:
@@ -12,3 +17,58 @@ def _square_evens(v: np.ndarray) -> np.ndarray:
 
 def square_even_terms(v: np.ndarray, axis=1) -> np.ndarray:
     return np.apply_along_axis(func1d=_square_evens, axis=axis, arr=v)
+
+
+def _get_ordered_X(X_mapping, variables):
+    ordered_tensors = [X_mapping[v] for v in variables]
+    return assure_same_dims(ordered_tensors)
+
+
+def process_batch_Xy_data(
+    variables: Iterable[str],
+    batch_data: Mapping[str, tf.Tensor],
+    rank_divider: RankDivider,
+    autoencoder: ReloadableTransfomer,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """ Convert physical state to corresponding reservoir hidden state,
+    and reshape data into the format used in training.
+    """
+    batch_X = _get_ordered_X(batch_data, variables)
+
+    # Concatenate features, normalize and optionally convert data
+    # to latent representation
+    batch_data_encoded = encode_columns(batch_X, autoencoder)
+
+    time_series_X_reshaped, time_series_Y_reshaped = [], []
+    for timestep_data in batch_data_encoded:
+        # Divide into subdomains and flatten each subdomain by stacking
+        # x/y/encoded-feature dims into a single subdomain-feature dimension.
+        # Dimensions of a single subdomain's data become [time, subdomain-feature]
+        X_subdomains_as_columns, Y_subdomains_as_columns = [], []
+        for s in range(rank_divider.n_subdomains):
+            X_subdomain_data = rank_divider.get_subdomain_tensor_slice(
+                timestep_data, subdomain_index=s, with_overlap=True,
+            )
+            X_subdomains_as_columns.append(
+                stack_data(X_subdomain_data, keep_first_dim=False)
+            )
+
+            # Prediction does not include overlap
+            Y_subdomain_data = rank_divider.get_subdomain_tensor_slice(
+                timestep_data, subdomain_index=s, with_overlap=False,
+            )
+            Y_subdomains_as_columns.append(
+                stack_data(Y_subdomain_data, keep_first_dim=False)
+            )
+        # Concatentate subdomain data arrays along a new subdomain axis.
+        # Dimensions are now [time, subdomain-feature, subdomain]
+        X_reshaped = np.stack(X_subdomains_as_columns, axis=-1)
+        Y_reshaped = np.stack(Y_subdomains_as_columns, axis=-1)
+
+        time_series_X_reshaped.append(X_reshaped)
+        time_series_Y_reshaped.append(Y_reshaped)
+
+    return (
+        np.stack(time_series_X_reshaped, axis=0),
+        np.stack(time_series_Y_reshaped, axis=0),
+    )

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -18,7 +18,7 @@ def square_even_terms(v: np.ndarray, axis=1) -> np.ndarray:
     return np.apply_along_axis(func1d=_square_evens, axis=axis, arr=v)
 
 
-def _get_ordered_X(X_mapping, variables):
+def get_ordered_X(X_mapping, variables):
     ordered_tensors = [X_mapping[v] for v in variables]
     return assure_same_dims(ordered_tensors)
 
@@ -32,7 +32,7 @@ def process_batch_Xy_data(
     """ Convert physical state to corresponding reservoir hidden state,
     and reshape data into the format used in training.
     """
-    batch_X = _get_ordered_X(batch_data, variables)
+    batch_X = get_ordered_X(batch_data, variables)
 
     # Concatenate features, normalize and optionally convert data
     # to latent representation

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -18,8 +18,8 @@ def square_even_terms(v: np.ndarray, axis=1) -> np.ndarray:
     return np.apply_along_axis(func1d=_square_evens, axis=axis, arr=v)
 
 
-def get_ordered_X(X_mapping, variables):
-    ordered_tensors = [X_mapping[v] for v in variables]
+def get_ordered_X(X: Mapping[str, tf.Tensor], variables: Iterable[str]):
+    ordered_tensors = [X[v] for v in variables]
     return assure_same_dims(ordered_tensors)
 
 

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import tensorflow as tf
 from typing import Iterable, Mapping, Tuple
-from fv3fit.reservoir._reshaping import stack_data
 from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
 from fv3fit.reservoir.domain import RankDivider, assure_same_dims
 
@@ -49,17 +48,13 @@ def process_batch_Xy_data(
             X_subdomain_data = rank_divider.get_subdomain_tensor_slice(
                 timestep_data, subdomain_index=s, with_overlap=True,
             )
-            X_subdomains_as_columns.append(
-                stack_data(X_subdomain_data, keep_first_dim=False)
-            )
+            X_subdomains_as_columns.append(np.reshape(X_subdomain_data, -1))
 
             # Prediction does not include overlap
             Y_subdomain_data = rank_divider.get_subdomain_tensor_slice(
                 timestep_data, subdomain_index=s, with_overlap=False,
             )
-            Y_subdomains_as_columns.append(
-                stack_data(Y_subdomain_data, keep_first_dim=False)
-            )
+            Y_subdomains_as_columns.append(np.reshape(Y_subdomain_data, -1))
         # Concatentate subdomain data arrays along a new subdomain axis.
         # Dimensions are now [time, subdomain-feature, subdomain]
         X_reshaped = np.stack(X_subdomains_as_columns, axis=-1)

--- a/external/fv3fit/tests/reservoir/test__reshaping.py
+++ b/external/fv3fit/tests/reservoir/test__reshaping.py
@@ -2,25 +2,8 @@ import numpy as np
 
 from fv3fit.reservoir._reshaping import (
     flatten_2d_keeping_columns_contiguous,
-    stack_data,
     split_1d_samples_into_2d_rows,
 )
-
-
-def test_stack_data_has_time_dim():
-    time_series = np.array([np.ones((2, 2)) * i for i in range(10)])
-    stacked = stack_data(time_series, keep_first_dim=True)
-    assert stacked.shape == (10, 4)
-    np.testing.assert_array_equal(stacked[-1], np.array([9, 9, 9, 9]))
-
-
-def test_stack_data_no_time_dim():
-    data = [
-        np.arange(4).reshape(2, 2),
-        -1 * np.arange(4).reshape(2, 2),
-    ]
-    stacked = stack_data(data, keep_first_dim=False)
-    np.testing.assert_array_equal(stacked, np.array([0, 1, 2, 3, 0, -1, -2, -3]))
 
 
 def test_flatten_2d_keeping_columns_contiguous():
@@ -32,19 +15,7 @@ def test_flatten_2d_keeping_columns_contiguous():
 
 def test_split_1d_samples_into_2d_rows():
     x = np.arange(12)
-    x_2d = split_1d_samples_into_2d_rows(x, n_rows=4, keep_first_dim_shape=False)
+    x_2d = split_1d_samples_into_2d_rows(x, n_rows=4)
     np.testing.assert_array_equal(
         x_2d, np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]])
     )
-
-
-def test_split_1d_samples_into_2d_rows_keep_first_dim_shape():
-    nt = 3
-    x = np.array([np.arange(12) for i in range(nt)])
-    x_2d = split_1d_samples_into_2d_rows(x, n_rows=4, keep_first_dim_shape=True)
-
-    expected = np.array(
-        [np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]]) for i in range(nt)]
-    )
-
-    np.testing.assert_array_equal(x_2d, expected)

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -3,7 +3,6 @@ import pytest
 from fv3fit.reservoir.domain import (
     slice_along_axis,
     RankDivider,
-    TimeSeriesRankDivider,
     assure_same_dims,
 )
 from fv3fit.reservoir._reshaping import stack_data
@@ -87,26 +86,6 @@ def test_RankDivider_subdomain_slice():
     assert divider.subdomain_slice(3, with_overlap=False) == (slice(3, 5), slice(3, 5))
 
 
-def test_TimeSeriesRankDivider_subdomain_tensor_slice_overlap():
-    xy_arr = np.pad(np.arange(1, 5).reshape(2, 2), pad_width=1)
-    arr = np.reshape(xy_arr, (1, 4, 4, 1))
-    divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[4, 4], overlap=1,
-    )
-    bottom_right_with_overlap = divider.get_subdomain_tensor_slice(
-        arr, 3, with_overlap=True,
-    )
-    np.testing.assert_array_equal(
-        bottom_right_with_overlap[0, :, :, 0],
-        np.array([[1, 2, 0], [3, 4, 0], [0, 0, 0]]),
-    )
-
-    bottom_right_no_overlap = divider.get_subdomain_tensor_slice(
-        arr, 3, with_overlap=False,
-    )
-    np.testing.assert_array_equal(bottom_right_no_overlap[0, :, :, 0], np.array([[4]]))
-
-
 def test_RankDivider_subdomain_tensor_slice_overlap():
     xy_arr = np.pad(np.arange(1, 5).reshape(2, 2), pad_width=1)
     arr = np.reshape(xy_arr, (4, 4, 1))
@@ -126,22 +105,6 @@ def test_RankDivider_subdomain_tensor_slice_overlap():
     np.testing.assert_array_equal(bottom_right_no_overlap[:, :, 0], np.array([[4]]))
 
 
-def test_TimeSeriesRankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
-    divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[2, 2], overlap=0,
-    )
-    arr = np.arange(1, 5).reshape(1, 2, 2, 1)
-    subdomain_values = []
-    for s in range(divider.n_subdomains):
-        subdomain_values.append(
-            divider.get_subdomain_tensor_slice(arr, s, with_overlap=False)
-            .flatten()
-            .item()
-        )
-
-    assert set(subdomain_values) == {1, 2, 3, 4}
-
-
 def test_RankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
     divider = RankDivider(
         subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[2, 2], overlap=0,
@@ -155,34 +118,6 @@ def test_RankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
             .item()
         )
     assert set(subdomain_values) == {1, 2, 3, 4}
-
-
-@pytest.mark.parametrize(
-    "data_extent, overlap, with_overlap, ",
-    [
-        ([5, 6, 6], 1, True),
-        ([5, 6, 6], 1, True),
-        ([5, 6, 6], 1, False),
-        ([5, 6, 6], 0, True),
-        ([1, 4, 4], 0, False),
-    ],
-)
-def test_TimeSeriesRankDivider_unstack_subdomain(data_extent, overlap, with_overlap):
-    divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2),
-        rank_dims=["x", "y"],
-        rank_extent=data_extent[1:],
-        overlap=overlap,
-    )
-    data_arr = np.arange(np.prod(data_extent)).reshape(*data_extent)
-    subdomain_arr = divider.get_subdomain_tensor_slice(
-        data_arr, 0, with_overlap=with_overlap,
-    )
-    stacked = stack_data(subdomain_arr, keep_first_dim=True)
-    assert len(stacked.shape) == 2
-    np.testing.assert_array_equal(
-        divider.unstack_subdomain(stacked, with_overlap=with_overlap), subdomain_arr,
-    )
 
 
 @pytest.mark.parametrize(
@@ -211,48 +146,6 @@ def test_RankDivider_unstack_subdomain(data_extent, overlap, with_overlap, nz):
     assert len(stacked.shape) == 1
     np.testing.assert_array_equal(
         divider.unstack_subdomain(stacked, with_overlap=with_overlap), subdomain_arr,
-    )
-
-
-def test_TimeSeriesRankDivider_flatten_subdomains_to_columns():
-    nx, ny = 6, 6
-    divider = TimeSeriesRankDivider(
-        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[nx, ny], overlap=1,
-    )
-    input = np.array(
-        [[0, 1, 10, 11], [2, 3, 12, 13], [20, 21, 30, 31], [22, 23, 32, 33]]
-    )
-    input_with_halo = np.pad(input, pad_width=1)
-    # add time dim of length 2
-    input_with_halo = np.stack([input_with_halo, input_with_halo], axis=0)
-    flattened = divider.flatten_subdomains_to_columns(
-        input_with_halo, with_overlap=True,
-    )
-
-    # 4 subdomains each with x, y dims (4, 4)
-    # subdomain layout ranks are [[0, 2],[1, 3]] on square
-    assert flattened.shape == (2, 16, 4)
-    # subdomain 0
-    np.testing.assert_array_almost_equal(
-        flattened[0, :, 0],
-        np.array([0, 0, 0, 0, 0, 0, 1, 10, 0, 2, 3, 12, 0, 20, 21, 30]),
-    )
-
-    # subdomain 2
-    np.testing.assert_array_almost_equal(
-        flattened[0, :, 2],
-        np.array([0, 0, 0, 0, 1, 10, 11, 0, 3, 12, 13, 0, 21, 30, 31, 0]),
-    )
-    # subdomain 1
-    np.testing.assert_array_almost_equal(
-        flattened[0, :, 1],
-        np.array([0, 2, 3, 12, 0, 20, 21, 30, 0, 22, 23, 32, 0, 0, 0, 0]),
-    )
-
-    # subdomain 2
-    np.testing.assert_array_almost_equal(
-        flattened[0, :, 3],
-        np.array([3, 12, 13, 0, 21, 30, 31, 0, 23, 32, 33, 0, 0, 0, 0, 0]),
     )
 
 

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -5,7 +5,6 @@ from fv3fit.reservoir.domain import (
     RankDivider,
     assure_same_dims,
 )
-from fv3fit.reservoir._reshaping import stack_data
 
 
 arr = np.arange(3)
@@ -142,7 +141,7 @@ def test_RankDivider_unstack_subdomain(data_extent, overlap, with_overlap, nz):
     subdomain_arr = divider.get_subdomain_tensor_slice(
         data_arr, 0, with_overlap=with_overlap,
     )
-    stacked = stack_data(subdomain_arr, keep_first_dim=False)
+    stacked = np.reshape(subdomain_arr, -1)
     assert len(stacked.shape) == 1
     np.testing.assert_array_equal(
         divider.unstack_subdomain(stacked, with_overlap=with_overlap), subdomain_arr,

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
-from fv3fit.reservoir.utils import square_even_terms
+from fv3fit.reservoir.utils import square_even_terms, process_batch_Xy_data
+from fv3fit.reservoir.transformers import DoNothingAutoencoder
+from fv3fit.reservoir.domain import RankDivider
 
 
 @pytest.mark.parametrize(
@@ -18,3 +20,44 @@ from fv3fit.reservoir.utils import square_even_terms
 )
 def test__square_even_terms(arr, axis, expected):
     np.testing.assert_array_equal(square_even_terms(arr, axis=axis), expected)
+
+
+@pytest.mark.parametrize("nz", [1, 3])
+def test_process_batch_Xy_data(nz):
+    overlap = 1
+    nvars = 2
+    nt, nx, ny = 10, 8, 8
+    subdomain_layout = [2, 2]
+    rank_divider = RankDivider(
+        subdomain_layout=subdomain_layout,
+        rank_dims=["x", "y"],
+        rank_extent=[nx, ny],
+        overlap=overlap,
+    )
+    autoencoder = DoNothingAutoencoder([nz, nz])
+    batch_data = {
+        "a": np.ones((nt, nx, ny, nz)),
+        "b": np.ones((nt, nx, ny, nz)),
+    }
+    time_series_with_overlap, time_series_without_overlap = process_batch_Xy_data(
+        variables=["a", "b"],
+        batch_data=batch_data,
+        rank_divider=rank_divider,
+        autoencoder=autoencoder,
+    )
+    features_per_subdomain_with_overlap = (
+        np.prod(rank_divider.get_subdomain_extent(True)) * nvars * nz
+    )
+    features_per_subdomain_without_overlap = (
+        np.prod(rank_divider.get_subdomain_extent(False)) * nvars * nz
+    )
+    assert time_series_with_overlap.shape == (
+        nt,
+        features_per_subdomain_with_overlap,
+        rank_divider.n_subdomains,
+    )
+    assert time_series_without_overlap.shape == (
+        nt,
+        features_per_subdomain_without_overlap,
+        rank_divider.n_subdomains,
+    )


### PR DESCRIPTION
In investigating [this issue](https://github.com/orgs/ai2cm/projects/4/views/1?pane=issue&itemId=31907382) I found that using the spatial-only `RankDivider` class to slice data into subdomains within a loop over timesteps was actually faster than using the `TimeSeriesRankDivider` class to do the slicing directly on the full array with a time dim (not sure why- maybe the slicing implementation is weird). See issue for timing details.

Therefore I decided to just remove the `TimeSeriesRankDivider` in order to simplify the codebase. This also allows for some helper functions to be deleted or simplifed since we don't need to provide the option of operating on an array with a time dimension- it is now assumed that the input arrays will have dims (x, y, z_feature/encoded_feature).

I updated the function `process_batch_Xy_data` to handle the data processing inside a loop over timesteps, and moved this function into `utils.py` so the tests were more organized.

There's a decent number of files with changes but most are just related to the deleted or simplified helpers, plus moving `process_batch_Xy_data`  to the utils module. The main change to review is within `process_batch_Xy_data`  where the loop over timesteps was added. This is hard to see in the file diff, since that function was moved to another module, so here is a diff of what changed in that function: https://www.diffchecker.com/FKtr1Z8o/


- [x] Tests added

Resolves https://github.com/ai2cm/fv3net/issues/2275

Coverage reports (updated automatically):
