### PR TITLE
Ensure all input arrays to reservoir have a feature dimension

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -317,18 +317,19 @@ class TimeSeriesRankDivider(RankDivider):
         return reshaped
 
 
-def assure_same_dims(variable_tensors: Iterable[tf.Tensor]) -> Iterable[tf.Tensor]:
-    max_dims = max(len(v.shape) for v in variable_tensors)
+def assure_txyz_dims(variable_tensors: Iterable[tf.Tensor]) -> Iterable[tf.Tensor]:
+    # Assumes dims 1, 2, 3 are t, x, y.
+    # If variable data has 3 dims, adds a 4th feature dim of size 1.
     reshaped_tensors = []
     for var_data in variable_tensors:
-        if len(var_data.shape) == max_dims:
+        if len(var_data.shape) == 4:
             reshaped_tensors.append(var_data)
-        elif len(var_data.shape) == max_dims - 1:
+        elif len(var_data.shape) == 3:
             orig_shape = var_data.shape
             reshaped_tensors.append(tf.reshape(var_data, shape=(*orig_shape, 1)))
         else:
             raise ValueError(
                 f"Tensor data has {len(var_data.shape)} dims, must either "
-                f"have either {max_dims} or {max_dims-1}."
+                "have either 4 dims (t, x, y, z) or 3 dims (t, x, y)."
             )
     return reshaped_tensors

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -149,10 +149,12 @@ class HybridDatasetAdapter:
         transposed_inputs = _transpose_xy_dims(
             ds=inputs, rank_dims=self.model.rank_divider.rank_dims
         )
-        input_arrs = [
-            transposed_inputs[variable].values
-            for variable in self.model.input_variables
-        ]
+        input_arrs = []
+        for variable in self.model.input_variables:
+            da = transposed_inputs[variable]
+            if "z" not in da.dims:
+                da = da.expand_dims("z", axis=-1)
+            input_arrs.append(da.values)
         return input_arrs
 
     def _output_array_to_ds(

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -18,7 +18,7 @@ from . import (
     ReservoirComputingReadout,
 )
 from .readout import combine_readouts
-from .domain import TimeSeriesRankDivider, assure_same_dims
+from .domain import TimeSeriesRankDivider, assure_txyz_dims
 from ._reshaping import stack_data
 from fv3fit.reservoir.transformers import ReloadableTransfomer
 
@@ -51,7 +51,7 @@ def _encode_columns(
 
 def _get_ordered_X(X_mapping, variables):
     ordered_tensors = [X_mapping[v] for v in variables]
-    return assure_same_dims(ordered_tensors)
+    return assure_txyz_dims(ordered_tensors)
 
 
 @register_training_function("reservoir", ReservoirTrainingConfig)

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -4,7 +4,7 @@ from fv3fit.reservoir.domain import (
     slice_along_axis,
     RankDivider,
     TimeSeriesRankDivider,
-    assure_same_dims,
+    assure_txyz_dims,
 )
 from fv3fit.reservoir._reshaping import stack_data
 
@@ -32,22 +32,30 @@ default_rank_divider_kwargs = {
 }
 
 
-def test_assure_same_dims():
+def test_assure_txyz_dims():
     nt, nx, ny, nz = 5, 4, 4, 6
     arr_3d = np.ones((nt, nx, ny, nz))
     arr_2d = np.ones((nt, nx, ny))
     data = [arr_3d, arr_2d]
-    assert assure_same_dims(data)[0].shape == (nt, nx, ny, nz)
-    assert assure_same_dims(data)[1].shape == (nt, nx, ny, 1)
+    assert assure_txyz_dims(data)[0].shape == (nt, nx, ny, nz)
+    assert assure_txyz_dims(data)[1].shape == (nt, nx, ny, 1)
 
 
-def test_assure_same_dims_incompatible_shapes():
+def test_assure_txyz_dims_2d_only_inputs():
+    nt, nx, ny = 5, 4, 4
+    arr_2d = np.ones((nt, nx, ny))
+    data = [arr_2d, arr_2d]
+    for arr in assure_txyz_dims(data):
+        assert arr.shape == (nt, nx, ny, 1)
+
+
+def test_assure_txyz_dims_incompatible_shapes():
     nt, nx, ny, nz = 5, 4, 4, 6
     arr_3d = np.ones((nt, nx, ny, nz, 2))
     arr_2d = np.ones((nt, nx, ny))
     data = [arr_3d, arr_2d]
     with pytest.raises(ValueError):
-        assure_same_dims(data)
+        assure_txyz_dims(data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The changes in this PR ensure that the arrays in the reservoir training and reservoir model prediction always have a feature dimension, even if the variables are 2D (feature dim is size 1 in that case).

See [this issue](https://github.com/ai2cm/fv3net/issues/2273) for more explanation of why these changes are needed.

Resolves https://github.com/ai2cm/fv3net/issues/2273
  

Coverage reports (updated automatically):
