### PR TITLE
`HybridReservoirComputingModel` takes rank data without halo points as input

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -25,6 +25,9 @@ class RankDivider:
         overlap: int,
     ):
         """ Divides a rank of data into subdomains for use in training.
+        When dividing a tensor into subdomains, it is assumed that the input rank
+        data always includes <overlap> number of halo points.
+
         Args:
             subdomain_layout: layout describing subdomain grid within the rank
                 ex. [2,2] means the rank is divided into 4 subdomains
@@ -139,7 +142,13 @@ class RankDivider:
     def get_subdomain_tensor_slice(
         self, tensor_data: tf.Tensor, subdomain_index: int, with_overlap: bool,
     ) -> tf.Tensor:
-
+        if tensor_data.shape[:2] != tuple(self.rank_extent):
+            raise ValueError(
+                f"Data array being divided must be of shape {self.rank_extent}, "
+                f"which is the rank shape {self.rank_extent_without_overlap} plus "
+                f"{self.overlap} halo points. "
+                f"Array provided was shape {tensor_data.shape}"
+            )
         subdomain_slice = self.subdomain_slice(subdomain_index, with_overlap)
         x_ind, y_ind = self._x_ind, self._y_ind
         tensor_data_xsliced = slice_along_axis(

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -131,19 +131,20 @@ def test_RankDivider_get_subdomain_tensor_slice_covers_all_subdomains():
     "data_extent, overlap, with_overlap, nz ",
     [
         ([6, 6], 1, True, 2),
-        ([6, 6], 1, True, 2),
+        ([6, 6], 1, False, 2),
         ([4, 4], 0, False, 2),
         ([6, 6], 1, True, 1),
     ],
 )
 def test_RankDivider_unstack_subdomain(data_extent, overlap, with_overlap, nz):
+
+    xy_shape = [n + 2 * overlap for n in data_extent]
     divider = RankDivider(
         subdomain_layout=(2, 2),
         rank_dims=["x", "y"],
-        rank_extent=data_extent,
+        rank_extent=xy_shape,
         overlap=overlap,
     )
-    xy_shape = data_extent[:2]
     data_shape = (*xy_shape, nz) if nz > 1 else xy_shape
     data_arr = np.random.rand(*data_shape)
     subdomain_arr = divider.get_subdomain_tensor_slice(
@@ -242,3 +243,13 @@ def test_RankDivider_merge_subdomains():
 
     merged = rank_divider.merge_subdomains(prediction)
     np.testing.assert_array_equal(merged, data_orig)
+
+
+def test_RankDivider_get_subdomain_tensor_slice_wrong_input_shape():
+    divider = RankDivider(
+        subdomain_layout=(2, 2), rank_dims=["x", "y"], rank_extent=[6, 6], overlap=1,
+    )
+    with pytest.raises(ValueError):
+        divider.flatten_subdomains_to_columns(
+            np.ones((5, 5)), with_overlap=False,
+        )

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -86,8 +86,11 @@ def test_adapter_predict(regtest):
     data = get_single_rank_xarray_data()
 
     model = HybridDatasetAdapter(hybrid_predictor)
-
-    result = model.predict(data)
+    nhalo = model.model.rank_divider.overlap
+    data_without_overlap = data.isel(
+        {"x": slice(nhalo, -nhalo), "y": slice(nhalo, -nhalo)}
+    )
+    result = model.predict(data_without_overlap)
     print(result, file=regtest)
 
 

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -273,14 +273,15 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
     )
     hybrid_predictor.reset_state()
     ts_sync = [
-        np.ones((input_size, hybrid_predictor.rank_divider.n_subdomains))
+        np.ones((input_size, hybrid_predictor.rank_divider.n_subdomains,))
         for i in range(20)
     ]
 
     hybrid_predictor.synchronize(ts_sync)
 
+    # Training data always has a feature dim, even if it's size 1
     hybrid_input = [
-        np.random.rand(*rank_divider.rank_extent),
+        np.random.rand(*rank_divider.rank_extent, 1),
     ]
     prediction0 = hybrid_predictor.predict(hybrid_input)
 


### PR DESCRIPTION
The implementation of `HybridReservoirComputingModel.predict` didn't match the intended usage in the docstring. This method should take in hybrid rank data *without* the halo points, since in online usage that would require an additional halo update to retrieve those points. I added a check that the input data is the expected shape, without halo points. 

This was enabled by a lower down bug in `RankDivider.get_subdomain_tensor_slice`. The slicing methods in that class are intended only to be used on the full input (i.e. rank plus halo points) but it was possible to call that method on an array with smaller x/y dim size. I added a check to this method that raises a ValueError if the input array not the expected shape. 

Since `RankDivider.get_subdomain_tensor_slice` is still the simplest method to use in `predict` to divide the xy array into subdomains, I added a step in `HybridReservoirComputingModel.predict` which pads the input hybrid data (which has no halo points) with a halo of zeros so that it is compatible with `RankDivider.get_subdomain_tensor_slice`. Using the arg `overlap=False` when dividing into subdomains omits the zero padded points from the subdomain slices.
 
A few tests were amended to reflect these changes in requirements.

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
