### PR TITLE
Fix prognostic scream run unit test

### DIFF
--- a/docker/prognostic_scream_run/Dockerfile
+++ b/docker/prognostic_scream_run/Dockerfile
@@ -132,6 +132,10 @@ RUN pip install -e /fv3net/workflows/prognostic_scream_run
 RUN pip uninstall -y tensorflow h5py
 RUN pip install tensorflow==2.8.0
 
+# this is a workaround because python does not recognize the already installed py package
+RUN pip uninstall -y py
+RUN pip install py==1.11.0
+
 COPY docker/prognostic_scream_run/precompile_scream.sh /src/precompile_scream.sh
 ENV CC=/opt/conda/bin/mpicc
 ENV CXX=/opt/conda/bin/mpicxx

--- a/docker/prognostic_scream_run/requirements.in
+++ b/docker/prognostic_scream_run/requirements.in
@@ -99,7 +99,7 @@ pybind11==2.9.1
 pycparser==2.20
 pyparsing==2.4.7
 pytest-regtest==1.4.4
-pytest==4.6.11
+pytest==7.4.0
 python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0


### PR DESCRIPTION
Unit tests broke due to missing `py` package and outdated `pytest`. `py` was already installed but for some reason python did not recognize it, uninstall and install fixed the issue. 

Coverage reports (updated automatically):
