### PR TITLE
Count reservoir synchronization by timestep instead of batch during training

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -65,7 +65,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     output_variables: time series variables, must be subset of input_variables
     reservoir_hyperparameters: hyperparameters for reservoir
     readout_hyperparameters: hyperparameters for readout
-    n_batches_burn: number of training batches at start of time series to use
+    n_timesteps_synchronize: number of timesteps at start of time series to use
         for synchronizaton.  This data is  used to update the reservoir state
         but is not included in training.
     input_noise: stddev of normal distribution which is sampled to add input
@@ -88,7 +88,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     subdomain: CubedsphereSubdomainConfig
     reservoir_hyperparameters: ReservoirHyperparameters
     readout_hyperparameters: BatchLinearRegressorHyperparameters
-    n_batches_burn: int
+    n_timesteps_synchronize: int
     input_noise: float
     seed: int = 0
     n_jobs: Optional[int] = 1
@@ -148,7 +148,7 @@ class ReservoirTrainingConfig(Hyperparameters):
 
     def dump(self, path: str):
         metadata = {
-            "n_batches_burn": self.n_batches_burn,
+            "n_timesteps_synchronize": self.n_timesteps_synchronize,
             "input_noise": self.input_noise,
             "seed": self.seed,
             "n_jobs": self.n_jobs,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -98,7 +98,7 @@ def train_reservoir_model(
         reservoir_state_time_series = _get_reservoir_state_time_series(
             time_series_with_overlap, hyperparameters.input_noise, reservoir
         )
-        sync_tracker.count(len(reservoir_state_time_series))
+        sync_tracker.count_synchronization_steps(len(reservoir_state_time_series))
         hybrid_time_series: Optional[np.ndarray]
         if hyperparameters.hybrid_variables is not None:
             _, hybrid_time_series = process_batch_Xy_data(

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -6,6 +6,11 @@ from fv3fit.reservoir.domain import RankDivider, assure_txyz_dims
 
 
 class SynchronziationTracker:
+    """Counts the number of times a reservoir has been incremented,
+    and excludes time series data from training set if the number of
+    incrments is less than the specified synchronization length.
+    """
+
     def __init__(self, n_synchronize: int):
         self.n_synchronize = n_synchronize
         self.n_steps_synchronized = 0
@@ -17,7 +22,7 @@ class SynchronziationTracker:
         else:
             return False
 
-    def count(self, n_samples: int):
+    def count_synchronization_steps(self, n_samples: int):
         self.n_steps_synchronized += n_samples
 
     def trim_synchronization_samples_if_needed(self, arr: np.ndarray) -> np.ndarray:

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -5,6 +5,29 @@ from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
 from fv3fit.reservoir.domain import RankDivider, assure_txyz_dims
 
 
+class SynchronziationTracker:
+    def __init__(self, n_synchronize: int):
+        self.n_synchronize = n_synchronize
+        self.n_steps_synchronized = 0
+
+    @property
+    def completed_synchronization(self):
+        if self.n_steps_synchronized > self.n_synchronize:
+            return True
+        else:
+            return False
+
+    def count(self, n_samples: int):
+        self.n_steps_synchronized += n_samples
+
+    def trim_synchronization_samples_if_needed(self, arr):
+        steps_past_sync = self.n_steps_synchronized - self.n_synchronize
+        if steps_past_sync > len(arr):
+            return arr
+        else:
+            return arr[-steps_past_sync:]
+
+
 def _square_evens(v: np.ndarray) -> np.ndarray:
     evens = v[::2]
     odds = v[1::2]

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -20,12 +20,18 @@ class SynchronziationTracker:
     def count(self, n_samples: int):
         self.n_steps_synchronized += n_samples
 
-    def trim_synchronization_samples_if_needed(self, arr):
-        steps_past_sync = self.n_steps_synchronized - self.n_synchronize
-        if steps_past_sync > len(arr):
-            return arr
+    def trim_synchronization_samples_if_needed(self, arr: np.ndarray) -> np.ndarray:
+        """ Removes samples from the input array if they fall within the
+        synchronization range.
+        """
+        if self.completed_synchronization is True:
+            steps_past_sync = self.n_steps_synchronized - self.n_synchronize
+            if steps_past_sync > len(arr):
+                return arr
+            else:
+                return arr[-steps_past_sync:]
         else:
-            return arr[-steps_past_sync:]
+            return np.array([])
 
 
 def _square_evens(v: np.ndarray) -> np.ndarray:

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -14,7 +14,7 @@ def test_SynchronziationTracker():
     batches = np.arange(15).reshape(3, 5)
     expected = [np.array([]), np.array([6, 7, 8, 9]), np.array([10, 11, 12, 13, 14])]
     for expected_trimmed, batch in zip(expected, batches):
-        sync_tracker.count(len(batch))
+        sync_tracker.count_synchronization_steps(len(batch))
         np.testing.assert_array_equal(
             sync_tracker.trim_synchronization_samples_if_needed(batch), expected_trimmed
         )

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -1,8 +1,23 @@
 import numpy as np
 import pytest
-from fv3fit.reservoir.utils import square_even_terms, process_batch_Xy_data
+from fv3fit.reservoir.utils import (
+    square_even_terms,
+    process_batch_Xy_data,
+    SynchronziationTracker,
+)
 from fv3fit.reservoir.transformers import DoNothingAutoencoder
 from fv3fit.reservoir.domain import RankDivider
+
+
+def test_SynchronziationTracker():
+    sync_tracker = SynchronziationTracker(n_synchronize=6)
+    batches = np.arange(15).reshape(3, 5)
+    expected = [np.array([]), np.array([6, 7, 8, 9]), np.array([10, 11, 12, 13, 14])]
+    for expected_trimmed, batch in zip(expected, batches):
+        sync_tracker.count(len(batch))
+        np.testing.assert_array_equal(
+            sync_tracker.trim_synchronization_samples_if_needed(batch), expected_trimmed
+        )
 
 
 @pytest.mark.parametrize(

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -55,7 +55,7 @@ def test_train_reservoir():
         subdomain=subdomain_config,
         reservoir_hyperparameters=reservoir_config,
         readout_hyperparameters=reg_config,
-        n_batches_burn=2,
+        n_timesteps_synchronize=5,
         input_noise=0.01,
     )
     model = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)


### PR DESCRIPTION
This PR updates how the synchronization is tracked in training. Previously the amount of data at the start of the training set to use for synchronization was specified as a number of batches. This was inflexible since the synchronization had to be a multiple of the data batch size, and in some cases the entire training dataset is a single large batch. Now, the synchronization can be set as a number of time steps. To enable this, a `SynchronziationTracker` class is added which counts the number of times the reservoir has been incremented. If the number of increments is less than the synchronization length, the data is cut out of the training set.

 
Added public API:
- replaces the reservoir model config parameter `n_batches_burn` with `n_timesteps_synchronize`, which allows for more control over how many timesteps are used for reservoir  synchronization.
  

- [x] Tests added
 