### PR TITLE
preprocessing of era5 sst data format changed for fv3net reservoir computing

### DIFF
--- a/projects/reservoir/fv3/era_process.py
+++ b/projects/reservoir/fv3/era_process.py
@@ -12,6 +12,7 @@ import os
 import atexit
 import shutil
 
+# todo: add land mask
 
 FREGRID_EXAMPLE_SOURCE_DATA = (
     "gs://vcm-ml-raw/2020-11-12-gridspec-orography-and-mosaic-data/C48/*.nc"
@@ -78,6 +79,7 @@ def add_arguments():
 def main(args):
     tempdirname = "temp"
     os.system("mkdir -p " + tempdirname)
+    atexit.register(shutil.rmtree, tempdirname)
     path = args.in_path
     variables = args.variables
     setup_fregrid(tempdirname)
@@ -102,7 +104,6 @@ def main(args):
         var_id = var_id_mapping[var]
         interpolated = interpolated.rename_vars({var_id: shift_rename_mapping[var_id]})
     save_data_as_tiles(interpolated, args)
-    atexit.register(shutil.rmtree, tempdirname)
 
 
 def download_source_data(tempdirname):

--- a/projects/reservoir/fv3/era_process.py
+++ b/projects/reservoir/fv3/era_process.py
@@ -110,7 +110,9 @@ def download_source_data(tempdirname):
     os.system(
         "gsutil -m cp "
         + FREGRID_EXAMPLE_SOURCE_DATA
-        + " temp/fregrid-example/source-grid-data/"
+        + " "
+        + tempdirname
+        + "/fregrid-example/source-grid-data/"
     )
 
 
@@ -236,7 +238,9 @@ def regrid_to_cubed_sphere(full_variables, variables, tempdir):
     var_id_commas_string = var_id_commas_string[:-1]
     command = (
         "sudo docker run \
-        -v $(pwd)/temp/fregrid-example:/work \
+        -v $(pwd)/"
+        + tempdir
+        + "/fregrid-example:/work \
         us.gcr.io/vcm-ml/post_process_run:latest \
         fregrid \
         --input_mosaic /work/era5_lonlat_grid_mosaic.nc \


### PR DESCRIPTION
I changed era_process.py to
- have weekly mean quantities instead of daily
- take start and end dates as arguments to create a dataset for a specific time period
- not have a time dim issue that requires decode_times=False when loading with xarray
- have separate files for different tiles
- enable separate files for train/val/test
- include all given variables (sst,t2m,u10,v10,sst_tend) in one file
- shift t2m,u10,v10
- have a new field "sst_tendency", the sst tendency