### PR TITLE
Update coarsening method for `snoalb`, `shdmin`, and `shdmax`

### DIFF
--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -1285,36 +1285,6 @@ def _area_and_fice_weighted_mean(
     ).fillna(0.0)
 
 
-def _minimum_over_dominant_sfc_type(
-    data_var: xr.DataArray,
-    coarsening_factor: int,
-    is_dominant_surface_type: xr.DataArray,
-    **unused_kwargs,
-) -> xr.DataArray:
-    return block_coarsen(
-        data_var.where(is_dominant_surface_type),
-        coarsening_factor,
-        x_dim=X_DIM,
-        y_dim=Y_DIM,
-        method="min",
-    )
-
-
-def _maximum_over_dominant_sfc_type(
-    data_var: xr.DataArray,
-    coarsening_factor: int,
-    is_dominant_surface_type: xr.DataArray,
-    **unused_kwargs,
-) -> xr.DataArray:
-    return block_coarsen(
-        data_var.where(is_dominant_surface_type),
-        coarsening_factor,
-        x_dim=X_DIM,
-        y_dim=Y_DIM,
-        method="max",
-    )
-
-
 def _area_or_area_and_fice_weighted_mean(
     data_var: xr.DataArray,
     coarsening_factor: int,
@@ -1376,9 +1346,9 @@ SFC_DATA_COARSENING_METHOD: Mapping[Hashable, Callable] = {
     "slope": _mode_over_dominant_sfc_type,
     "sheleg": _area_and_sncovr_weighted_mean,
     "hice": _area_and_fice_weighted_mean,
-    "shdmin": _minimum_over_dominant_sfc_type,
-    "shdmax": _maximum_over_dominant_sfc_type,
-    "snoalb": _maximum_over_dominant_sfc_type,
+    "shdmin": _area_weighted_mean_over_dominant_sfc_type,
+    "shdmax": _area_weighted_mean_over_dominant_sfc_type,
+    "snoalb": _area_weighted_mean_over_dominant_sfc_type,
     "tisfc": _area_or_area_and_fice_weighted_mean,
 }
 


### PR DESCRIPTION
This PR updates the coarsening method for `snoalb` (maximum snow albedo), `shdmin` (minimum green vegetation fraction), and `shdmax` (maximum green vegetation fraction) from a block minimum or maximum over the dominant surface type to a simple area-weighted average over the dominant surface type.  

This is because an area-weighted average over the dominant surface type is a more physically reasonable approach (a block min or block max emphasizes the extreme of a single fine grid cell, while an average is more representative of all fine grid cells in a coarse grid cell).  We have known this for a while, but just have not gotten around to updating our code.  The main variable where this has an important impact is `snoalb`, but for consistency we remove this block min / max coarse-graining strategy from the `shdmin` / `shdmax` variables as well.

[This notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2021-11-10-offline-to-online-connection/2022-01-10-snoalb-fix-biases.ipynb) from early 2022 illustrates that biases are improved in baseline simulations started from initial conditions where these fields were coarsened in this way, when compared with the previous approach, particularly for upward shortwave radiative flux at the surface (we get a 37% improvement in the RMSE of the one-year time mean over land).

Significant internal changes:
- Coarsen `snoalb`, `shdmin`, and `shdmax` in `sfc_data` restart files with an area-weighted average over the dominant surface type instead of a block minimum or maximum over the dominant surface type.

xref: ai2cm/fv3gfs-fortran#372

Coverage reports (updated automatically):
