### PR TITLE
Move non negative sphum to vcm

### DIFF
--- a/external/vcm/tests/test_non_negative_sphum.py
+++ b/external/vcm/tests/test_non_negative_sphum.py
@@ -1,12 +1,12 @@
 import pytest
 import xarray as xr
-from runtime.steppers.machine_learning import (
+from vcm import (
     non_negative_sphum,
     update_temperature_tendency_to_conserve_mse,
     update_moisture_tendency_to_ensure_non_negative_humidity,
     non_negative_sphum_mse_conserving,
+    moist_static_energy_tendency,
 )
-import vcm
 
 
 sphum = 1.0e-3 * xr.DataArray(data=[1.0, 1.0, 1.0], dims=["x"])  # type: ignore
@@ -62,8 +62,8 @@ def test_update_q1_to_conserve_mse():
     q2_limited = xr.DataArray([-1, -1])
     q1_limited = update_temperature_tendency_to_conserve_mse(q1, q2, q2_limited)
     xr.testing.assert_identical(
-        vcm.moist_static_energy_tendency(q1, q2),
-        vcm.moist_static_energy_tendency(q1_limited, q2_limited),
+        moist_static_energy_tendency(q1, q2),
+        moist_static_energy_tendency(q1_limited, q2_limited),
     )
 
 

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -60,6 +60,12 @@ from .calc.thermo.local import (
     temperature_tendency,
     moist_static_energy_tendency,
 )
+from .calc.thermo.non_negative_sphum import (
+    non_negative_sphum,
+    update_moisture_tendency_to_ensure_non_negative_humidity,
+    update_temperature_tendency_to_conserve_mse,
+    non_negative_sphum_mse_conserving,
+)
 from .calc.histogram import histogram, histogram2d
 from .calc.clouds import gridcell_to_incloud_condensate, incloud_to_gridcell_condensate
 

--- a/external/vcm/vcm/calc/thermo/non_negative_sphum.py
+++ b/external/vcm/vcm/calc/thermo/non_negative_sphum.py
@@ -1,0 +1,38 @@
+import xarray as xr
+from typing import Tuple, Optional
+from .local import moist_static_energy_tendency, temperature_tendency
+
+
+def non_negative_sphum(
+    sphum: xr.DataArray, dQ1: xr.DataArray, dQ2: xr.DataArray, dt: float
+) -> Tuple[xr.DataArray, xr.DataArray]:
+    delta = dQ2 * dt
+    reduction_ratio = (-sphum) / (dt * dQ2)  # type: ignore
+    dQ1_updated = xr.where(sphum + delta >= 0, dQ1, reduction_ratio * dQ1)
+    dQ2_updated = xr.where(sphum + delta >= 0, dQ2, reduction_ratio * dQ2)
+    return dQ1_updated, dQ2_updated
+
+
+def update_moisture_tendency_to_ensure_non_negative_humidity(
+    sphum: xr.DataArray, q2: xr.DataArray, dt: float
+) -> xr.DataArray:
+    return xr.where(sphum + q2 * dt >= 0, q2, -sphum / dt)
+
+
+def update_temperature_tendency_to_conserve_mse(
+    q1: xr.DataArray, q2_old: xr.DataArray, q2_new: xr.DataArray
+) -> xr.DataArray:
+    mse_tendency = moist_static_energy_tendency(q1, q2_old)
+    q1_new = temperature_tendency(mse_tendency, q2_new)
+    return q1_new
+
+
+def non_negative_sphum_mse_conserving(
+    sphum: xr.DataArray, q2: xr.DataArray, dt: float, q1: Optional[xr.DataArray] = None
+) -> Tuple[xr.DataArray, Optional[xr.DataArray]]:
+    q2_new = update_moisture_tendency_to_ensure_non_negative_humidity(sphum, q2, dt)
+    if q1 is not None:
+        q1_new = update_temperature_tendency_to_conserve_mse(q1, q2, q2_new)
+    else:
+        q1_new = None
+    return q2_new, q1_new

--- a/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/fv3fit.py
@@ -4,10 +4,8 @@ from typing import Mapping, MutableMapping, Iterable, Hashable, Sequence
 
 import xarray as xr
 import fv3fit
-from runtime.steppers.machine_learning import (
-    non_negative_sphum_mse_conserving,
-    MultiModelAdapter,
-)
+from runtime.steppers.machine_learning import MultiModelAdapter
+from vcm import non_negative_sphum_mse_conserving
 from runtime.types import State
 from runtime.names import SPHUM, TEMP
 

--- a/workflows/prognostic_scream_run/scream_run/steppers/machine_learning.py
+++ b/workflows/prognostic_scream_run/scream_run/steppers/machine_learning.py
@@ -8,12 +8,14 @@ from typing import (
     Sequence,
     Set,
     cast,
+    Tuple,
 )
 import fv3fit
 import xarray as xr
-
+import vcm
 
 State = MutableMapping[Hashable, xr.DataArray]
+SPHUM = "qv"
 
 
 @dataclasses.dataclass
@@ -26,6 +28,8 @@ class MachineLearningConfig:
         scaling: if given, scale the outputs by the given factor. This is a manually
             defined alteration of the model, and should not be used for
             normalization.
+        mse_conserving_limiter (optional): whether to use MSE-conserving humidity
+                limiter. Defaults to True.
     Example::
 
         MachineLearningConfig(
@@ -38,6 +42,7 @@ class MachineLearningConfig:
     models: Sequence[str] = dataclasses.field(default_factory=list)
     diagnostic_ml: bool = False
     scaling: Mapping[str, float] = dataclasses.field(default_factory=dict)
+    mse_conserving_limiter: bool = True
 
 
 class MultiModelAdapter:
@@ -45,17 +50,21 @@ class MultiModelAdapter:
         self,
         models: Iterable[fv3fit.Predictor],
         scaling: Optional[Mapping[str, float]] = None,
+        mse_conserving_limiter: bool = True,
     ):
         """
         Args:
             models: models for which to combine predictions
             scaling: if given, scale the predictions by the given factor
+            mse_conserving_limiter (optional): whether to use MSE-conserving humidity
+                limiter. Defaults to True.
         """
         self.models = models
         if scaling is None:
             self._scaling: Mapping[str, float] = {}
         else:
             self._scaling = scaling
+        self.mse_conserving_limiter = mse_conserving_limiter
 
     @property
     def input_variables(self) -> Set[str]:
@@ -80,12 +89,74 @@ def open_model(config: MachineLearningConfig) -> MultiModelAdapter:
     for path in model_paths:
         model = cast(fv3fit.Predictor, fv3fit.load(path))
         models.append(model)
-    return MultiModelAdapter(models, scaling=config.scaling)
+    return MultiModelAdapter(
+        models,
+        scaling=config.scaling,
+        mse_conserving_limiter=config.mse_conserving_limiter,
+    )
 
 
-def predict(model: MultiModelAdapter, state: State) -> State:
+def predict(model: MultiModelAdapter, state: State, dt: float) -> State:
     """Given ML model and state, return prediction"""
     state_loaded = {key: state[key] for key in model.input_variables}
     ds = xr.Dataset(state_loaded)  # type: ignore
     output = model.predict(ds)
+    output = enforce_non_negative_humidity(
+        output, state, dt, model.mse_conserving_limiter
+    )
     return {key: cast(xr.DataArray, output[key]) for key in output.data_vars}
+
+
+def non_negative_sphum(
+    sphum: xr.DataArray, dQ1: xr.DataArray, dQ2: xr.DataArray, dt: float
+) -> Tuple[xr.DataArray, xr.DataArray]:
+    delta = dQ2 * dt
+    reduction_ratio = (-sphum) / (dt * dQ2)  # type: ignore
+    dQ1_updated = xr.where(sphum + delta >= 0, dQ1, reduction_ratio * dQ1)
+    dQ2_updated = xr.where(sphum + delta >= 0, dQ2, reduction_ratio * dQ2)
+    return dQ1_updated, dQ2_updated
+
+
+def update_moisture_tendency_to_ensure_non_negative_humidity(
+    sphum: xr.DataArray, q2: xr.DataArray, dt: float
+) -> xr.DataArray:
+    return xr.where(sphum + q2 * dt >= 0, q2, -sphum / dt)
+
+
+def update_temperature_tendency_to_conserve_mse(
+    q1: xr.DataArray, q2_old: xr.DataArray, q2_new: xr.DataArray
+) -> xr.DataArray:
+    mse_tendency = vcm.moist_static_energy_tendency(q1, q2_old)
+    q1_new = vcm.temperature_tendency(mse_tendency, q2_new)
+    return q1_new
+
+
+def non_negative_sphum_mse_conserving(
+    sphum: xr.DataArray, q2: xr.DataArray, dt: float, q1: Optional[xr.DataArray] = None
+) -> Tuple[xr.DataArray, Optional[xr.DataArray]]:
+    q2_new = update_moisture_tendency_to_ensure_non_negative_humidity(sphum, q2, dt)
+    if q1 is not None:
+        q1_new = update_temperature_tendency_to_conserve_mse(q1, q2, q2_new)
+    else:
+        q1_new = None
+    return q2_new, q1_new
+
+
+def enforce_non_negative_humidity(
+    prediction: dict, state: State, dt: float, mse_conserving_limiter: bool = True,
+):
+    dQ1_initial = prediction.get("dQ1", xr.zeros_like(state[SPHUM]))
+    dQ2_initial = prediction.get("dQ2", xr.zeros_like(state[SPHUM]))
+    if mse_conserving_limiter:
+        dQ2_updated, dQ1_updated = non_negative_sphum_mse_conserving(
+            state[SPHUM], dQ2_initial, dt, q1=dQ1_initial,
+        )
+    else:
+        dQ1_updated, dQ2_updated = non_negative_sphum(
+            state[SPHUM], dQ1_initial, dQ2_initial, dt,
+        )
+    if "dQ1" in prediction:
+        prediction.update({"dQ1": dQ1_updated})
+    if "dQ2" in prediction:
+        prediction.update({"dQ2": dQ2_updated})
+    return prediction

--- a/workflows/prognostic_scream_run/tests/test_ML_correction.py
+++ b/workflows/prognostic_scream_run/tests/test_ML_correction.py
@@ -41,7 +41,7 @@ def test_mock_scream_ml_prediction():
     )
     predictor.set_outputs(**outputs)
     model = MultiModelAdapter([predictor])
-    output = predict(model, data)
+    output = predict(model, data, dt=1.0)
     assert output["dQ1"].values.all() == pytest.approx(0.0)
     assert output["dQ2"].values.all() == pytest.approx(0.0)
     assert output["dQ1"].dims == ("ncol", "z")


### PR DESCRIPTION
In this PR, we move functions related to non negative sphum to vcm so that it can be used in both `prognostic_c48_run` and `prognostic_scream_run` without having to duplicate them.

Added public API:
- `vcm` now has the following functions: 
  - `non_negative_sphum`
  - `update_moisture_tendency_to_ensure_non_negative_humidity`
  - `update_temperature_tendency_to_conserve_mse`
  - `non_negative_sphum_mse_conserving`
 
- [x] Tests added
  - tests related to `non_negative_sphum` are moved to vcm

Coverage reports (updated automatically):
