### PR TITLE
Dev branch for  reservoir model training features

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -99,10 +99,11 @@ class ReservoirTrainingConfig(Hyperparameters):
 
     def __post_init__(self):
         if set(self.output_variables).issubset(self.input_variables) is False:
-            raise ValueError(
-                f"Output variables {self.output_variables} must be a subset of "
-                f"input variables {self.input_variables}."
-            )
+            if len(set(self.output_variables).intersection(self.input_variables)) > 0:
+                raise ValueError(
+                    f"Output variables {self.output_variables} must either be a subset "
+                    f"of input variables {self.input_variables} or mutually exclusive."
+                )
         if self.hybrid_variables is not None:
             hybrid_and_input_vars_intersection = set(
                 self.hybrid_variables
@@ -119,7 +120,9 @@ class ReservoirTrainingConfig(Hyperparameters):
             hybrid_vars = list(self.hybrid_variables)  # type: ignore
         else:
             hybrid_vars = []
-        return set(list(self.input_variables) + hybrid_vars)
+        return set(
+            list(self.input_variables) + list(self.output_variables) + hybrid_vars
+        )
 
     @classmethod
     def from_dict(cls, kwargs) -> "ReservoirTrainingConfig":

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -65,7 +65,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     output_variables: time series variables, must be subset of input_variables
     reservoir_hyperparameters: hyperparameters for reservoir
     readout_hyperparameters: hyperparameters for readout
-    n_batches_burn: number of training batches at start of time series to use
+    n_timesteps_synchronize: number of timesteps at start of time series to use
         for synchronizaton.  This data is  used to update the reservoir state
         but is not included in training.
     input_noise: stddev of normal distribution which is sampled to add input
@@ -88,7 +88,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     subdomain: CubedsphereSubdomainConfig
     reservoir_hyperparameters: ReservoirHyperparameters
     readout_hyperparameters: BatchLinearRegressorHyperparameters
-    n_batches_burn: int
+    n_timesteps_synchronize: int
     input_noise: float
     seed: int = 0
     n_jobs: Optional[int] = 1
@@ -152,7 +152,7 @@ class ReservoirTrainingConfig(Hyperparameters):
 
     def dump(self, path: str):
         metadata = {
-            "n_batches_burn": self.n_batches_burn,
+            "n_timesteps_synchronize": self.n_timesteps_synchronize,
             "input_noise": self.input_noise,
             "seed": self.seed,
             "n_jobs": self.n_jobs,

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -94,6 +94,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     n_jobs: Optional[int] = 1
     square_half_hidden_state: bool = False
     autoencoder_path: Optional[str] = None
+    hybrid_autoencoder_path: Optional[str] = None
     hybrid_variables: Optional[Sequence[str]] = None
     _METADATA_NAME = "reservoir_training_config.yaml"
 

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -1,7 +1,7 @@
 import fsspec
 import numpy as np
 import os
-from typing import Iterable, Hashable, Sequence, cast
+from typing import Iterable, Hashable, Sequence, cast, Optional
 import xarray as xr
 import yaml
 
@@ -45,6 +45,7 @@ class HybridReservoirComputingModel(Predictor):
         readout: ReservoirComputingReadout,
         rank_divider: RankDivider,
         autoencoder: ReloadableTransfomer,
+        output_autoencoder: Optional[ReloadableTransfomer] = None,
         square_half_hidden_state: bool = False,
     ):
         self.reservoir_model = ReservoirComputingModel(
@@ -55,6 +56,7 @@ class HybridReservoirComputingModel(Predictor):
             square_half_hidden_state=square_half_hidden_state,
             rank_divider=rank_divider,
             autoencoder=autoencoder,
+            output_autoencoder=output_autoencoder,
         )
         self.input_variables = input_variables
         self.hybrid_variables = hybrid_variables
@@ -62,13 +64,14 @@ class HybridReservoirComputingModel(Predictor):
         self.readout = readout
         self.square_half_hidden_state = square_half_hidden_state
         self.rank_divider = rank_divider
-        self.autoencoder = autoencoder
+        self.input_autoencoder = autoencoder
+        self.output_autoencoder = output_autoencoder or autoencoder
 
     def predict(self, hybrid_input: Sequence[np.ndarray]):
         # hybrid input is assumed to be in original spatial xy dims
         # (x, y, feature) and does not include overlaps.
         encoded_hybrid_input = encode_columns(
-            input_arrs=hybrid_input, transformer=self.autoencoder
+            input_arrs=hybrid_input, transformer=self.input_autoencoder
         )
         if encoded_hybrid_input.shape[:2] != tuple(
             self.rank_divider.rank_extent_without_overlap
@@ -95,7 +98,7 @@ class HybridReservoirComputingModel(Predictor):
         prediction = self.rank_divider.merge_subdomains(flat_prediction)
         decoded_prediction = decode_columns(
             encoded_output=prediction,
-            transformer=self.autoencoder,
+            transformer=self.output_autoencoder,
             xy_shape=self.rank_divider.rank_extent_without_overlap,
         )
         return decoded_prediction
@@ -135,7 +138,8 @@ class HybridReservoirComputingModel(Predictor):
             readout=pure_reservoir_model.readout,
             square_half_hidden_state=pure_reservoir_model.square_half_hidden_state,
             rank_divider=pure_reservoir_model.rank_divider,
-            autoencoder=pure_reservoir_model.autoencoder,
+            autoencoder=pure_reservoir_model.input_autoencoder,
+            output_autoencoder=pure_reservoir_model.output_autoencoder,
             hybrid_variables=hybrid_variables,
         )
 
@@ -200,6 +204,7 @@ class ReservoirComputingModel(Predictor):
         readout: ReservoirComputingReadout,
         rank_divider: RankDivider,
         autoencoder: ReloadableTransfomer,
+        output_autoencoder: Optional[ReloadableTransfomer] = None,
         square_half_hidden_state: bool = False,
     ):
         """_summary_
@@ -219,7 +224,8 @@ class ReservoirComputingModel(Predictor):
         self.readout = readout
         self.square_half_hidden_state = square_half_hidden_state
         self.rank_divider = rank_divider
-        self.autoencoder = autoencoder
+        self.input_autoencoder = autoencoder
+        self.output_autoencoder = output_autoencoder or autoencoder
 
     def process_state_to_readout_input(self):
         if self.square_half_hidden_state is True:
@@ -238,7 +244,7 @@ class ReservoirComputingModel(Predictor):
         prediction = self.rank_divider.merge_subdomains(flat_prediction)
         decoded_prediction = decode_columns(
             encoded_output=prediction,
-            transformer=self.autoencoder,
+            transformer=self.output_autoencoder,
             xy_shape=self.rank_divider.rank_extent_without_overlap,
         )
         return decoded_prediction
@@ -253,7 +259,7 @@ class ReservoirComputingModel(Predictor):
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         # input array is in native x, y, z_feature coordinates
         encoded_xy_input_arrs = encode_columns(
-            prediction_with_overlap, self.autoencoder
+            prediction_with_overlap, self.input_autoencoder
         )
         encoded_flattened_subdomains = self.rank_divider.flatten_subdomains_to_columns(
             encoded_xy_input_arrs, with_overlap=True
@@ -281,8 +287,15 @@ class ReservoirComputingModel(Predictor):
             f.write(yaml.dump(metadata))
 
         self.rank_divider.dump(os.path.join(path, self._RANK_DIVIDER_NAME))
-        if self.autoencoder is not None:
-            fv3fit.dump(self.autoencoder, os.path.join(path, self._AUTOENCODER_SUBDIR))
+        fv3fit.dump(
+            self.input_autoencoder,
+            os.path.join(path, self._AUTOENCODER_SUBDIR, "input"),
+        )
+        if self.output_autoencoder is not None:
+            fv3fit.dump(
+                self.output_autoencoder,
+                os.path.join(path, self._AUTOENCODER_SUBDIR, "output"),
+            )
 
     @classmethod
     def load(cls, path: str) -> "ReservoirComputingModel":
@@ -298,8 +311,16 @@ class ReservoirComputingModel(Predictor):
 
         autoencoder = cast(
             ReloadableTransfomer,
-            fv3fit.load(os.path.join(path, cls._AUTOENCODER_SUBDIR)),
+            fv3fit.load(os.path.join(path, cls._AUTOENCODER_SUBDIR, "input")),
         )
+        try:
+            output_autoencoder = cast(
+                ReloadableTransfomer,
+                fv3fit.load(os.path.join(path, cls._AUTOENCODER_SUBDIR, "output")),
+            )
+        except (KeyError):
+            output_autoencoder = None  # type: ignore
+
         return cls(
             input_variables=metadata["input_variables"],
             output_variables=metadata["output_variables"],
@@ -308,4 +329,5 @@ class ReservoirComputingModel(Predictor):
             square_half_hidden_state=metadata["square_half_hidden_state"],
             rank_divider=rank_divider,
             autoencoder=autoencoder,
+            output_autoencoder=output_autoencoder,
         )

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -6,7 +6,12 @@ import numpy as np
 import tensorflow as tf
 from typing import Optional, List, Union, cast
 from .. import Predictor
-from .utils import square_even_terms, process_batch_Xy_data, get_ordered_X
+from .utils import (
+    square_even_terms,
+    process_batch_Xy_data,
+    get_ordered_X,
+    SynchronziationTracker,
+)
 from .transformers.autoencoder import build_concat_and_scale_only_autoencoder
 from .._shared import register_training_function
 from ._reshaping import concat_inputs_along_subdomain_features
@@ -108,6 +113,9 @@ def train_reservoir_model(
         BatchLinearRegressor(hyperparameters.readout_hyperparameters)
         for r in range(rank_divider.n_subdomains)
     ]
+    sync_tracker = SynchronziationTracker(
+        n_synchronize=hyperparameters.n_timesteps_synchronize
+    )
     for b, batch_data in enumerate(train_batches):
         time_series_with_overlap, time_series_without_overlap = process_batch_Xy_data(
             variables=hyperparameters.input_variables,
@@ -116,14 +124,12 @@ def train_reservoir_model(
             autoencoder=input_autoencoder,
         )
 
-        if b < hyperparameters.n_batches_burn:
-            logger.info(f"Synchronizing on batch {b+1}")
-
         # reservoir increment occurs in this call, so always call this
         # function even if X, Y are not used for readout training.
         reservoir_state_time_series = _get_reservoir_state_time_series(
             time_series_with_overlap, hyperparameters.input_noise, reservoir
         )
+        sync_tracker.count(len(reservoir_state_time_series))
         hybrid_time_series: Optional[np.ndarray]
         if hyperparameters.hybrid_variables is not None:
             _, hybrid_time_series = process_batch_Xy_data(
@@ -151,7 +157,13 @@ def train_reservoir_model(
             )
             readout_output = output_time_series_without_overlap[:-1]
 
-        if b >= hyperparameters.n_batches_burn:
+        if sync_tracker.completed_synchronization:
+            readout_input = sync_tracker.trim_synchronization_samples_if_needed(
+                readout_input
+            )
+            readout_output = sync_tracker.trim_synchronization_samples_if_needed(
+                readout_output
+            )
             logger.info(f"Fitting on batch {b+1}")
             _fit_batch_over_subdomains(
                 X_batch=readout_input,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -88,7 +88,8 @@ def train_reservoir_model(
         output_autoencoder = _get_standard_normalizing_transformer(
             hyperparameters.output_variables, sample_batch
         )
-
+    else:
+        output_autoencoder = input_autoencoder
     subdomain_config = hyperparameters.subdomain
 
     # sample_X[0] is the first data variable, shape elements 1:-1 are the x,y shape

--- a/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
@@ -4,6 +4,8 @@ import os
 import tensorflow as tf
 from toolz.functoolz import curry
 from typing import Union, Sequence, Optional, List, Set, Tuple
+from tensorflow.python.keras.utils.generic_utils import to_list
+
 from fv3fit.reservoir.transformers.transformer import Transformer
 from fv3fit._shared import (
     get_dir,
@@ -68,8 +70,8 @@ class Autoencoder(tf.keras.Model, Transformer):
         x = _ensure_all_items_have_sample_dim(x)
         return self.encoder.predict(x)
 
-    def decode(self, latent_x: ArrayLike) -> ArrayLike:
-        return self.decoder.predict(latent_x)
+    def decode(self, latent_x: ArrayLike) -> Sequence[ArrayLike]:
+        return to_list(self.decoder.predict(latent_x))
 
     def dump(self, path: str) -> None:
         with put_dir(path) as path:

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -5,6 +5,35 @@ from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
 from fv3fit.reservoir.domain import RankDivider, assure_txyz_dims
 
 
+class SynchronziationTracker:
+    def __init__(self, n_synchronize: int):
+        self.n_synchronize = n_synchronize
+        self.n_steps_synchronized = 0
+
+    @property
+    def completed_synchronization(self):
+        if self.n_steps_synchronized > self.n_synchronize:
+            return True
+        else:
+            return False
+
+    def count(self, n_samples: int):
+        self.n_steps_synchronized += n_samples
+
+    def trim_synchronization_samples_if_needed(self, arr: np.ndarray) -> np.ndarray:
+        """ Removes samples from the input array if they fall within the
+        synchronization range.
+        """
+        if self.completed_synchronization is True:
+            steps_past_sync = self.n_steps_synchronized - self.n_synchronize
+            if steps_past_sync > len(arr):
+                return arr
+            else:
+                return arr[-steps_past_sync:]
+        else:
+            return np.array([])
+
+
 def _square_evens(v: np.ndarray) -> np.ndarray:
     evens = v[::2]
     odds = v[1::2]

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -1,8 +1,23 @@
 import numpy as np
 import pytest
-from fv3fit.reservoir.utils import square_even_terms, process_batch_Xy_data
+from fv3fit.reservoir.utils import (
+    square_even_terms,
+    process_batch_Xy_data,
+    SynchronziationTracker,
+)
 from fv3fit.reservoir.transformers import DoNothingAutoencoder
 from fv3fit.reservoir.domain import RankDivider
+
+
+def test_SynchronziationTracker():
+    sync_tracker = SynchronziationTracker(n_synchronize=6)
+    batches = np.arange(15).reshape(3, 5)
+    expected = [np.array([]), np.array([6, 7, 8, 9]), np.array([10, 11, 12, 13, 14])]
+    for expected_trimmed, batch in zip(expected, batches):
+        sync_tracker.count(len(batch))
+        np.testing.assert_array_equal(
+            sync_tracker.trim_synchronization_samples_if_needed(batch), expected_trimmed
+        )
 
 
 @pytest.mark.parametrize(

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -55,7 +55,7 @@ def test_train_reservoir():
         subdomain=subdomain_config,
         reservoir_hyperparameters=reservoir_config,
         readout_hyperparameters=reg_config,
-        n_batches_burn=2,
+        n_timesteps_synchronize=5,
         input_noise=0.01,
     )
     model = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)


### PR DESCRIPTION
-   specify number of synchronization timesteps, rather than batches. i.e. the training config parameter `n_batches_burn`is replaced by `n_timesteps_synchronize`
- can predict output variables that are different from inputs (ex. reservoir takes SST state as input but readout predicts an update tendency)
- separate normalization transforms are fit for each set of input, output, and hybrid variables (since in the SST model, the hybrid variables have different scales than the input)
 