### PR TITLE
Coarsening: expose `toa_pressure` as parameter

### DIFF
--- a/external/vcm/tests/test_coarsen_restarts.py
+++ b/external/vcm/tests/test_coarsen_restarts.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 
 from pathlib import Path
+from vcm.calc.thermo.constants import TOA_PRESSURE
 from vcm.cubedsphere.coarsen_restarts import (
     coarsen_restarts_on_sigma,
     coarsen_restarts_on_pressure,
@@ -112,7 +113,11 @@ def test_coarsen_restarts(tag):
     restart_data, grid_data = generate_synthetic_data(restart_schemas, grid_spec_schema)
 
     func, kwargs = REGRESSION_TESTS[tag]
-    result = func(FACTOR, grid_data, restart_data, **kwargs)
+    if func == coarsen_restarts_on_sigma:
+        # coarsen_restarts_on_sigma does not require the toa_pressure as an argument
+        result = func(FACTOR, grid_data, restart_data, **kwargs)
+    else:
+        result = func(FACTOR, grid_data, TOA_PRESSURE, restart_data, **kwargs)
     result = {category: ds for category, ds in result.items()}
 
     # To reset the reference data, run this module as a script:

--- a/external/vcm/tests/test_coarsen_restarts.py
+++ b/external/vcm/tests/test_coarsen_restarts.py
@@ -113,11 +113,7 @@ def test_coarsen_restarts(tag):
     restart_data, grid_data = generate_synthetic_data(restart_schemas, grid_spec_schema)
 
     func, kwargs = REGRESSION_TESTS[tag]
-    if func == coarsen_restarts_on_sigma:
-        # coarsen_restarts_on_sigma does not require the toa_pressure as an argument
-        result = func(FACTOR, grid_data, restart_data, **kwargs)
-    else:
-        result = func(FACTOR, grid_data, TOA_PRESSURE, restart_data, **kwargs)
+    result = func(FACTOR, grid_data, TOA_PRESSURE, restart_data, **kwargs)
     result = {category: ds for category, ds in result.items()}
 
     # To reset the reference data, run this module as a script:

--- a/external/vcm/tests/test_cubedsphere.py
+++ b/external/vcm/tests/test_cubedsphere.py
@@ -932,9 +932,7 @@ def test__compute_blending_weights_agrid():
     expected = (ps_coarse - pfull_coarse) / (ps_coarse - blending_pressure)
     expected = xr.where(expected < 1, expected, 1.0).expand_dims(DIMS)
 
-    result = _compute_blending_weights_agrid(
-        delp_fine, area_fine, 2, toa_pressure=TOA_PRESSURE
-    )
+    result = _compute_blending_weights_agrid(delp_fine, area_fine, TOA_PRESSURE, 2)
     xr.testing.assert_allclose(result, expected)
 
 
@@ -980,7 +978,7 @@ def test__compute_blending_weights_dgrid(dgrid_dims, edge_lengths_shape, edge):
 
     edge_lengths_fine = xr.DataArray(np.ones(edge_lengths_shape), dims=dgrid_dims)
     result = _compute_blending_weights_dgrid(
-        delp_fine, edge_lengths_fine, 4, edge, *dgrid_dims, toa_pressure=TOA_PRESSURE
+        delp_fine, edge_lengths_fine, TOA_PRESSURE, 4, edge, *dgrid_dims,
     )
 
     ps_min = TOA_PRESSURE + MIN_FACTOR * (np.exp(LEVELS) - np.exp(0))

--- a/external/vcm/vcm/calc/thermo/vertically_dependent.py
+++ b/external/vcm/vcm/calc/thermo/vertically_dependent.py
@@ -209,7 +209,11 @@ def surface_pressure_from_delp(
 
 
 def hydrostatic_dz(
-    T: xr.DataArray, q: xr.DataArray, delp: xr.DataArray, dim: str = COORD_Z_CENTER
+    T: xr.DataArray,
+    q: xr.DataArray,
+    delp: xr.DataArray,
+    dim: str = COORD_Z_CENTER,
+    toa_pressure: float = TOA_PRESSURE,
 ) -> xr.DataArray:
     """Compute layer thickness assuming hydrostatic balance.
 
@@ -218,11 +222,16 @@ def hydrostatic_dz(
         q: specific humidity
         delp: pressure thickness
         dim (optional): name of vertical dimension. Defaults to "pfull".
+        toa_pressure (optional): pressure at the top of the model in units of
+            Pascals.  Defaults to 300 Pa, the top of model pressure in the 79
+            level FV3GFS configuration.
 
     Returns:
         layer thicknesses dz
     """
-    pi = pressure_at_interface(delp, dim_center=dim, dim_outer=dim)
+    pi = pressure_at_interface(
+        delp, dim_center=dim, dim_outer=dim, toa_pressure=toa_pressure
+    )
     tv = T * (1 + (_RVGAS / _RDGAS - 1) * q)
     dlogp = np.log(pi).diff(dim)
     return -dlogp * _RDGAS * tv / _GRAVITY

--- a/external/vcm/vcm/calc/thermo/vertically_dependent.py
+++ b/external/vcm/vcm/calc/thermo/vertically_dependent.py
@@ -212,8 +212,8 @@ def hydrostatic_dz(
     T: xr.DataArray,
     q: xr.DataArray,
     delp: xr.DataArray,
+    toa_pressure: float,
     dim: str = COORD_Z_CENTER,
-    toa_pressure: float = TOA_PRESSURE,
 ) -> xr.DataArray:
     """Compute layer thickness assuming hydrostatic balance.
 
@@ -221,10 +221,8 @@ def hydrostatic_dz(
         T: temperature
         q: specific humidity
         delp: pressure thickness
+        toa_pressure: pressure at the top of the model in units of Pascals.
         dim (optional): name of vertical dimension. Defaults to "pfull".
-        toa_pressure (optional): pressure at the top of the model in units of
-            Pascals.  Defaults to 300 Pa, the top of model pressure in the 79
-            level FV3GFS configuration.
 
     Returns:
         layer thicknesses dz

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -163,7 +163,7 @@ def coarsen_restarts_on_pressure(
         coarsening_factor: the amount of coarsening to apply. C384 to C48 is a factor
             of 8.
         grid_spec: Dataset containing the variables area, dx, dy.
-        toa_pressure: pressure at the top of the model in units of Pascals.
+        toa_pressure: pressure at the top of the atmosphere in units of Pascals.
         restarts: dictionary of restart data. Must have the keys
             "fv_core.res", "fv_srf_wnd.res", "fv_tracer.res", and "sfc_data".
         coarsen_agrid_winds: flag indicating whether to coarsen A-grid winds in
@@ -252,7 +252,7 @@ def coarsen_restarts_via_blended_method(
         coarsening_factor: the amount of coarsening to apply. C384 to C48 is a
             factor of 8.
         grid_spec: Dataset containing the variables area, dx, dy.
-        toa_pressure: pressure at the top of the model in units of Pascals.
+        toa_pressure: pressure at the top of the atmosphere in units of Pascals.
         restarts: dictionary of restart data. Must have the keys
             "fv_core.res", "fv_srf_wnd.res", "fv_tracer.res", and "sfc_data".
         coarsen_agrid_winds: flag indicating whether to coarsen A-grid winds in
@@ -451,7 +451,7 @@ def _coarse_grain_fv_core_on_pressure(
     dy : xr.DataArray
         y edge lengths
     toa_pressure : float
-        Pressure at the top of the model in units of Pascals.
+        Pressure at the top of the atmosphere in units of Pascals.
     coarsening_factor : int
         Coarsening factor to use
     coarsen_agrid_winds : bool
@@ -717,7 +717,7 @@ def _coarse_grain_fv_core_via_blended_method(
     dy : xr.DataArray
         y edge lengths
     toa_pressure : float
-        Pressure at the top of the model in units of Pascals.
+        Pressure at the top of the atmosphere in units of Pascals.
     coarsening_factor : int
         Coarsening factor to use
     coarsen_agrid_winds : bool
@@ -790,7 +790,7 @@ def _coarse_grain_fv_tracer_via_blended_method(
     area : xr.DataArray
         Area weights
     toa_pressure : float
-        Pressure at the top of the model in units of Pascals.
+        Pressure at the top of the atmosphere in units of Pascals.
     coarsening_factor : int
         Coarsening factor to use
     mass_weighted: bool
@@ -911,7 +911,7 @@ def _coarse_grain_fv_tracer_on_pressure(
     area : xr.DataArray
         Area weights
     toa_pressure : float
-        Pressure at the top of the model in units of Pascals.
+        Pressure at the top of the atmosphere in units of Pascals.
     coarsening_factor : int
         Coarsening factor to use
     extrapolate : bool
@@ -992,8 +992,8 @@ def _impose_hydrostatic_balance(
     Args:
         ds_fv_core (xr.Dataset): fv_core restart category Dataset
         ds_fv_tracer (xr.Dataset): fv_tracer restart category Dataset
-        toa_pressure (float): pressure at the top of the model in units of
-            Pascals
+        toa_pressure (float): pressure at the top of the atmosphere in units
+            of Pascals
         dim (str): vertical dimension name (default "zaxis_1")
 
     Returns:

--- a/external/vcm/vcm/cubedsphere/coarsen_restarts.py
+++ b/external/vcm/vcm/cubedsphere/coarsen_restarts.py
@@ -76,6 +76,7 @@ logger = logging.getLogger("vcm.coarsen")
 def coarsen_restarts_on_sigma(
     coarsening_factor: int,
     grid_spec: xr.Dataset,
+    toa_pressure: float,
     restarts: Mapping[str, xr.Dataset],
     coarsen_agrid_winds: bool = False,
     mass_weighted: bool = True,
@@ -87,6 +88,9 @@ def coarsen_restarts_on_sigma(
         coarsening_factor: the amount of coarsening to apply. C384 to C48 is a factor
             of 8.
         grid_spec: Dataset containing the variables area, dx, dy.
+        toa_pressure: pressure at the top of the atmosphere in units of Pascals
+            (not used in this function, but required for harmonizing the required
+            arguments with other coarse-graining functions).
         restarts: dictionary of restart data. Must have the keys
             "fv_core.res", "fv_srf_wnd.res", "fv_tracer.res", and "sfc_data".
         coarsen_agrid_winds: flag indicating whether to coarsen A-grid winds in

--- a/external/vcm/vcm/cubedsphere/regridz.py
+++ b/external/vcm/vcm/cubedsphere/regridz.py
@@ -11,7 +11,6 @@ except ModuleNotFoundError:
 from ..calc.thermo.vertically_dependent import (
     pressure_at_interface,
     pressure_at_midpoint_log,
-    TOA_PRESSURE,
 )
 from ..cubedsphere import edge_weighted_block_average, weighted_block_average
 from ..cubedsphere.coarsen import block_upsample_like
@@ -33,12 +32,12 @@ def regrid_to_area_weighted_pressure(
     ds: xr.Dataset,
     delp: xr.DataArray,
     area: xr.DataArray,
+    toa_pressure: float,
     coarsening_factor: int,
     x_dim: str = FV_CORE_X_CENTER,
     y_dim: str = FV_CORE_Y_CENTER,
     z_dim: str = RESTART_Z_CENTER,
     extrapolate: bool = False,
-    toa_pressure: float = TOA_PRESSURE,
 ) -> Union[xr.Dataset, xr.DataArray]:
     """ Vertically regrid a dataset of cell-centered quantities to coarsened
     pressure levels.
@@ -47,6 +46,8 @@ def regrid_to_area_weighted_pressure(
         ds: input Dataset
         delp: pressure thicknesses
         area: area weights
+        toa_pressure: pressure at the top of the model in units of
+            Pascals
         coarsening_factor: coarsening-factor for pressure levels
         x_dim (optional): x-dimension name. Defaults to "xaxis_1"
         y_dim (optional): y-dimension name. Defaults to "yaxis_2"
@@ -56,9 +57,6 @@ def regrid_to_area_weighted_pressure(
             is at least greater than the coarse layer midpoint's pressure.
             Otherwise do not allow any nearest-neighbor extrapolation (the
             setting by default).
-        toa_pressure (optional): pressure at the top of the model in units of
-            Pascals.  Defaults to 300 Pa, the top of model pressure in the 79
-            level FV3GFS configuration.
 
     Returns:
         tuple of regridded input Dataset and area masked wherever coarse
@@ -72,11 +70,11 @@ def regrid_to_area_weighted_pressure(
         delp,
         delp_coarse,
         area,
+        toa_pressure,
         x_dim=x_dim,
         y_dim=y_dim,
         z_dim=z_dim,
         extrapolate=extrapolate,
-        toa_pressure=toa_pressure,
     )
 
 
@@ -84,13 +82,13 @@ def regrid_to_edge_weighted_pressure(
     ds: xr.Dataset,
     delp: xr.DataArray,
     length: xr.DataArray,
+    toa_pressure: float,
     coarsening_factor: int,
     x_dim: str = FV_CORE_X_CENTER,
     y_dim: str = FV_CORE_Y_OUTER,
     z_dim: str = RESTART_Z_CENTER,
     edge: str = "x",
     extrapolate: bool = False,
-    toa_pressure: float = TOA_PRESSURE,
 ) -> Union[xr.Dataset, xr.DataArray]:
     """ Vertically regrid a dataset of edge-valued quantities to coarsened
     pressure levels.
@@ -99,6 +97,8 @@ def regrid_to_edge_weighted_pressure(
         ds: input Dataset
         delp: pressure thicknesses
         length: edge length weights
+        toa_pressure: pressure at the top of the model in units of
+            Pascals.
         coarsening_factor: coarsening-factor for pressure levels
         x_dim (optional): x-dimension name. Defaults to "xaxis_1"
         y_dim (optional): y-dimension name. Defaults to "yaxis_1"
@@ -109,9 +109,6 @@ def regrid_to_edge_weighted_pressure(
             is at least greater than the coarse layer midpoint's pressure.
             Otherwise do not allow any nearest-neighbor extrapolation (the
             setting by default).
-        toa_pressure (optional): pressure at the top of the model in units of
-            Pascals.  Defaults to 300 Pa, the top of model pressure in the 79
-            level FV3GFS configuration.
 
     Returns:
         tuple of regridded input Dataset and length masked wherever coarse
@@ -141,11 +138,11 @@ def regrid_to_edge_weighted_pressure(
         delp_staggered,
         delp_staggered_coarse,
         length,
+        toa_pressure,
         x_dim=x_dim,
         y_dim=y_dim,
         z_dim=z_dim,
         extrapolate=extrapolate,
-        toa_pressure=toa_pressure,
     )
 
 
@@ -154,11 +151,11 @@ def _regrid_given_delp(
     delp_fine,
     delp_coarse,
     weights,
+    toa_pressure,
     x_dim: str = FV_CORE_X_CENTER,
     y_dim: str = FV_CORE_Y_CENTER,
     z_dim: str = RESTART_Z_CENTER,
     extrapolate: bool = False,
-    toa_pressure: float = TOA_PRESSURE,
 ):
     """Given a fine and coarse delp, do vertical regridding to coarse pressure levels
     and mask weights below fine surface pressure.

--- a/external/vcm/vcm/cubedsphere/regridz.py
+++ b/external/vcm/vcm/cubedsphere/regridz.py
@@ -46,7 +46,7 @@ def regrid_to_area_weighted_pressure(
         ds: input Dataset
         delp: pressure thicknesses
         area: area weights
-        toa_pressure: pressure at the top of the model in units of
+        toa_pressure: pressure at the top of the atmosphere in units of
             Pascals
         coarsening_factor: coarsening-factor for pressure levels
         x_dim (optional): x-dimension name. Defaults to "xaxis_1"
@@ -97,7 +97,7 @@ def regrid_to_edge_weighted_pressure(
         ds: input Dataset
         delp: pressure thicknesses
         length: edge length weights
-        toa_pressure: pressure at the top of the model in units of
+        toa_pressure: pressure at the top of the atmosphere in units of
             Pascals.
         coarsening_factor: coarsening-factor for pressure levels
         x_dim (optional): x-dimension name. Defaults to "xaxis_1"

--- a/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
+++ b/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
@@ -154,7 +154,7 @@ def main(argv):
         "--toa_pressure",
         type=float,
         default=vcm.calc.thermo.constants.TOA_PRESSURE,
-        help="Pressure at the top of the model in units of Pascals.",
+        help="Pressure at the top of the atmosphere in units of Pascals.",
     )
     parser.add_argument(
         "--coarsen-agrid-winds",

--- a/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
+++ b/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
@@ -129,6 +129,11 @@ def main(argv):
         ),
     )
     parser.add_argument(
+        "toa_pressure",
+        type=float,
+        help="Pressure at the top of the atmosphere in units of Pascals.",
+    )
+    parser.add_argument(
         "source_resolution", type=int, help="Source data cubed-sphere grid resolution.",
     )
     parser.add_argument(
@@ -149,12 +154,6 @@ def main(argv):
             "Add subdirectory with C{target-resolution} to the specified "
             "destination directory. "
         ),
-    )
-    parser.add_argument(
-        "--toa_pressure",
-        type=float,
-        default=vcm.calc.thermo.constants.TOA_PRESSURE,
-        help="Pressure at the top of the atmosphere in units of Pascals.",
     )
     parser.add_argument(
         "--coarsen-agrid-winds",

--- a/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
+++ b/workflows/dataflow/fv3net/pipelines/coarsen_restarts/pipeline.py
@@ -7,7 +7,6 @@ import apache_beam as beam
 import xarray as xr
 from apache_beam.options.pipeline_options import PipelineOptions
 
-import vcm.calc.thermo.constants
 import vcm.cubedsphere
 from fv3net.pipelines.common import FunctionSource, WriteToNetCDFs, list_timesteps
 

--- a/workflows/dataflow/tests/local/test_coarsen_restarts.py
+++ b/workflows/dataflow/tests/local/test_coarsen_restarts.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from fv3net.pipelines.coarsen_restarts.pipeline import main
 from typing import Optional, Set
+from vcm.calc.thermo.constants import TOA_PRESSURE
 
 
 OUTPUT_CATEGORY_NAMES = {
@@ -94,12 +95,13 @@ def test_regression_coarsen_restarts(
 ):
     grid_spec_path = str(restart_dir.join("grid_spec"))
     src_path = str(restart_dir)
+    toa_pressure = TOA_PRESSURE
     in_res = "48"
     out_res = "6"
     time = "20160101.000000"
     dest = str(restart_dir.join("output"))
 
-    args = [src_path, grid_spec_path, in_res, out_res, dest]
+    args = [src_path, grid_spec_path, toa_pressure, in_res, out_res, dest]
     if coarsen_agrid_winds:
         args.append("--coarsen-agrid-winds")
 

--- a/workflows/dataflow/tests/local/test_coarsen_restarts.py
+++ b/workflows/dataflow/tests/local/test_coarsen_restarts.py
@@ -95,7 +95,7 @@ def test_regression_coarsen_restarts(
 ):
     grid_spec_path = str(restart_dir.join("grid_spec"))
     src_path = str(restart_dir)
-    toa_pressure = TOA_PRESSURE
+    toa_pressure = str(TOA_PRESSURE)
     in_res = "48"
     out_res = "6"
     time = "20160101.000000"


### PR DESCRIPTION
We are more frequently running with different vertical level configurations than the 79-level GSRM configuration of X-SHiELD.  These configurations importantly have different top of model pressures.  If this is not properly accounted for when computing pressure at the interfaces and midpoints during the coarsening process, errors are introduced.  These lower-level functions generally all have `toa_pressure` as a parameter; however this parameter is not exposed at the higher level of our restart coarsening routines.  This PR fixes that, making it possible to apply these routines reliably to sets of restart files produced with different model configurations.

[This notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2023-07-28-illustrate-toa-pressure-error.ipynb) illustrates the type of errors one experiences when using the wrong TOA pressure.  `phis` after hydrostatic adjustment is the most sensitive variable.

Added public API:
- A required `toa_pressure` parameter to:
  - `vcm.calc.thermo.vertically_dependent.hydrostatic_dz`
  - `vcm.cubed_sphere.coarsen_restarts.coarsen_restarts_on_sigma`
  - `vcm.cubed_sphere.coarsen_restarts.coarsen_restarts_on_pressure`
  - `vcm.cubed_sphere.coarsen_restarts.coarsen_restarts_via_blended_method`
  - `vcm.cubed_sphere.regridz.regrid_to_area_weighted_pressure`
  - `vcm.cubed_sphere.regridz.regrid_to_edge_weighted_pressure`
- An optional `--toa_pressure` flag to the coarsen restarts dataflow pipeline (default `vcm.calc.thermo.constants.TOA_PRESSURE)`.

Significant internal changes:
- `toa_pressure` argument threaded through numerous internal coarsening functions.

- [x] Tests added

Coverage reports (updated automatically):
