### PR TITLE
Address lint error associated with `flake8` update

### DIFF
--- a/external/radiation/tests/test_driver/test_driver.py
+++ b/external/radiation/tests/test_driver/test_driver.py
@@ -24,7 +24,7 @@ nlay = 63
 
 def getscalars(indict):
     for var in indict.keys():
-        if not type(indict[var]) == dict:
+        if not isinstance(indict[var], dict):
             if indict[var].size == 1:
                 indict[var] = indict[var][0]
 


### PR DESCRIPTION
`flake8` 6.1.0 was released five days ago ([release](https://github.com/PyCQA/flake8/releases/tag/6.1.0)), and seems to have turned up a new lint error in our codebase, which came up in #2302 ([lint build](https://app.circleci.com/pipelines/github/ai2cm/fv3net/14948/workflows/98d52566-9577-4959-8415-c3863bf2126c/jobs/142513)):

```
external/radiation/tests/test_driver/test_driver.py:27:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

This PR addresses this lint error.

Coverage reports (updated automatically):
