### PR TITLE
Load and call reservoir adapters in prognostic run

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/__init__.py
@@ -10,3 +10,4 @@ from .domain import RankDivider
 from .transformers.autoencoder import Autoencoder
 from .transformers.sk_transformer import SkTransformer
 from .cubed_sphere import CubedSphereDivider
+from .adapters import HybridReservoirDatasetAdapter, ReservoirDatasetAdapter

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -146,6 +146,9 @@ class HybridReservoirDatasetAdapter(Predictor):
         )  # x, y, feature dims
         self.model.increment_state(xy_input_arrs)
 
+    def reset_state(self):
+        self.model.reset_state()
+
     def dump(self, path):
         self.model.dump(path)
 

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -1,18 +1,10 @@
-import fsspec
 import numpy as np
-import os
-from typing import Iterable, Hashable, Sequence, cast, Union, TypeVar
+from typing import Iterable, Hashable, Sequence
 import xarray as xr
-import yaml
 
-import fv3fit
 from fv3fit import Predictor
-from .domain import RankDivider
 from fv3fit._shared import io
-from .utils import square_even_terms
 from .model import HybridReservoirComputingModel, ReservoirComputingModel
-from .transformers import ReloadableTransfomer, encode_columns, decode_columns
-from ._reshaping import flatten_2d_keeping_columns_contiguous
 
 
 def _transpose_xy_dims(ds: xr.Dataset, rank_dims: Sequence[str]):
@@ -31,70 +23,139 @@ def _transpose_xy_dims(ds: xr.Dataset, rank_dims: Sequence[str]):
     return ds.transpose(*ordered_dims, ...)
 
 
-ReservoirModel = TypeVar("T", HybridReservoirComputingModel, ReservoirComputingModel)
+class DatasetAdapter:
+    def __init__(
+        self,
+        input_variables: Iterable[Hashable],
+        output_variables: Iterable[Hashable],
+        rank_dims: Sequence[str],
+    ):
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+        self.rank_dims = rank_dims
+
+    def _ndarray_to_dataarray(self, arr: np.ndarray) -> xr.DataArray:
+        dims = [*self.rank_dims]
+        if len(arr.shape) == 3 and arr.shape[-1] > 1:
+            dims.append("z")
+        return xr.DataArray(data=arr, dims=dims)
+
+    def output_array_to_ds(
+        self, outputs: Sequence[np.ndarray], output_dims: Sequence[str]
+    ) -> xr.Dataset:
+        return xr.Dataset(
+            {
+                var: self._ndarray_to_dataarray(output)
+                for var, output in zip(self.output_variables, outputs)
+            }
+        ).transpose(*output_dims)
+
+    def input_dataset_to_arrays(
+        self, inputs: xr.Dataset, variables: Iterable[Hashable]
+    ) -> Sequence[np.ndarray]:
+        # Converts from xr dataset to sequence of variable ndarrays expected by encoder
+        # Make sure the xy dimensions match the rank divider
+        transposed_inputs = _transpose_xy_dims(ds=inputs, rank_dims=self.rank_dims)
+        input_arrs = []
+        for variable in variables:
+            da = transposed_inputs[variable]
+            if "z" not in da.dims:
+                da = da.expand_dims("z", axis=-1)
+            input_arrs.append(da.values)
+        return input_arrs
 
 
 @io.register("reservoir-adapter")
 class ReservoirDatasetAdapter(Predictor):
     def __init__(
         self,
+        model: ReservoirComputingModel,
         input_variables: Iterable[Hashable],
         output_variables: Iterable[Hashable],
-        model: ReservoirModel,
     ) -> None:
         self.model = model
-        if isinstance(model, HybridReservoirComputingModel):
-            self.input_variables = list(
-                set(input_variables.union(model.hybrid_variables))
-            )
-        else:
-            self.input_variables = input_variables
+        self.input_variables = input_variables
         self.output_variables = output_variables
-
-    def _ndarray_to_dataarray(self, arr: np.ndarray) -> xr.DataArray:
-        dims = [*self.model.rank_divider.rank_dims]
-        if len(arr.shape) == 3 and arr.shape[-1] > 1:
-            dims.append("z")
-        return xr.DataArray(data=arr, dims=dims)
-
-    def _output_array_to_ds(
-        self, outputs: Sequence[np.ndarray], output_dims: Sequence[str]
-    ) -> xr.Dataset:
-        return xr.Dataset(
-            {
-                var: self._ndarray_to_dataarray(output)
-                for var, output in zip(self.model.output_variables, outputs)
-            }
-        ).transpose(*output_dims)
+        self.model_adapter = DatasetAdapter(
+            input_variables=input_variables,
+            output_variables=output_variables,
+            rank_dims=model.rank_divider.rank_dims,
+        )
 
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
-        # TODO: potentially use in train.py instead of special functions there
-        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
-        predict_args = []
-        if isinstance(self.model, HybridReservoirComputingModel):
-            predict_args = [
-                xy_input_arrs,
-            ]
-        prediction_arr = self.model.predict(**predict_args)
-        return self._output_array_to_ds(prediction_arr, dims=list(inputs.dims))
+        # inputs arg is not used, but is required by Predictor signature and prog run
+        prediction_arr = self.model.predict()
+        return self.model_adapter.output_array_to_ds(
+            prediction_arr, output_dims=list(inputs.dims)
+        )
 
     def increment_state(self, inputs: xr.Dataset):
-        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
+        xy_input_arrs = self.model_adapter.input_dataset_to_arrays(
+            inputs, self.input_variables
+        )  # x, y, feature dims
         self.model.increment_state(xy_input_arrs)
 
     def reset_state(self):
         self.model.reset_state()
 
-    def _input_dataset_to_arrays(self, inputs: xr.Dataset) -> Sequence[np.ndarray]:
-        # Converts from xr dataset to sequence of variable ndarrays expected by encoder
-        # Make sure the xy dimensions match the rank divider
-        transposed_inputs = _transpose_xy_dims(
-            ds=inputs, rank_dims=self.model.rank_divider.rank_dims
+    def dump(self, path):
+        self.model.dump(path)
+
+    @classmethod
+    def load(cls, path: str) -> "ReservoirDatasetAdapter":
+        model = ReservoirComputingModel.load(path)
+        model.reset_state()
+        adapter = cls(
+            input_variables=model.input_variables,
+            output_variables=model.output_variables,
+            model=model,
         )
-        input_arrs = []
-        for variable in self.model.input_variables:
-            da = transposed_inputs[variable]
-            if "z" not in da.dims:
-                da = da.expand_dims("z", axis=-1)
-            input_arrs.append(da.values)
-        return input_arrs
+        return adapter
+
+
+@io.register("hybrid-reservoir-adapter")
+class HybridReservoirDatasetAdapter(Predictor):
+    def __init__(
+        self,
+        model: HybridReservoirComputingModel,
+        input_variables: Iterable[Hashable],
+        output_variables: Iterable[Hashable],
+    ) -> None:
+        self.model = model
+        self.input_variables = list(set(input_variables).union(model.hybrid_variables))
+        self.output_variables = output_variables
+        self.model_adapter = DatasetAdapter(
+            input_variables=self.input_variables,
+            output_variables=output_variables,
+            rank_dims=model.rank_divider.rank_dims,
+        )
+
+    def predict(self, inputs: xr.Dataset) -> xr.Dataset:
+        xy_input_arrs = self.model_adapter.input_dataset_to_arrays(
+            inputs, self.model.hybrid_variables
+        )  # x, y, feature dims
+
+        prediction_arr = self.model.predict(xy_input_arrs)
+        return self.model_adapter.output_array_to_ds(
+            prediction_arr, output_dims=list(inputs.dims)
+        )
+
+    def increment_state(self, inputs: xr.Dataset):
+        xy_input_arrs = self.model_adapter.input_dataset_to_arrays(
+            inputs, self.input_variables
+        )  # x, y, feature dims
+        self.model.increment_state(xy_input_arrs)
+
+    def dump(self, path):
+        self.model.dump(path)
+
+    @classmethod
+    def load(cls, path: str) -> "HybridReservoirDatasetAdapter":
+        model = HybridReservoirComputingModel.load(path)
+        model.reset_state()
+        adapter = cls(
+            input_variables=model.input_variables,
+            output_variables=model.output_variables,
+            model=model,
+        )
+        return adapter

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -1,0 +1,100 @@
+import fsspec
+import numpy as np
+import os
+from typing import Iterable, Hashable, Sequence, cast, Union, TypeVar
+import xarray as xr
+import yaml
+
+import fv3fit
+from fv3fit import Predictor
+from .domain import RankDivider
+from fv3fit._shared import io
+from .utils import square_even_terms
+from .model import HybridReservoirComputingModel, ReservoirComputingModel
+from .transformers import ReloadableTransfomer, encode_columns, decode_columns
+from ._reshaping import flatten_2d_keeping_columns_contiguous
+
+
+def _transpose_xy_dims(ds: xr.Dataset, rank_dims: Sequence[str]):
+    # Useful for transposing the x, y dims in a dataset to match those in
+    # RankDivider.rank_dims, and leaves other dims in the same order
+    # relative to x,y. Dims after the first occurence of one of the rank_dims
+    # are assumed to be feature dims.
+    # e.g. (time, y, x, z) -> (time, x, y, z) for rank_dims=(x, y)
+    leading_non_xy_dims = []
+    for dim in ds.dims:
+        if dim not in rank_dims:
+            leading_non_xy_dims.append(dim)
+        if dim in rank_dims:
+            break
+    ordered_dims = (*leading_non_xy_dims, *rank_dims)
+    return ds.transpose(*ordered_dims, ...)
+
+
+ReservoirModel = TypeVar("T", HybridReservoirComputingModel, ReservoirComputingModel)
+
+
+@io.register("reservoir-adapter")
+class ReservoirDatasetAdapter(Predictor):
+    def __init__(
+        self,
+        input_variables: Iterable[Hashable],
+        output_variables: Iterable[Hashable],
+        model: ReservoirModel,
+    ) -> None:
+        self.model = model
+        if isinstance(model, HybridReservoirComputingModel):
+            self.input_variables = list(
+                set(input_variables.union(model.hybrid_variables))
+            )
+        else:
+            self.input_variables = input_variables
+        self.output_variables = output_variables
+
+    def _ndarray_to_dataarray(self, arr: np.ndarray) -> xr.DataArray:
+        dims = [*self.model.rank_divider.rank_dims]
+        if len(arr.shape) == 3 and arr.shape[-1] > 1:
+            dims.append("z")
+        return xr.DataArray(data=arr, dims=dims)
+
+    def _output_array_to_ds(
+        self, outputs: Sequence[np.ndarray], output_dims: Sequence[str]
+    ) -> xr.Dataset:
+        return xr.Dataset(
+            {
+                var: self._ndarray_to_dataarray(output)
+                for var, output in zip(self.model.output_variables, outputs)
+            }
+        ).transpose(*output_dims)
+
+    def predict(self, inputs: xr.Dataset) -> xr.Dataset:
+        # TODO: potentially use in train.py instead of special functions there
+        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
+        predict_args = []
+        if isinstance(self.model, HybridReservoirComputingModel):
+            predict_args = [
+                xy_input_arrs,
+            ]
+        prediction_arr = self.model.predict(**predict_args)
+        return self._output_array_to_ds(prediction_arr, dims=list(inputs.dims))
+
+    def increment_state(self, inputs: xr.Dataset):
+        xy_input_arrs = self._input_dataset_to_arrays(inputs)  # x, y, feature dims
+        self.model.increment_state(xy_input_arrs)
+
+    def reset_state(self):
+        self.model.reset_state()
+
+    def _input_dataset_to_arrays(self, inputs: xr.Dataset) -> Sequence[np.ndarray]:
+        # Converts from xr dataset to sequence of variable ndarrays expected by encoder
+        # Make sure the xy dimensions match the rank divider
+        transposed_inputs = _transpose_xy_dims(
+            ds=inputs, rank_dims=self.model.rank_divider.rank_dims
+        )
+        input_arrs = []
+        for variable in self.model.input_variables:
+            da = transposed_inputs[variable]
+            if "z" not in da.dims:
+                da = da.expand_dims("z", axis=-1)
+            input_arrs.append(da.values)
+        return input_arrs

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 from typing import Iterable, Hashable, Sequence
 import xarray as xr
 
@@ -67,6 +68,8 @@ class DatasetAdapter:
 
 @io.register("reservoir-adapter")
 class ReservoirDatasetAdapter(Predictor):
+    MODEL_DIR = "reservoir_model"
+
     def __init__(
         self,
         model: ReservoirComputingModel,
@@ -99,11 +102,11 @@ class ReservoirDatasetAdapter(Predictor):
         self.model.reset_state()
 
     def dump(self, path):
-        self.model.dump(path)
+        self.model.dump(os.path.join(path, self.MODEL_DIR))
 
     @classmethod
     def load(cls, path: str) -> "ReservoirDatasetAdapter":
-        model = ReservoirComputingModel.load(path)
+        model = ReservoirComputingModel.load(os.path.join(path, cls.MODEL_DIR))
         model.reset_state()
         adapter = cls(
             input_variables=model.input_variables,
@@ -115,6 +118,8 @@ class ReservoirDatasetAdapter(Predictor):
 
 @io.register("hybrid-reservoir-adapter")
 class HybridReservoirDatasetAdapter(Predictor):
+    MODEL_DIR = "hybrid_reservoir_model"
+
     def __init__(
         self,
         model: HybridReservoirComputingModel,
@@ -150,11 +155,11 @@ class HybridReservoirDatasetAdapter(Predictor):
         self.model.reset_state()
 
     def dump(self, path):
-        self.model.dump(path)
+        self.model.dump(os.path.join(path, self.MODEL_DIR))
 
     @classmethod
     def load(cls, path: str) -> "HybridReservoirDatasetAdapter":
-        model = HybridReservoirComputingModel.load(path)
+        model = HybridReservoirComputingModel.load(os.path.join(path, cls.MODEL_DIR))
         model.reset_state()
         adapter = cls(
             input_variables=model.input_variables,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -17,6 +17,7 @@ from . import (
     ReservoirTrainingConfig,
     ReservoirComputingReadout,
 )
+from .adapters import ReservoirDatasetAdapter, HybridReservoirDatasetAdapter
 from .readout import combine_readouts
 from .domain import RankDivider
 from ._reshaping import stack_array_preserving_last_dim
@@ -144,6 +145,11 @@ def train_reservoir_model(
             rank_divider=rank_divider,
             autoencoder=autoencoder,
         )
+        return ReservoirDatasetAdapter(
+            model=model,
+            input_variables=model.input_variables,
+            output_variables=model.output_variables,
+        )
     else:
         model = HybridReservoirComputingModel(
             input_variables=hyperparameters.input_variables,
@@ -155,7 +161,11 @@ def train_reservoir_model(
             rank_divider=rank_divider,
             autoencoder=autoencoder,
         )
-    return model
+        return HybridReservoirDatasetAdapter(
+            model=model,
+            input_variables=model.input_variables,
+            output_variables=model.output_variables,
+        )
 
 
 def _get_reservoir_state_time_series(

--- a/external/fv3fit/tests/reservoir/_regtest_outputs/test_model_adapter.test_nonhybrid_adapter_predict.out
+++ b/external/fv3fit/tests/reservoir/_regtest_outputs/test_model_adapter.test_nonhybrid_adapter_predict.out
@@ -1,0 +1,6 @@
+<xarray.Dataset>
+Dimensions:  (x: 4, y: 4, z: 3)
+Dimensions without coordinates: x, y, z
+Data variables:
+    a        (x, y, z) float64 0.9064 0.1769 0.5555 ... 0.8058 0.1051 0.6322
+    b        (x, y, z) float64 0.7414 0.9793 0.2091 ... 0.7822 0.6339 0.6977

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -58,7 +58,8 @@ def test_train_reservoir():
         n_batches_burn=2,
         input_noise=0.01,
     )
-    model = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)
+    adapter = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)
+    model = adapter.model
     model.reset_state()
 
     assert model.predict()[0].shape == (

--- a/workflows/diagnostics/fv3net/diagnostics/reservoir/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/reservoir/compute.py
@@ -3,20 +3,26 @@ import fsspec
 import numpy as np
 import os
 from tempfile import NamedTemporaryFile
-from typing import Union, Optional, Sequence
+from typing import Union, Optional, Sequence, cast
 import xarray as xr
 import vcm
 import yaml
 
 import fv3fit
 from fv3fit.reservoir.utils import get_ordered_X
-from fv3fit.reservoir import ReservoirComputingModel, HybridReservoirComputingModel
+from fv3fit.reservoir import (
+    ReservoirComputingModel,
+    HybridReservoirComputingModel,
+    HybridReservoirDatasetAdapter,
+    ReservoirDatasetAdapter,
+)
 
 import logging
 
 logger = logging.getLogger(__name__)
 
 ReservoirModel = Union[ReservoirComputingModel, HybridReservoirComputingModel]
+ReservoirAdapter = Union[HybridReservoirDatasetAdapter, ReservoirDatasetAdapter]
 
 
 def _get_parser() -> argparse.ArgumentParser:
@@ -112,7 +118,8 @@ def _get_states_without_overlap(
 
 
 def main(args):
-    model: ReservoirModel = fv3fit.load(args.reservoir_model_path)
+    adapter = cast(ReservoirAdapter, fv3fit.load(args.reservoir_model_path))
+    model: ReservoirModel = adapter.model
     with fsspec.open(args.validation_config_path, "r") as f:
         val_data_config = yaml.safe_load(f)
     val_batches = _load_batches(


### PR DESCRIPTION
- adds an adapter for non-hybrid reservoir and moves all adapter-related code to `reservoir.adapters`
- refactor the dataset operations into separate `DatasetAdapter` class and use composition for the predictors
- add dump and load

 Added public API:
- HybridReservoirDatasetAdapter, ReservoirDatasetAdapter
 
  

- [x] Tests added
 