### PR TITLE
Reservoir separate transforms

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -59,6 +59,13 @@ class BatchLinearRegressorHyperparameters:
 
 
 @dataclass
+class TransformerConfig:
+    input: Optional[str] = None
+    output: Optional[str] = None
+    hybrid: Optional[str] = None
+
+
+@dataclass
 class ReservoirTrainingConfig(Hyperparameters):
     """
     input_variables: variables and additional features in time series
@@ -91,6 +98,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     n_batches_burn: int
     input_noise: float
     seed: int = 0
+    transformers: Optional[TransformerConfig] = None
     n_jobs: Optional[int] = 1
     square_half_hidden_state: bool = False
     autoencoder_path: Optional[str] = None
@@ -138,6 +146,11 @@ class ReservoirTrainingConfig(Hyperparameters):
         kwargs["subdomain"] = dacite.from_dict(
             data_class=CubedsphereSubdomainConfig,
             data=kwargs.get("subdomain", {}),
+            config=dacite_config,
+        )
+        kwargs["transformers"] = dacite.from_dict(
+            data_class=TransformerConfig,
+            data=kwargs.get("transformers", {}),
             config=dacite_config,
         )
         return dacite.from_dict(

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -86,8 +86,9 @@ class ReservoirTrainingConfig(Hyperparameters):
         state before it is used as input to the regressor's .fit and
         .predict methods. This option was found to be important for skillful
         predictions in Wikner+2020 (https://doi.org/10.1063/5.0005541)
-    autoencoder_path: optional path for autoencoder to use in encoding time series
-        before passing to reservoir
+    transformers: optional TransformerConfig for autoencoders to use in
+        encoding input, output, and/or hybrid variable sets.
+
     """
 
     input_variables: Sequence[str]
@@ -101,7 +102,6 @@ class ReservoirTrainingConfig(Hyperparameters):
     transformers: Optional[TransformerConfig] = None
     n_jobs: Optional[int] = 1
     square_half_hidden_state: bool = False
-    autoencoder_path: Optional[str] = None
     hybrid_variables: Optional[Sequence[str]] = None
     _METADATA_NAME = "reservoir_training_config.yaml"
 
@@ -168,7 +168,7 @@ class ReservoirTrainingConfig(Hyperparameters):
             "reservoir_hyperparameters": asdict(self.reservoir_hyperparameters),
             "readout_hyperparameters": asdict(self.readout_hyperparameters),
             "subdomain": asdict(self.subdomain),
-            "autoencoder_path": self.autoencoder_path,
+            "transformers": asdict(self.transformers),
         }
         fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
         fs.makedirs(path, exist_ok=True)

--- a/external/fv3fit/fv3fit/reservoir/domain2.py
+++ b/external/fv3fit/fv3fit/reservoir/domain2.py
@@ -124,6 +124,14 @@ class RankXYDivider:
         else:
             return False
 
+    def get_new_zdim_rank_divider(self, z_feature_size: int):
+        return RankXYDivider(
+            subdomain_layout=self.subdomain_layout,
+            overlap=self.overlap,
+            rank_extent=self.rank_extent,
+            z_feature_size=z_feature_size,
+        )
+
     def get_no_overlap_rank_divider(self):
         if self.overlap == 0:
             return self

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -69,6 +69,8 @@ def _get_transformers(
         transformers["hybrid"] = get_standard_normalizing_transformer(
             hyperparameters.hybrid_variables, sample_batch
         )
+    else:
+        transformers["hybrid"] = transformers["input"]
     return TransformerGroup(**transformers)
 
 
@@ -142,7 +144,7 @@ def train_reservoir_model(
 
         if hyperparameters.hybrid_variables is not None:
             _hybrid_rank_divider_with_overlap = rank_divider.get_new_zdim_rank_divider(
-                z_feature_size=transformers.hybrid.n_latent_dims  # type: ignore
+                z_feature_size=transformers.hybrid.n_latent_dims
             )
             hybrid_time_series = process_batch_data(
                 variables=hyperparameters.hybrid_variables,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -118,6 +118,15 @@ def train_reservoir_model(
             rank_divider=rank_divider,
             autoencoder=transformers.input,
         )
+        # If the output variables differ from inputs, use the transformer specific
+        # to the output set to transform the output data
+        if hyperparameters.output_variables != hyperparameters.input_variables:
+            _, time_series_without_overlap = process_batch_Xy_data(
+                variables=hyperparameters.output_variables,
+                batch_data=batch_data,
+                rank_divider=rank_divider,
+                autoencoder=transformers.output,
+            )
 
         # reservoir increment occurs in this call, so always call this
         # function even if X, Y are not used for readout training.
@@ -125,6 +134,7 @@ def train_reservoir_model(
             time_series_with_overlap, hyperparameters.input_noise, reservoir
         )
         sync_tracker.count_synchronization_steps(len(reservoir_state_time_series))
+
         hybrid_time_series: Optional[np.ndarray]
         if hyperparameters.hybrid_variables is not None:
             _, hybrid_time_series = process_batch_Xy_data(
@@ -174,7 +184,7 @@ def train_reservoir_model(
             readout=readout,
             square_half_hidden_state=hyperparameters.square_half_hidden_state,
             rank_divider=rank_divider,  # type: ignore
-            autoencoder=transformers.input,
+            transformers=transformers,
         )
         return ReservoirDatasetAdapter(
             model=model,
@@ -190,7 +200,7 @@ def train_reservoir_model(
             readout=readout,
             square_half_hidden_state=hyperparameters.square_half_hidden_state,
             rank_divider=rank_divider,  # type: ignore
-            autoencoder=transformers.input,
+            transformers=transformers,
         )
         return HybridReservoirDatasetAdapter(
             model=model,

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -54,23 +54,23 @@ def _get_transformers(
 
     # If output transformer not specified and output_variables != input_variables,
     # create a separate standard norm transform
-    if "output" not in transformers and (
-        hyperparameters.output_variables != hyperparameters.input_variables
-    ):
-        transformers["output"] = get_standard_normalizing_transformer(
-            hyperparameters.output_variables, sample_batch
-        )
-    else:
-        transformers["output"] = transformers["input"]
+    if "output" not in transformers:
+        if hyperparameters.output_variables != hyperparameters.input_variables:
+            transformers["output"] = get_standard_normalizing_transformer(
+                hyperparameters.output_variables, sample_batch
+            )
+        else:
+            transformers["output"] = transformers["input"]
 
     # If hybrid variables transformer not specified, and hybrid variables are defined,
     # create a separate standard norm transform
-    if "hybrid" not in transformers and hyperparameters.hybrid_variables is not None:
-        transformers["hybrid"] = get_standard_normalizing_transformer(
-            hyperparameters.hybrid_variables, sample_batch
-        )
-    else:
-        transformers["hybrid"] = transformers["input"]
+    if "hybrid" not in transformers:
+        if hyperparameters.hybrid_variables is not None:
+            transformers["hybrid"] = get_standard_normalizing_transformer(
+                hyperparameters.hybrid_variables, sample_batch
+            )
+        else:
+            transformers["hybrid"] = transformers["input"]
     return TransformerGroup(**transformers)
 
 

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -1,6 +1,11 @@
 from .autoencoder import Autoencoder, build_concat_and_scale_only_autoencoder
 from .sk_transformer import SkTransformer
-from .transformer import encode_columns, DoNothingAutoencoder, decode_columns
+from .transformer import (
+    encode_columns,
+    DoNothingAutoencoder,
+    decode_columns,
+    TransformerGroup,
+)
 from typing import Union
 
 ReloadableTransfomer = Union[Autoencoder, SkTransformer]

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -8,5 +8,3 @@ from .transformer import (
     TransformerGroup,
 )
 from typing import Union
-
-# ReloadableTransformer = Union[Autoencoder, SkTransformer]

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -1,4 +1,4 @@
-from .autoencoder import Autoencoder
+from .autoencoder import Autoencoder, build_concat_and_scale_only_autoencoder
 from .sk_transformer import SkTransformer
 from .transformer import encode_columns, DoNothingAutoencoder, decode_columns
 from typing import Union

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -36,7 +36,7 @@ class Transformer(BaseTransformer, Reloadable):
 
 
 @io.register("do-nothing-transformer")
-class DoNothingAutoencoder(Transformer, Reloadable):
+class DoNothingAutoencoder(Transformer):
     _CONFIG_NAME = "mock_transformer.yaml"
 
     """Useful class for tests. Encode just concatenates input

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -83,7 +83,6 @@ class TransformerGroup:
     INPUT_DIR = "input_transformer"
     OUTPUT_DIR = "output_transformer"
     HYBRID_DIR = "hybrid_transformer"
-    CONFIG_NAME = "config.yaml"
 
     def __init__(
         self,

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -83,43 +83,35 @@ class TransformerGroup:
     INPUT_DIR = "input_transformer"
     OUTPUT_DIR = "output_transformer"
     HYBRID_DIR = "hybrid_transformer"
+    CONFIG_NAME = "config.yaml"
 
     def __init__(
         self,
         input: Transformer,
-        output: Optional[Transformer] = None,
+        output: Transformer,
         hybrid: Optional[Transformer] = None,
     ):
         self.input = input
-        self._output_same_as_input = True if output is None else False
-        self._hybrid_same_as_input = True if hybrid is None else False
-        self.output = output or input
-        self.hybrid = hybrid or input
+        self.output = output
+        self.hybrid = hybrid
 
     def dump(self, path):
+
         self.input.dump(os.path.join(path, self.INPUT_DIR))
-        if not self._output_same_as_input:
-            self.output.dump(os.path.join(path, self.OUTPUT_DIR))
-        if not self._hybrid_same_as_input:
+        self.output.dump(os.path.join(path, self.OUTPUT_DIR))
+        if self.hybrid is not None:
             self.hybrid.dump(os.path.join(path, self.HYBRID_DIR))
 
     @classmethod
     def load(cls, path) -> "TransformerGroup":
         input = cast(Transformer, fv3fit.load(os.path.join(path, cls.INPUT_DIR)))
-
-        try:
-            output: Optional[Transformer] = cast(
-                Transformer, fv3fit.load(os.path.join(path, cls.OUTPUT_DIR))
-            )
-        except (KeyError):
-            output = None
+        output = cast(Transformer, fv3fit.load(os.path.join(path, cls.OUTPUT_DIR)))
         try:
             hybrid: Optional[Transformer] = cast(
                 Transformer, fv3fit.load(os.path.join(path, cls.HYBRID_DIR))
             )
         except (KeyError):
             hybrid = None
-
         return cls(input=input, output=output, hybrid=hybrid)
 
 

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import tensorflow as tf
-from typing import Iterable, Mapping
+from typing import Iterable, Mapping, Optional
 from fv3fit.reservoir.transformers import (
     # ReloadableTransformer,
     Transformer,
@@ -68,7 +68,7 @@ def process_batch_data(
     variables: Iterable[str],
     batch_data: Mapping[str, tf.Tensor],
     rank_divider: RankXYDivider,
-    autoencoder: Transformer,
+    autoencoder: Optional[Transformer],
     trim_halo: bool,
 ):
     """ Converts physical state to latent state
@@ -81,7 +81,8 @@ def process_batch_data(
 
     # Concatenate features, normalize and optionally convert data
     # to latent representation
-    data_encoded = encode_columns(data, autoencoder)
+    if autoencoder is not None:
+        data_encoded = encode_columns(data, autoencoder)
 
     if trim_halo:
         data_trimmed = rank_divider.trim_halo_from_rank_data(data_encoded)

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -1,8 +1,13 @@
 import numpy as np
 import tensorflow as tf
 from typing import Iterable, Mapping, Tuple
-from fv3fit.reservoir.transformers import ReloadableTransfomer, encode_columns
+from fv3fit.reservoir.transformers import (
+    ReloadableTransfomer,
+    encode_columns,
+    build_concat_and_scale_only_autoencoder,
+)
 from fv3fit.reservoir.domain import RankDivider, assure_txyz_dims
+from ._reshaping import stack_array_preserving_last_dim
 
 
 def _square_evens(v: np.ndarray) -> np.ndarray:
@@ -66,4 +71,14 @@ def process_batch_Xy_data(
     return (
         np.stack(time_series_X_reshaped, axis=0),
         np.stack(time_series_Y_reshaped, axis=0),
+    )
+
+
+def get_standard_normalizing_transformer(variables, sample_batch):
+    variable_data = get_ordered_X(sample_batch, variables)
+    variable_data_stacked = [
+        stack_array_preserving_last_dim(arr).numpy() for arr in variable_data
+    ]
+    return build_concat_and_scale_only_autoencoder(
+        variables=variables, X=variable_data_stacked
     )

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -75,7 +75,6 @@ def process_batch_data(
     and reshape data into the format used in training.
     The rank divider provided includes the full overlap, since
     the data it is operating on includes all halo points.
-    The rank
     """
     data = get_ordered_X(batch_data, variables)
 

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -2,7 +2,10 @@ import numpy as np
 import pytest
 import xarray as xr
 import fv3fit
-from fv3fit.reservoir.transformers.transformer import DoNothingAutoencoder
+from fv3fit.reservoir.transformers.transformer import (
+    DoNothingAutoencoder,
+    TransformerGroup,
+)
 from fv3fit.reservoir.domain2 import RankXYDivider
 from fv3fit.reservoir.readout import ReservoirComputingReadout
 from fv3fit.reservoir import (
@@ -33,8 +36,7 @@ def test__transpose_xy_dims(original_dims, reordered_dims):
 def get_initialized_model(hybrid: bool):
     # expects rank size (including halos) in latent space
     divider = RankXYDivider((2, 2), 2, overlap_rank_extent=(8, 8), z_feature_size=6)
-    autoencoder = DoNothingAutoencoder([3, 3])
-
+    transformers = TransformerGroup(input=DoNothingAutoencoder([3, 3]))
     state_size = 25
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,
@@ -69,7 +71,7 @@ def get_initialized_model(hybrid: bool):
             reservoir=reservoir,
             readout=readout,
             rank_divider=divider,
-            autoencoder=autoencoder,
+            transformers=transformers,
         )
     else:
         predictor = ReservoirComputingModel(
@@ -78,7 +80,7 @@ def get_initialized_model(hybrid: bool):
             reservoir=reservoir,
             readout=readout,
             rank_divider=divider,
-            autoencoder=autoencoder,
+            transformers=transformers,
         )
     predictor.reset_state()
 

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -36,7 +36,10 @@ def test__transpose_xy_dims(original_dims, reordered_dims):
 def get_initialized_model(hybrid: bool):
     # expects rank size (including halos) in latent space
     divider = RankXYDivider((2, 2), 2, overlap_rank_extent=(8, 8), z_feature_size=6)
-    transformers = TransformerGroup(input=DoNothingAutoencoder([3, 3]))
+    transformer = DoNothingAutoencoder([3, 3])
+    transformers = TransformerGroup(
+        input=transformer, output=transformer, hybrid=transformer
+    )
     state_size = 25
     hyperparameters = ReservoirHyperparameters(
         state_size=state_size,

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -53,7 +53,9 @@ def get_ReservoirComputingModel(
         coefficients=np.random.rand(rank_divider.n_subdomains, state_size, input_size),
         intercepts=np.random.rand(input_size),
     )
-    transformers = TransformerGroup(input=autoencoder, output=autoencoder)
+    transformers = TransformerGroup(
+        input=autoencoder, output=autoencoder, hybrid=autoencoder
+    )
     predictor = ReservoirComputingModel(
         input_variables=variables,
         output_variables=variables,
@@ -137,7 +139,9 @@ def test_ReservoirComputingModel_state_increment():
 
     input = [(0.25 * np.ones((*rank_divider.rank_extent, 1)))]
     transformer = DoNothingAutoencoder([1])
-    transformers = TransformerGroup(input=transformer, output=transformer)
+    transformers = TransformerGroup(
+        input=transformer, output=transformer, hybrid=transformer
+    )
     transformers.input.encode(input)
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -53,7 +53,7 @@ def get_ReservoirComputingModel(
         coefficients=np.random.rand(rank_divider.n_subdomains, state_size, input_size),
         intercepts=np.random.rand(input_size),
     )
-    transformers = TransformerGroup(input=autoencoder)
+    transformers = TransformerGroup(input=autoencoder, output=autoencoder)
     predictor = ReservoirComputingModel(
         input_variables=variables,
         output_variables=variables,
@@ -136,8 +136,8 @@ def test_ReservoirComputingModel_state_increment():
     readout = MultiOutputMeanRegressor(n_outputs=input_size)
 
     input = [(0.25 * np.ones((*rank_divider.rank_extent, 1)))]
-
-    transformers = TransformerGroup(input=DoNothingAutoencoder([1]))
+    transformer = DoNothingAutoencoder([1])
+    transformers = TransformerGroup(input=transformer, output=transformer)
     transformers.input.encode(input)
     predictor = ReservoirComputingModel(
         input_variables=["a", "b"],

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -120,7 +120,7 @@ def test_prediction_shape(nz, nvars):
 
 
 def test_ReservoirComputingModel_state_increment():
-    rank_divider = RankXYDivider((1, 1), 0, rank_extent=(2, 2))
+    rank_divider = RankXYDivider((1, 1), 0, rank_extent=(2, 2), z_feature_size=1)
     input_size = rank_divider.flat_subdomain_len
     state_size = 3
     hyperparameters = ReservoirHyperparameters(
@@ -135,7 +135,7 @@ def test_ReservoirComputingModel_state_increment():
 
     readout = MultiOutputMeanRegressor(n_outputs=input_size)
 
-    input = [(0.25 * np.ones((input_size))).reshape(rank_divider.rank_extent)]
+    input = [(0.25 * np.ones((*rank_divider.rank_extent, 1)))]
 
     transformers = TransformerGroup(input=DoNothingAutoencoder([1]))
     transformers.input.encode(input)

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -1,33 +1,11 @@
 import numpy as np
-import os
 import pytest
 
 from fv3fit.reservoir.transformers.transformer import (
     encode_columns,
     DoNothingAutoencoder,
     decode_columns,
-    TransformerGroup,
 )
-
-
-@pytest.mark.parametrize("hybrid_transformer", [None, DoNothingAutoencoder([2])])
-def test_TransformerGroup(tmpdir, hybrid_transformer):
-    input_transformer = DoNothingAutoencoder([4])
-    output_transformer = DoNothingAutoencoder([2])
-
-    transformers = TransformerGroup(
-        input=input_transformer, output=output_transformer, hybrid=hybrid_transformer,
-    )
-    n_saved_transformers = 3 if hybrid_transformer is not None else 2
-    transformers.dump(str(tmpdir))
-    assert len(os.listdir(str(tmpdir))) == n_saved_transformers
-    loaded_transformers = TransformerGroup.load(str(tmpdir))
-
-    x = np.random.rand(2)
-    if hybrid_transformer is not None:
-        np.testing.assert_array_equal(
-            loaded_transformers.hybrid.encode([x]), hybrid_transformer.encode([x])
-        )
 
 
 @pytest.mark.parametrize("nz, nvars", [(2, 2), (2, 1), (1, 2), (1, 1)])


### PR DESCRIPTION
This PR adds the ability to load separate transforms for input/output/hybrid variable sets (or fit different standard normalization transforms if not specified). These are organized in a new `TransformerGroup` class that replaces the single `autoencoder` attribute of the reservoir models. 

If the output variable list is different from the input variable list, the training script will use the output transformer when preparing the paired output set.

Added public API:
- The previous single `autoencoder_path` parameter in the `ReservoirTrainingConfig` is now replaced by a `TransformerConfig` which contains optional paths for input, output, and hybrid transformers

Refactored public API:
- Aforementioned API change breaks old configs
- Breaks old model loading, since models now dump and load a `TransformerGroup` instead of a single autoencoder 

 

- [ x] Tests added
 