### PR TITLE
Decoder always returns list of arrays

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
@@ -14,7 +14,7 @@ from fv3fit._shared import (
     DatasetPredictor,
 )
 from fv3fit._shared.training_config import Hyperparameters
-
+from tensorflow.python.keras.utils.generic_utils import to_list
 from fv3fit.keras import (
     train_pure_keras_model,
     CallbackConfig,
@@ -68,8 +68,8 @@ class Autoencoder(tf.keras.Model, Transformer):
         x = _ensure_all_items_have_sample_dim(x)
         return self.encoder.predict(x)
 
-    def decode(self, latent_x: ArrayLike) -> ArrayLike:
-        return self.decoder.predict(latent_x)
+    def decode(self, latent_x: ArrayLike) -> Sequence[ArrayLike]:
+        return to_list(self.decoder.predict(latent_x))
 
     def dump(self, path: str) -> None:
         with put_dir(path) as path:

--- a/external/fv3fit/tests/reservoir/test_autoencoder.py
+++ b/external/fv3fit/tests/reservoir/test_autoencoder.py
@@ -14,6 +14,14 @@ test_inputs = [
 ]
 
 
+def test_decode_single_output_returns_list():
+    model = build_concat_and_scale_only_autoencoder(["a"], [a])
+    encoded = model.encode([test_inputs[0]])
+    decoded = model.decode(encoded)
+    assert isinstance(decoded, list)
+    assert len(decoded) == 1
+
+
 def test_build_concat_and_scale_only_autoencoder_normalize():
     model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
     np.testing.assert_array_almost_equal(


### PR DESCRIPTION
One-liner fix for the case where there is only one output variable. Keras models return a list of arrays for >2 outputs, but just an array for 1 output. This PR ensures a list is always returned.
 