### PR TITLE
Reservoir stepper updates for SST prediction

### DIFF
--- a/external/fv3fit/fv3fit/_shared/halos.py
+++ b/external/fv3fit/fv3fit/_shared/halos.py
@@ -102,7 +102,7 @@ def _get_cubed_sphere_communicator(comm):
     # configuration of the prognostic run
     #
     # This could possibly be changed if/when we integrate with the DSL model
-    layout_1d = int((comm.total_ranks / 6.0) ** 0.5)
+    layout_1d = int((comm.Get_size() / 6.0) ** 0.5)
     return pace.util.CubedSphereCommunicator(
         comm=comm,
         partitioner=pace.util.CubedSpherePartitioner(
@@ -115,7 +115,7 @@ def append_halos_using_mpi(ds: xr.Dataset, n_halo: int) -> xr.Dataset:
     comm = _get_comm()
     if comm.Get_size() < 6:
         raise RuntimeError("to halo update over MPI we need at least 6 ranks")
-    _append_halos_using_mpi(ds=ds, n_halo=n_halo, comm=comm)
+    return _append_halos_using_mpi(ds=ds, n_halo=n_halo, comm=comm)
 
 
 def _append_halos_using_mpi(ds: xr.Dataset, n_halo: int, comm):

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -91,6 +91,11 @@ class ReservoirDatasetAdapter(Predictor):
             output_variables=self.output_variables,
         )
 
+    @property
+    def input_overlap(self):
+        """Number of halo points expected for reservoir increment inputs"""
+        return self.model.rank_divider.overlap
+
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
         # inputs arg is not used, but is required by Predictor signature and prog run
         prediction_arr = self.model.predict()
@@ -147,6 +152,11 @@ class HybridReservoirDatasetAdapter(Predictor):
             input_variables=self.input_variables,
             output_variables=model.output_variables,
         )
+
+    @property
+    def input_overlap(self):
+        """Number of halo points expected for reservoir increment inputs"""
+        return self.model.rank_divider.overlap
 
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
         xy_input_arrs = self.model_adapter.input_dataset_to_arrays(

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -96,6 +96,10 @@ class ReservoirDatasetAdapter(Predictor):
         """Number of halo points expected for reservoir increment inputs"""
         return self.model.rank_divider.overlap
 
+    @property
+    def is_hybrid(self):
+        return False
+
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
         # inputs arg is not used, but is required by Predictor signature and prog run
         prediction_arr = self.model.predict()
@@ -157,6 +161,10 @@ class HybridReservoirDatasetAdapter(Predictor):
     def input_overlap(self):
         """Number of halo points expected for reservoir increment inputs"""
         return self.model.rank_divider.overlap
+
+    @property
+    def is_hybrid(self):
+        return True
 
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
         xy_input_arrs = self.model_adapter.input_dataset_to_arrays(

--- a/workflows/prognostic_c48_run/runtime/diagnostics/time.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/time.py
@@ -109,14 +109,14 @@ class IntervalAveragedTimes(TimeContainer):
     initial_time: cftime.DatetimeJulian
     includes_lower: bool = False
 
-    def is_endpoint(self, time: cftime.DatetimeJulian) -> bool:
+    def _is_endpoint(self, time: cftime.DatetimeJulian) -> bool:
         remainder = (time - self.initial_time) % self.frequency
         return remainder == datetime.timedelta(0)
 
     def indicator(self, time: cftime.DatetimeJulian) -> Optional[cftime.DatetimeJulian]:
         n = (time - self.initial_time) // self.frequency
 
-        if self.is_endpoint(time) and not self.includes_lower:
+        if self._is_endpoint(time) and not self.includes_lower:
             n = n - 1
 
         return n * self.frequency + self.frequency / 2 + self.initial_time

--- a/workflows/prognostic_c48_run/runtime/diagnostics/time.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/time.py
@@ -109,14 +109,14 @@ class IntervalAveragedTimes(TimeContainer):
     initial_time: cftime.DatetimeJulian
     includes_lower: bool = False
 
-    def _is_endpoint(self, time: cftime.DatetimeJulian) -> bool:
+    def is_endpoint(self, time: cftime.DatetimeJulian) -> bool:
         remainder = (time - self.initial_time) % self.frequency
         return remainder == datetime.timedelta(0)
 
     def indicator(self, time: cftime.DatetimeJulian) -> Optional[cftime.DatetimeJulian]:
         n = (time - self.initial_time) // self.frequency
 
-        if self._is_endpoint(time) and not self.includes_lower:
+        if self.is_endpoint(time) and not self.includes_lower:
             n = n - 1
 
         return n * self.frequency + self.frequency / 2 + self.initial_time

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -683,7 +683,6 @@ class TimeLoop(
 
     def _increment_reservoir(self) -> Diagnostics:
         if self._reservior_increment_stepper is not None:
-            self._log_info("Incrementing reservoir state.")
             [_, diags, _] = self._reservior_increment_stepper(
                 self._state.time, self._state
             )
@@ -694,7 +693,6 @@ class TimeLoop(
     def _apply_reservoir_update_to_state(self) -> Diagnostics:
         # TODO: handle tendencies
         if self._reservoir_predict_stepper is not None:
-            self._log_info("Applying reservior prediction to state.")
             [_, diags, state] = self._reservoir_predict_stepper(
                 self._state.time, self._state
             )

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 RESERVOIR_NAME_TO_STATE_NAME = {"sst": SST}
 VARIABLE_UNITS = {SST: "degK"}
-LAND_MASK_FILL_VALUE = 270.0  # TODO: have this value stored in the sst model?
+LAND_MASK_FILL_VALUE = 291.0  # TODO: have this value stored in the sst model?
 
 
 def _get_state_name(key):

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -252,7 +252,12 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
 
             logger.info(f"Incrementing rc at time {time}")
             self.increment_reservoir(inputs)
-            diags.update({f"{k}_rc_in": v for k, v in inputs.items()})
+            diags.update(
+                {
+                    f"{k}_rc_in": v.rename({"y": "y_halo", "x": "x_halo"})
+                    for k, v in inputs.items()
+                }
+            )
 
         return {}, diags, {}
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -223,7 +223,7 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
         if RESERVOIR_SST in reservoir_inputs:
             land_points = reservoir_inputs[MASK].values.round().astype("int") == 1
             reservoir_inputs[RESERVOIR_SST] = xr.where(
-                land_points, LAND_MASK_FILL_VALUE, reservoir_inputs[SST]
+                land_points, LAND_MASK_FILL_VALUE, reservoir_inputs[RESERVOIR_SST]
             )
 
         return reservoir_inputs

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 RESERVOIR_NAME_TO_STATE_NAME = {"sst": SST}
 VARIABLE_UNITS = {SST: "degK"}
-LAND_MASK_FILL_VALUE = 270.0
+LAND_MASK_FILL_VALUE = 270.0  # TODO: have this value stored in the sst model?
 
 
 def _get_state_name(key):

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -236,12 +236,12 @@ class ReservoirPredictStepper(_ReservoirStepper):
             _add_units(output_state)
             diags.update({f"{k}_rc_out": v for k, v in output_state.items()})
 
-            if not self.diagnostic:
-                # SST consistency update
+            if SST in output_state:
                 output_state = sst_update_from_reference(
                     state, output_state, reference_sst_name=SST
                 )
-            else:
+
+            if self.diagnostic:
                 output_state = {}
         else:
             # Necessary for diags to work when syncing reservoir

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -199,7 +199,7 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
         """
 
         reservoir_inputs = xr.Dataset(
-            {k: state[_get_state_name(k)] for k in self.input_averager.variables}
+            {k: state[_get_state_name(k)] for k in self.model.input_variables}
         )
 
         if RESERVOIR_SST in reservoir_inputs:
@@ -311,7 +311,7 @@ class ReservoirPredictStepper(_ReservoirStepper):
         # increment during the next time loop based on those outputs.
 
         inputs = xr.Dataset(
-            {k: state[_get_state_name(k)] for k in self.input_averager.variables}
+            {k: state[_get_state_name(k)] for k in self.model.input_variables}
         )
         if self.input_averager is not None:
             self.input_averager.increment_running_average(inputs)

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -109,6 +109,12 @@ class TimeAverageInputs:
         self._n = 0
 
     def get_averages(self):
+        if not self._running_total and self.variables:
+            raise ValueError(
+                f"Average called when no fields ({self.variables})"
+                " present in running average."
+            )
+
         averaged_data = {key: val / self._n for key, val in self._running_total.items()}
         for key in averaged_data:
             averaged_data[key].attrs["units"] = self._recorded_units[key]

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -236,6 +236,12 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
         self._state_machine(self._state_machine.INCREMENT)
         self.model.increment_state(inputs)
 
+    @staticmethod
+    def _rename_halo_dims(da):
+        """Prevents name conflict with hybrid input / outputs with no halo points"""
+        if "x" and "y" in da.dims:
+            return da.rename({"x": "x_halo", "y": "y_halo"})
+
     def __call__(self, time, state):
 
         diags = {}
@@ -253,10 +259,7 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             logger.info(f"Incrementing rc at time {time}")
             self.increment_reservoir(inputs)
             diags.update(
-                {
-                    f"{k}_rc_in": v.rename({"y": "y_halo", "x": "x_halo"})
-                    for k, v in inputs.items()
-                }
+                {f"{k}_rc_in": self._rename_halo_dims(v) for k, v in inputs.items()}
             )
 
         return {}, diags, {}

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -238,6 +238,8 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
 
     def __call__(self, time, state):
 
+        diags = {}
+
         # add to averages
         inputs = self._get_inputs_from_state(state)
         if self.input_averager is not None:
@@ -250,8 +252,9 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
 
             logger.info(f"Incrementing rc at time {time}")
             self.increment_reservoir(inputs)
+            diags.update({f"{k}_rc_in": v for k, v in inputs.items()})
 
-        return {}, {}, {}
+        return {}, diags, {}
 
 
 class ReservoirPredictStepper(_ReservoirStepper):
@@ -322,6 +325,7 @@ class ReservoirPredictStepper(_ReservoirStepper):
 
             logger.info(f"Predicting rc at time {time}")
             tendencies, diags, state = self.predict(inputs, state)
+            diags.update({f"{k}_hyb_in": v for k, v in inputs.items()})
         else:
             tendencies, diags, state = {}, {}, {}
 

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
@@ -442,6 +442,7 @@ reservoir_corrector:
     3: gs://vcm-ml-scratch/rc-model-tile-3
     4: gs://vcm-ml-scratch/rc-model-tile-4
     5: gs://vcm-ml-scratch/rc-model-tile-5
+  rename_mapping: {}
   reservoir_timestep: 900s
   synchronize_steps: 12
   time_average_inputs: false

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
@@ -444,6 +444,7 @@ reservoir_corrector:
     5: gs://vcm-ml-scratch/rc-model-tile-5
   reservoir_timestep: 900s
   synchronize_steps: 12
+  time_average_inputs: false
 scikit_learn: null
 tendency_prescriber: null
 zhao_carr_emulation:

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
@@ -1,0 +1,452 @@
+bias_correction: null
+data_table: default
+diag_table:
+  base_time: 2000-01-01 00:00:00
+  file_configs: []
+  name: prognostic_run
+diagnostics: []
+experiment_name: default_experiment
+forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+fortran_diagnostics: []
+initial_conditions:
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile1.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile1.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile2.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile2.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile3.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile3.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile4.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile4.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile5.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile5.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_core.res.tile6.nc
+  target_location: INPUT
+  target_name: fv_core.res.tile6.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile1.nc
+  target_location: INPUT
+  target_name: sfc_data.tile1.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile2.nc
+  target_location: INPUT
+  target_name: sfc_data.tile2.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile3.nc
+  target_location: INPUT
+  target_name: sfc_data.tile3.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile4.nc
+  target_location: INPUT
+  target_name: sfc_data.tile4.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile5.nc
+  target_location: INPUT
+  target_name: sfc_data.tile5.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.sfc_data.tile6.nc
+  target_location: INPUT
+  target_name: sfc_data.tile6.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile1.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile1.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile2.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile2.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile3.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile3.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile4.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile4.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile5.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile5.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_tracer.res.tile6.nc
+  target_location: INPUT
+  target_name: fv_tracer.res.tile6.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile1.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile1.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile2.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile2.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile3.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile3.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile4.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile4.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile5.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile5.nc
+- copy_method: copy
+  source_location: gs://ic-bucket/20160805.000000
+  source_name: 20160805.000000.fv_srf_wnd.res.tile6.nc
+  target_location: INPUT
+  target_name: fv_srf_wnd.res.tile6.nc
+- copy_method: copy
+  source_location: gs://vcm-fv3config/data/initial_conditions/fv_core_79_levels/v1.0
+  source_name: fv_core.res.nc
+  target_location: INPUT
+  target_name: fv_core.res.nc
+namelist:
+  amip_interp_nml:
+    data_set: reynolds_oi
+    date_out_of_range: climo
+    interp_oi_sst: true
+    no_anom_sst: false
+    use_ncep_ice: false
+    use_ncep_sst: true
+  atmos_model_nml:
+    blocksize: 24
+    chksum_debug: false
+    dycore_only: false
+    fdiag: 0.0
+    fhmax: 1024.0
+    fhmaxhf: -1.0
+    fhout: 0.25
+    fhouthf: 0.0
+  cires_ugwp_nml:
+    knob_ugwp_azdir:
+    - 2
+    - 4
+    - 4
+    - 4
+    knob_ugwp_doaxyz: 1
+    knob_ugwp_doheat: 1
+    knob_ugwp_dokdis: 0
+    knob_ugwp_effac:
+    - 1
+    - 1
+    - 1
+    - 1
+    knob_ugwp_ndx4lh: 4
+    knob_ugwp_solver: 2
+    knob_ugwp_source:
+    - 1
+    - 1
+    - 1
+    - 0
+    knob_ugwp_stoch:
+    - 0
+    - 0
+    - 0
+    - 0
+    knob_ugwp_version: 0
+    knob_ugwp_wvspec:
+    - 1
+    - 32
+    - 32
+    - 32
+    launch_level: 55
+  coupler_nml:
+    atmos_nthreads: 1
+    calendar: julian
+    current_date:
+    - 2016
+    - 8
+    - 5
+    - 0
+    - 0
+    - 0
+    days: 10
+    dt_atmos: 900
+    dt_ocean: 900
+    force_date_from_namelist: true
+    hours: 0
+    memuse_verbose: true
+    minutes: 0
+    months: 0
+    ncores_per_node: 32
+    restart_secs: 0
+    seconds: 0
+    use_hyper_thread: true
+  diag_manager_nml:
+    prepend_date: false
+  external_ic_nml:
+    checker_tr: false
+    filtered_terrain: true
+    gfs_dwinds: true
+    levp: 64
+    nt_checker: 0
+  fms_io_nml:
+    checksum_required: false
+    max_files_r: 100
+    max_files_w: 100
+  fms_nml:
+    clock_grain: ROUTINE
+    domains_stack_size: 3000000
+    print_memory_usage: false
+  fv_core_nml:
+    a_imp: 1.0
+    adjust_dry_mass: false
+    beta: 0.0
+    consv_am: false
+    consv_te: 1.0
+    d2_bg: 0.0
+    d2_bg_k1: 0.16
+    d2_bg_k2: 0.02
+    d4_bg: 0.15
+    d_con: 1.0
+    d_ext: 0.0
+    dddmp: 0.2
+    delt_max: 0.002
+    dnats: 1
+    do_sat_adj: true
+    do_vort_damp: true
+    dwind_2d: false
+    external_eta: true
+    external_ic: false
+    fill: true
+    fv_debug: false
+    fv_sg_adj: 900
+    gfs_phil: false
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    hydrostatic: false
+    io_layout:
+    - 1
+    - 1
+    k_split: 1
+    ke_bg: 0.0
+    kord_mt: 10
+    kord_tm: -10
+    kord_tr: 10
+    kord_wz: 10
+    layout:
+    - 1
+    - 1
+    make_nh: false
+    mountain: true
+    n_split: 6
+    n_sponge: 4
+    na_init: 0
+    ncep_ic: false
+    nggps_ic: false
+    no_dycore: false
+    nord: 2
+    npx: 49
+    npy: 49
+    npz: 79
+    ntiles: 6
+    nudge: false
+    nudge_qv: true
+    nwat: 6
+    p_fac: 0.1
+    phys_hydrostatic: false
+    print_freq: 3
+    range_warn: false
+    reset_eta: false
+    rf_cutoff: 800.0
+    rf_fast: false
+    tau: 5.0
+    use_hydro_pressure: false
+    vtdm4: 0.06
+    warm_start: true
+    z_tracer: true
+  fv_grid_nml: {}
+  gfdl_cloud_microphysics_nml:
+    c_cracw: 0.8
+    c_paut: 0.5
+    c_pgacs: 0.01
+    c_psaci: 0.05
+    ccn_l: 300.0
+    ccn_o: 100.0
+    const_vg: false
+    const_vi: false
+    const_vr: false
+    const_vs: false
+    de_ice: false
+    do_qa: true
+    do_sedi_heat: false
+    dw_land: 0.16
+    dw_ocean: 0.1
+    fast_sat_adj: true
+    fix_negative: true
+    icloud_f: 1
+    mono_prof: true
+    mp_time: 450.0
+    prog_ccn: false
+    qi0_crt: 8.0e-05
+    qi_lim: 1.0
+    ql_gen: 0.001
+    ql_mlt: 0.001
+    qs0_crt: 0.001
+    rad_graupel: true
+    rad_rain: true
+    rad_snow: true
+    rh_inc: 0.3
+    rh_inr: 0.3
+    rh_ins: 0.3
+    rthresh: 1.0e-05
+    sedi_transport: false
+    tau_g2v: 900.0
+    tau_i2s: 1000.0
+    tau_l2v:
+    - 225.0
+    tau_v2l: 150.0
+    use_ccn: true
+    use_ppm: false
+    vg_max: 12.0
+    vi_max: 1.0
+    vr_max: 12.0
+    vs_max: 2.0
+    z_slope_ice: true
+    z_slope_liq: true
+  gfs_physics_nml:
+    cal_pre: false
+    cdmbgwd:
+    - 3.5
+    - 0.25
+    cnvcld: false
+    cnvgwd: true
+    debug: false
+    dspheat: true
+    fhcyc: 24.0
+    fhlwr: 3600.0
+    fhswr: 3600.0
+    fhzero: 0.25
+    hybedmf: true
+    iaer: 111
+    ialb: 1
+    ico2: 2
+    iems: 1
+    imfdeepcnv: 2
+    imfshalcnv: 2
+    imp_physics: 11
+    isol: 2
+    isot: 1
+    isubc_lw: 2
+    isubc_sw: 2
+    ivegsrc: 1
+    ldiag3d: true
+    lwhtr: true
+    ncld: 5
+    nst_anl: true
+    pdfcld: false
+    pre_rad: false
+    prslrd0: 0.0
+    random_clds: false
+    redrag: true
+    shal_cnv: true
+    swhtr: true
+    trans_trac: true
+    use_ufo: true
+  interpolator_nml:
+    interp_method: conserve_great_circle
+  nam_stochy:
+    lat_s: 96
+    lon_s: 192
+    ntrunc: 94
+  namsfc:
+    fabsl: 99999
+    faisl: 99999
+    faiss: 99999
+    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
+    fnacna: ''
+    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
+    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+    fnalbc2: grb/global_albedo4.1x1.grb
+    fnglac: grb/global_glacier.2x2.grb
+    fnmskh: grb/seaice_newland.grb
+    fnmxic: grb/global_maxice.2x2.grb
+    fnslpc: grb/global_slope.1x1.grb
+    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
+    fnsnoa: ''
+    fnsnoc: grb/global_snoclim.1.875.grb
+    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
+    fntg3c: grb/global_tg3clim.2.6x1.5.grb
+    fntsfa: ''
+    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
+    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
+    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
+    fnvmnc: grb/global_shdmin.0.144x0.144.grb
+    fnvmxc: grb/global_shdmax.0.144x0.144.grb
+    fnzorc: igbp
+    fsicl: 99999
+    fsics: 99999
+    fslpl: 99999
+    fsmcl:
+    - 99999
+    - 99999
+    - 99999
+    fsnol: 99999
+    fsnos: 99999
+    fsotl: 99999
+    ftsfl: 99999
+    ftsfs: 90
+    fvetl: 99999
+    fvmnl: 99999
+    fvmxl: 99999
+    ldebug: false
+nudging: null
+online_emulator: null
+orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+patch_files: []
+prephysics: null
+radiation_scheme: null
+reservoir_corrector:
+  diagnostic_only: false
+  models:
+    0: gs://vcm-ml-scratch/rc-model-tile-0
+    1: gs://vcm-ml-scratch/rc-model-tile-1
+    2: gs://vcm-ml-scratch/rc-model-tile-2
+    3: gs://vcm-ml-scratch/rc-model-tile-3
+    4: gs://vcm-ml-scratch/rc-model-tile-4
+    5: gs://vcm-ml-scratch/rc-model-tile-5
+  reservoir_timestep: 900s
+  synchronize_steps: 12
+scikit_learn: null
+tendency_prescriber: null
+zhao_carr_emulation:
+  gscond: null
+  model: null
+  storage: null

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/reservoir.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/reservoir.yml
@@ -1,0 +1,30 @@
+base_version: v0.5
+initial_conditions:
+  base_url: gs://ic-bucket
+  timestep: "20160805.000000"
+namelist:
+  coupler_nml:
+    days: 10 # total length
+    hours: 0
+    minutes: 0
+    seconds: 0
+    dt_atmos: 900 # seconds
+    dt_ocean: 900
+    restart_secs: 0 # seconds - frequency to save restarts
+  atmos_model_nml:
+    fhout: 0.25 # hours - frequency to save physics outputs
+  gfs_physics_nml:
+    fhzero: 0.25 # hours - frequency at which precip is set back to zero
+  fv_core_nml:
+    n_split: 6 # num dynamics steps per physics step
+reservoir_corrector:
+  models:
+    0: gs://vcm-ml-scratch/rc-model-tile-0
+    1: gs://vcm-ml-scratch/rc-model-tile-1
+    2: gs://vcm-ml-scratch/rc-model-tile-2
+    3: gs://vcm-ml-scratch/rc-model-tile-3
+    4: gs://vcm-ml-scratch/rc-model-tile-4
+    5: gs://vcm-ml-scratch/rc-model-tile-5
+  synchronize_steps: 12
+  reservoir_timestep: "900s"
+  diagnostic_only: False

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -26,6 +26,7 @@ TEST_DATA_DIR = "tests/prepare_config_test_data"
         pytest.param([f"{TEST_DATA_DIR}/nudge_to_obs_config.yml"], id="n2o"),
         pytest.param([f"{TEST_DATA_DIR}/emulator.yml"], id="emulator"),
         pytest.param([f"{TEST_DATA_DIR}/fine_res_ml.yml"], id="fine-res-ml"),
+        pytest.param([f"{TEST_DATA_DIR}/reservoir.yml"], id="reservoir"),
     ],
 )
 def test_prepare_ml_config_regression(regtest, argv):

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -80,7 +80,6 @@ def test_input_averager_get_averages():
     result = averager.get_averages()
     assert len(result) == 1
     xr.testing.assert_equal(result["a"], data["a"])
-    averager.reset_running_average()
 
     # multiple increments
     averager.increment_running_average(data)

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -214,8 +214,6 @@ def test_get_reservoir_steppers(patched_reservoir_module):
     # Check that both steppers share model and state machine objects
     assert incrementer.model is predictor.model
     assert incrementer._state_machine is predictor._state_machine
-    assert incrementer.input_averager.variables == ["a"]
-    assert predictor.input_averager.variables == ["a"]
 
     # check that call methods point to correct methods
     state = MockState(a=xr.DataArray(np.ones(1), dims=["x"]))

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -10,7 +10,6 @@ from runtime.steppers.reservoir import (
     ReservoirIncrementOnlyStepper,
     ReservoirPredictStepper,
     _FiniteStateMachine,
-    IntervalAveragedTimes,
     TimeAverageInputs,
     ReservoirConfig,
 )
@@ -123,22 +122,20 @@ def get_mock_ReservoirSteppers():
     model = get_mock_reservoir_model()
     state_machine = _FiniteStateMachine()
 
-    time_checker = IntervalAveragedTimes(
-        timedelta(minutes=10), datetime(1, 1, 1, 0, 0, 0)
-    )
-
     # Create a _ReservoirStepper object with mock objects
     incrementer = ReservoirIncrementOnlyStepper(
-        model=model,
-        time_checker=time_checker,
-        synchronize_steps=2,
+        model,
+        datetime(1, 1, 1, 0, 0, 0),
+        timedelta(minutes=10),
+        2,
         state_machine=state_machine,
     )
 
     predictor = ReservoirPredictStepper(
-        model=model,
-        time_checker=time_checker,
-        synchronize_steps=2,
+        model,
+        datetime(1, 1, 1, 0, 0, 0),
+        timedelta(minutes=10),
+        2,
         state_machine=state_machine,
     )
 

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -240,6 +240,22 @@ def test_reservoir_steppers_state_machine_constraint(patched_reservoir_module):
         predictor(time, state)
 
 
+def test_reservoir_steppers_with_interval_averaging(patched_reservoir_module):
+
+    config = ReservoirConfig(
+        {0: "model"}, 0, reservoir_timestep="30m", time_average_inputs=True
+    )
+    init_time = datetime(2020, 1, 1, 0, 0, 0)
+    incrementer, predictor = reservoir.get_reservoir_steppers(config, 0, init_time)
+
+    state = MockState(a=xr.DataArray(np.ones(1), dims=["x"]))
+    incrementer(init_time, state)
+
+    for i in range(1, 4):
+        predictor(init_time + timedelta(minutes=10 * i), state)
+        incrementer(init_time + timedelta(minutes=10 * i), state)
+
+
 def test_model_paths_and_rank_index_mismatch_on_load():
     config = ReservoirConfig({1: "model"}, 0, reservoir_timestep="10m")
     with pytest.raises(KeyError):


### PR DESCRIPTION
After receiving a global SST model to test out there were some remaining issues to fix before the reservoir stepper worked.

Added public API:
- `HybridReservoirDatasetAdapter` and `ReservoirDatasetAdapter` now include an `input_overlap` attribute to directly access information for adding the halo points during runtime
- `ReservoirConfig` now accepts flags for `diagnostic_only` and `time_average_inputs` to specify reservoir model usage

Significant internal changes:
- Added a hard-coded name translation to go from the reservoir model I/O names to the required state names for the wrapper (currently only sst since that's named differently)
- Added a method that fills the state input land areas with a hard coded fill value
- Predictor stepper now adds the diagnostics from the state in place of the Reservoir model outputs during synchronization
- Small fixes to the halo update functions
- Added tests for `ReservoirConfig` component of the runtime configuration
- Added a `TimeAverageInputs` class to keep track of fields needed for time-averaged inputs during model runtime

Coverage reports (updated automatically):
