### PR TITLE
Reservoir option to use input mask

### DIFF
--- a/external/fv3fit/fv3fit/_shared/training_config.py
+++ b/external/fv3fit/fv3fit/_shared/training_config.py
@@ -110,7 +110,7 @@ class TrainingConfig:
         hyperparameter_class = get_hyperparameter_class(kwargs["model_type"])
         # custom enums must be specified for dacite to handle correctly
         dacite_config = dacite.Config(
-            strict=True, cast=[bool, str, int, float, StdDevMethod, MeanMethod]
+            strict=True, cast=[bool, str, int, float, StdDevMethod, MeanMethod, tuple]
         )
         kwargs["hyperparameters"] = dacite.from_dict(
             data_class=hyperparameter_class,

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -88,7 +88,9 @@ class ReservoirTrainingConfig(Hyperparameters):
         predictions in Wikner+2020 (https://doi.org/10.1063/5.0005541)
     transformers: optional TransformerConfig for autoencoders to use in
         encoding input, output, and/or hybrid variable sets.
-
+    mask_land: if True, save mask array that is multiplied to the input array
+        before multiplication with W_in. This zeros any land points so they do
+        affect the hidden state.
     """
 
     input_variables: Sequence[str]
@@ -103,6 +105,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     n_jobs: Optional[int] = 1
     square_half_hidden_state: bool = False
     hybrid_variables: Optional[Sequence[str]] = None
+    mask_land: bool = False
     _METADATA_NAME = "reservoir_training_config.yaml"
 
     def __post_init__(self):
@@ -124,10 +127,12 @@ class ReservoirTrainingConfig(Hyperparameters):
     @property
     def variables(self) -> Set[str]:
         if self.hybrid_variables is not None:
-            hybrid_vars = list(self.hybrid_variables)  # type: ignore
+            additional_vars = list(self.hybrid_variables)  # type: ignore
         else:
-            hybrid_vars = []
-        return set(list(self.input_variables) + hybrid_vars)
+            additional_vars = []
+        if self.mask_land is True:
+            additional_vars.append("land_sea_mask")
+        return set(list(self.input_variables) + additional_vars)
 
     @classmethod
     def from_dict(cls, kwargs) -> "ReservoirTrainingConfig":

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -88,9 +88,9 @@ class ReservoirTrainingConfig(Hyperparameters):
         predictions in Wikner+2020 (https://doi.org/10.1063/5.0005541)
     transformers: optional TransformerConfig for autoencoders to use in
         encoding input, output, and/or hybrid variable sets.
-    mask_land: if True, save mask array that is multiplied to the input array
-        before multiplication with W_in. This zeros any land points so they do
-        affect the hidden state.
+    mask_variable: if specified, save mask array that is multiplied to the input array
+        before multiplication with W_in. This applies a mask using the
+        mask_variable field.
     """
 
     input_variables: Sequence[str]
@@ -105,7 +105,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     n_jobs: Optional[int] = 1
     square_half_hidden_state: bool = False
     hybrid_variables: Optional[Sequence[str]] = None
-    mask_land: bool = False
+    mask_variable: Optional[str] = None
     _METADATA_NAME = "reservoir_training_config.yaml"
 
     def __post_init__(self):
@@ -130,8 +130,8 @@ class ReservoirTrainingConfig(Hyperparameters):
             additional_vars = list(self.hybrid_variables)  # type: ignore
         else:
             additional_vars = []
-        if self.mask_land is True:
-            additional_vars.append("land_sea_mask")
+        if self.mask_variable is not None:
+            additional_vars.append(self.mask_variable)
         return set(list(self.input_variables) + additional_vars)
 
     @classmethod

--- a/external/fv3fit/fv3fit/reservoir/domain.py
+++ b/external/fv3fit/fv3fit/reservoir/domain.py
@@ -1,7 +1,7 @@
 import fsspec
 import numpy as np
 import tensorflow as tf
-from typing import Sequence, Iterable
+from typing import Sequence
 import yaml
 from ._reshaping import split_1d_samples_into_2d_rows
 import pace.util
@@ -257,21 +257,3 @@ class RankDivider:
 
         # Merge along Xdomain, Ydomain dims into a single array of dims (x, y, z)
         return np.concatenate(np.concatenate(domain_z_blocks, axis=2), axis=0)
-
-
-def assure_txyz_dims(variable_tensors: Iterable[tf.Tensor]) -> Iterable[tf.Tensor]:
-    # Assumes dims 1, 2, 3 are t, x, y.
-    # If variable data has 3 dims, adds a 4th feature dim of size 1.
-    reshaped_tensors = []
-    for var_data in variable_tensors:
-        if len(var_data.shape) == 4:
-            reshaped_tensors.append(var_data)
-        elif len(var_data.shape) == 3:
-            orig_shape = var_data.shape
-            reshaped_tensors.append(tf.reshape(var_data, shape=(*orig_shape, 1)))
-        else:
-            raise ValueError(
-                f"Tensor data has {len(var_data.shape)} dims, must either "
-                "have either 4 dims (t, x, y, z) or 3 dims (t, x, y)."
-            )
-    return reshaped_tensors

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -40,6 +40,7 @@ class Reservoir:
         input_size: int,
         W_in: Optional[scipy.sparse.csc_matrix] = None,
         W_res: Optional[scipy.sparse.csc_matrix] = None,
+        input_mask_array: Optional[np.ndarray] = None,
     ):
         """
 
@@ -58,13 +59,19 @@ class Reservoir:
         self.W_in = W_in if W_in is not None else self._generate_W_in()
         self.W_res = W_res if W_res is not None else self._generate_W_res()
         self.state: Optional[np.ndarray] = None
+        self.input_mask_array = input_mask_array
 
     def increment_state(self, input):
         # input: [subdomain, features]
+        # (optional) input_mask: [subdomain, features]
         # W_in: [features, state_size]
         # W_res: [state_size, state_size]
         # output: [subdomain, state_size]
-        self.state = np.tanh(input @ self.W_in.T + self.state @ self.W_res.T)
+        if self.input_mask_array is not None:
+            masked_input = input * self.input_mask_array
+        else:
+            masked_input = input
+        self.state = np.tanh(masked_input @ self.W_in.T + self.state @ self.W_res.T)
 
     def reset_state(self, input_shape: tuple):
         logger.info("Resetting reservoir state.")

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -13,6 +13,7 @@ from .utils import (
     square_even_terms,
     process_batch_data,
     get_ordered_X,
+    assure_txyz_dims,
     SynchronziationTracker,
     get_standard_normalizing_transformer,
 )
@@ -100,7 +101,7 @@ def train_reservoir_model(
         input_mask_array: Optional[
             np.ndarray
         ] = rank_divider.get_all_subdomains_with_flat_feature(
-            np.where(sample_batch["land_sea_mask"] == 1.0, 0, 1)
+            np.where(assure_txyz_dims(sample_batch["land_sea_mask"])[0] == 1.0, 0, 1)
         )
     else:
         input_mask_array = None

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -85,9 +85,14 @@ def _get_input_mask_array(
             f"'{mask_variable}' must be included in training data if "
             "the mask_variable is specified in training configuration."
         )
-    return rank_divider.get_all_subdomains_with_flat_feature(
-        np.where(assure_txyz_dims(sample_batch[mask_variable])[0] == 1.0, 0, 1)
+    mask = rank_divider.get_all_subdomains_with_flat_feature(
+        assure_txyz_dims(sample_batch[mask_variable])[0]
     )
+    if set(np.unique(mask)) != {0, 1}:
+        raise ValueError(
+            f"Mask variable values in field {mask_variable} are not " "all in {0, 1}."
+        )
+    return mask
 
 
 @register_training_function("reservoir", ReservoirTrainingConfig)

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -96,11 +96,21 @@ def train_reservoir_model(
         z_feature_size=transformers.input.n_latent_dims,
     )
 
+    if hyperparameters.mask_land is True:
+        input_mask_array: Optional[
+            np.ndarray
+        ] = rank_divider.get_all_subdomains_with_flat_feature(
+            np.where(sample_batch["land_sea_mask"] == 1.0, 0, 1)
+        )
+    else:
+        input_mask_array = None
+
     # First data dim is time, the rest of the elements of each
     # subdomain+halo are are flattened into feature dimension
     reservoir = Reservoir(
         hyperparameters=hyperparameters.reservoir_hyperparameters,
         input_size=rank_divider.flat_subdomain_len,
+        input_mask_array=input_mask_array,
     )
 
     # One readout is trained per subdomain when iterating over batches,

--- a/external/fv3fit/tests/reservoir/test_domain.py
+++ b/external/fv3fit/tests/reservoir/test_domain.py
@@ -3,7 +3,6 @@ import pytest
 from fv3fit.reservoir.domain import (
     slice_along_axis,
     RankDivider,
-    assure_txyz_dims,
 )
 
 
@@ -28,32 +27,6 @@ default_rank_divider_kwargs = {
     "rank_dims": ["x", "y"],
     "rank_extent": [6, 6],
 }
-
-
-def test_assure_txyz_dims():
-    nt, nx, ny, nz = 5, 4, 4, 6
-    arr_3d = np.ones((nt, nx, ny, nz))
-    arr_2d = np.ones((nt, nx, ny))
-    data = [arr_3d, arr_2d]
-    assert assure_txyz_dims(data)[0].shape == (nt, nx, ny, nz)
-    assert assure_txyz_dims(data)[1].shape == (nt, nx, ny, 1)
-
-
-def test_assure_txyz_dims_2d_only_inputs():
-    nt, nx, ny = 5, 4, 4
-    arr_2d = np.ones((nt, nx, ny))
-    data = [arr_2d, arr_2d]
-    for arr in assure_txyz_dims(data):
-        assert arr.shape == (nt, nx, ny, 1)
-
-
-def test_assure_txyz_dims_incompatible_shapes():
-    nt, nx, ny, nz = 5, 4, 4, 6
-    arr_3d = np.ones((nt, nx, ny, nz, 2))
-    arr_2d = np.ones((nt, nx, ny))
-    data = [arr_3d, arr_2d]
-    with pytest.raises(ValueError):
-        assure_txyz_dims(data)
 
 
 @pytest.mark.parametrize(

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -4,6 +4,7 @@ from fv3fit.reservoir.utils import (
     square_even_terms,
     process_batch_data,
     SynchronziationTracker,
+    assure_txyz_dims,
 )
 from fv3fit.reservoir.transformers import DoNothingAutoencoder
 from fv3fit.reservoir.domain2 import RankXYDivider
@@ -71,3 +72,17 @@ def test_process_batch_data(nz, overlap, trim_halo):
     else:
         features_per_subdomain = rank_divider.flat_subdomain_len
     assert time_series.shape == (nt, rank_divider.n_subdomains, features_per_subdomain,)
+
+
+def test_assure_txyz_dims():
+    nt, nx, ny, nz = 5, 4, 4, 6
+    arr_3d = np.ones((nt, nx, ny, nz))
+    arr_2d = np.ones((nt, nx, ny))
+    assert assure_txyz_dims(arr_3d).shape == (nt, nx, ny, nz)
+    assert assure_txyz_dims(arr_2d).shape == (nt, nx, ny, 1)
+
+
+def test_assure_txyz_dims_incompatible_shapes():
+    nt, nx, ny, nz = 5, 4, 4, 6
+    with pytest.raises(ValueError):
+        assure_txyz_dims(np.ones((nt, nx, ny, nz, 2)))


### PR DESCRIPTION
This adds the optional config parameter `mask_variable` to mask reservoir training inputs according to the field specified by that arg. A mask array is saved with the reservoir that zeroes out any input points where the mask is zero. The mask is applied right before the inputs are multiplied with the input reservoir matrix that transforms the physical input into the higher dim hidden state,  ensuring the masked points don't have any effect on the hidden state. This could be useful in the case of masking out land and corner points in SST training. 

Additional minor changes:
- refactored a helper function `assure_txyz_dims` to operate on single tensors, since it is useful for ensuring the mask has the same dimensions as the input.
- fixed the dacite config in the training config so it can load tuples (used in rank extent of the reservoir subdomain config)


In addition to the unit test, I trained models on mock SST data using the land mask as the input mask, then loaded them and tested the input mask was working in the trained models' predictions. I altered the values over land in the test data to be way out of sample from the original data, and verified that the models' predictions did not change when using the altered data as input. (bottom of [this notebook](https://github.com/ai2cm/explore/blob/master/annak/2023-07-17-example-reservoir-training/2023-08-15-global-rollout.ipynb))
 
- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
