### PR TITLE
Record states prior to being overwritten by interval stepper

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -393,6 +393,7 @@ class TimeLoop(
                 apply_interval_seconds=stepper_config.apply_interval_seconds,
                 stepper=stepper,
                 offset_seconds=stepper_config.offset_seconds,
+                record_fields_before_update=stepper_config.record_fields_before_update,
             )
         else:
             return stepper


### PR DESCRIPTION
This PR enables saving the baseline FV3GFS coarse model state as the 'imperfect' hybrid input set. The state is prescribed to the nudged reference state every 3 hours, but we need to record the model state immediately before this correction is applied.
 
Added public API:
- optional field `IntervalConfig.record_fields_before_update` takes a list of state variables to save in diagnostics right before the postphysics stepper updates are applied. These are saved as `x_before_interval_update`. They are also saved at timesteps where the interval stepper does not overwrite the state, since the diagnostics need to be available at all timesteps.
 
Coverage reports (updated automatically):
