### PR TITLE
Remove constraint that outputs must be subset of inputs

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -109,11 +109,6 @@ class ReservoirTrainingConfig(Hyperparameters):
     _METADATA_NAME = "reservoir_training_config.yaml"
 
     def __post_init__(self):
-        if set(self.output_variables).issubset(self.input_variables) is False:
-            raise ValueError(
-                f"Output variables {self.output_variables} must be a subset of "
-                f"input variables {self.input_variables}."
-            )
         if self.hybrid_variables is not None:
             hybrid_and_input_vars_intersection = set(
                 self.hybrid_variables


### PR DESCRIPTION
A  [previous PR ](https://github.com/ai2cm/fv3net/pull/2308/files) enabled training reservoir models to predict different outputs from the input set (useful for predicting tendencies rather than absolute state). It forgot to remove a check in the hyperparameters that raised an error if output variables were not a subset of inputs. This PR removes that constraint.