### PR TITLE
Reservoir diagnostic adjustment

### DIFF
--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -136,6 +136,9 @@ spec:
       operator: "Equal"
       value: "{{inputs.parameters.node-pool}}"
       effect: "NoSchedule"
+    metadata:
+      labels:
+        app: fv3run
     podSpecPatch: |
       containers:
         - name: main

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -121,7 +121,7 @@ spec:
       container: *training-container
       metadata:
         labels:
-          app: ml-trainingtolerations
+          app: ml-training
       tolerations:
       - key: "dedicated"
         operator: "Equal"

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -27,6 +27,9 @@ spec:
           - {name: wandb-project, value: "argo-default"}
           - {name: wandb-tags, value: ""}
           - {name: wandb-group, value: ""}
+      metadata:
+        labels:
+          app: ml-training
       container: &training-container
         image: us.gcr.io/vcm-ml/fv3fit
         command: &training-container-cmd ["bash", "-c", "-x"]
@@ -116,6 +119,9 @@ spec:
     - name: training-gpu-def
       inputs: *training-inputs
       container: *training-container
+      metadata:
+        labels:
+          app: ml-trainingtolerations
       tolerations:
       - key: "dedicated"
         operator: "Equal"
@@ -144,6 +150,9 @@ spec:
         envFrom: *training-container-envfrom
         volumeMounts: *training-container-volmounts
         args: *training-container-args
+      metadata:
+        labels:
+          app: ml-training
       tolerations:
       - key: "dedicated"
         operator: "Equal"

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -257,7 +257,8 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
 
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:
-                diags = rename_dataset_members(diags, {"x": "x_halo", "y": "y_halo"})
+                overlap = self.model.input_overlap
+                diags.isel(x=slice(overlap, -overlap), y=slice(overlap, -overlap))
 
         return {}, diags, {}
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -258,7 +258,12 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:
                 overlap = self.model.input_overlap
-                diags.isel(x=slice(overlap, -overlap), y=slice(overlap, -overlap))
+                isel_kwargs = {
+                    dim: slice(overlap, -overlap)
+                    for dim in diags.dims
+                    if dim in ["x", "y"]
+                }
+                diags.isel(**isel_kwargs)
 
         return {}, diags, {}
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -251,7 +251,10 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             logger.info(f"Incrementing rc at time {time}")
             self.increment_reservoir(inputs)
 
-            diags = rename_dataset_members(inputs, {k: f"{k}_rc_in" for k in inputs})
+            diags = rename_dataset_members(
+                inputs, {k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs}
+            )
+            logger.info(f"input diags: {list(diags.keys())}")
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:
                 diags = rename_dataset_members(diags, {"x": "x_halo", "y": "y_halo"})
@@ -272,22 +275,19 @@ class ReservoirPredictStepper(_ReservoirStepper):
         """Called at the end of timeloop after time has ticked from t -> t+1"""
 
         self._state_machine(self._state_machine.PREDICT)
+        result = self.model.predict(inputs)
+        output_state = rename_dataset_members(result, self.rename_mapping)
+
+        diags = rename_dataset_members(
+            output_state, {k: f"{k}_rc_out" for k in output_state}
+        )
+
+        for k, v in output_state.items():
+            v.attrs["units"] = state[k].attrs.get("units", "unknown")
 
         # no halo necessary for potential hybrid inputs
         # +1 to align with the necessary increment before any prediction
         if self._state_machine.completed_increments >= self.synchronize_steps + 1:
-
-            logger.info(f"Predicting rc model")
-            result = self.model.predict(inputs)
-
-            output_state = rename_dataset_members(result, self.rename_mapping)
-
-            for k, v in output_state.items():
-                v.attrs["units"] = state[k].attrs.get("units", "unknown")
-
-            diags = rename_dataset_members(
-                output_state, {k: f"{k}_rc_out" for k in output_state}
-            )
 
             if SST in output_state:
                 output_state = sst_update_from_reference(
@@ -296,13 +296,6 @@ class ReservoirPredictStepper(_ReservoirStepper):
 
             if self.diagnostic:
                 output_state = {}
-        else:
-            # Necessary for diags to work when syncing reservoir
-            fv3_output_variables = [
-                self.rename_mapping.get(k, k) for k in self.model.output_variables
-            ]
-            diags = xr.Dataset({f"{k}_rc_out": state[k] for k in fv3_output_variables})
-            output_state = {}
 
         return {}, diags, output_state
 
@@ -329,11 +322,12 @@ class ReservoirPredictStepper(_ReservoirStepper):
             self.input_averager.increment_running_average(inputs)
 
         if self._is_rc_update_step(time):
+            logger.info(f"Reservoir model predict at time {time}")
             if self.input_averager is not None:
                 inputs.update(self.input_averager.get_averages())
             tendencies, diags, state = self.predict(inputs, state)
             hybrid_diags = rename_dataset_members(
-                inputs, {k: f"{k}_hyb_in" for k in inputs}
+                inputs, {k: f"{self.rename_mapping.get(k, k)}_hyb_in" for k in inputs}
             )
             diags.update(hybrid_diags)
         else:

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -254,7 +254,7 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             diags = rename_dataset_members(
                 inputs, {k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs}
             )
-            logger.info(f"input diags: {list(diags.keys())}")
+
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:
                 diags = rename_dataset_members(diags, {"x": "x_halo", "y": "y_halo"})

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -300,9 +300,10 @@ class ReservoirPredictStepper(_ReservoirStepper):
             output_state = {}
 
         if SST in output_state:
-            output_state = sst_update_from_reference(
+            sst_updates = sst_update_from_reference(
                 state, output_state, reference_sst_name=SST
             )
+            output_state.update(sst_updates)
 
         return {}, diags, output_state
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -287,15 +287,16 @@ class ReservoirPredictStepper(_ReservoirStepper):
 
         # no halo necessary for potential hybrid inputs
         # +1 to align with the necessary increment before any prediction
-        if self._state_machine.completed_increments >= self.synchronize_steps + 1:
+        if (
+            self._state_machine.completed_increments <= self.synchronize_steps
+            or self.diagnostic
+        ):
+            output_state = {}
 
-            if SST in output_state:
-                output_state = sst_update_from_reference(
-                    state, output_state, reference_sst_name=SST
-                )
-
-            if self.diagnostic:
-                output_state = {}
+        if SST in output_state:
+            output_state = sst_update_from_reference(
+                state, output_state, reference_sst_name=SST
+            )
 
         return {}, diags, output_state
 

--- a/workflows/prognostic_c48_run/tests/test_diagnostics.py
+++ b/workflows/prognostic_c48_run/tests/test_diagnostics.py
@@ -82,6 +82,18 @@ def test_IntervalTimes(frequency, time, initial_time, expected):
     assert (time in times) == expected
 
 
+@pytest.mark.parametrize(
+    "frequency, time, initial_time, expected",
+    [
+        (1800, datetime(year=2016, month=8, day=1, hour=0, minute=30), august_1, False),
+        (1800, datetime(year=2016, month=8, day=1, hour=0, minute=45), august_1, True),
+    ],
+)
+def test_IntervalTimes_offset(frequency, time, initial_time, expected):
+    times = IntervalTimes(frequency, initial_time, offset=timedelta(minutes=15))
+    assert (time in times) == expected
+
+
 def test_DiagnosticFile_time_selection():
     # mock the input data
     t1 = datetime(year=2016, month=8, day=1, hour=0, minute=15)


### PR DESCRIPTION
Fixes diagnostic names for inputs and hybrid inputs to match the fv3gfs standard names.  Switch output diagnostic to always be a prediction from the reservoir so we can investigate spinup during synchronization. Add offset to facilitate saving reservoir inputs since the increment happens before the timestep ticks over to the next time (diagnostics recorded at end of timestep).

Adjusted the workflow labels to adhere to the pod disruption budgets we have set on k8s.  This should prevent long-running pods from being evicted (hopefully)

Public API Changes:
* Added `offset` to `IntervalTimes` container to facilitate saving outputs at a frequency offset from the initial time

- [x] tests added

Coverage reports (updated automatically):
