### PR TITLE
Reservoir training on sequence of time series

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/domain2.py
+++ b/external/fv3fit/fv3fit/reservoir/domain2.py
@@ -306,7 +306,7 @@ class RankXYDivider:
             dim_slices = self._add_potential_leading_dim_to_slices(
                 subdomain.shape, dim_slices
             )
-            merged[dim_slices] = subdomain
+            merged[tuple(dim_slices)] = subdomain
 
         return merged
 

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -176,15 +176,14 @@ def train_reservoir_model(
             hybrid_time_series: Optional[np.ndarray]
 
             if hyperparameters.hybrid_variables is not None:
-                _hybrid_rank_divider_with_overlap = (
-                    rank_divider.get_new_zdim_rank_divider(
-                        z_feature_size=transformers.hybrid.n_latent_dims
-                    )
+                _hybrid_rank_divider_w_overlap = rank_divider.get_new_zdim_rank_divider(
+                    z_feature_size=transformers.hybrid.n_latent_dims
                 )
+
                 hybrid_time_series = process_batch_data(
                     variables=hyperparameters.hybrid_variables,
                     batch_data=batch_data,
-                    rank_divider=_hybrid_rank_divider_with_overlap,
+                    rank_divider=_hybrid_rank_divider_w_overlap,
                     autoencoder=transformers.hybrid,
                     trim_halo=True,
                 )

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -168,6 +168,7 @@ def train_reservoir_model(
 
             # reservoir increment occurs in this call, so always call this
             # function even if X, Y are not used for readout training.
+            reservoir.reset_state(input_shape=input_time_series[0].shape)
             reservoir_state_time_series = _get_reservoir_state_time_series(
                 input_time_series, hyperparameters.input_noise, reservoir
             )
@@ -260,10 +261,6 @@ def _get_reservoir_state_time_series(
     X: np.ndarray, input_noise: float, reservoir: Reservoir,
 ) -> np.ndarray:
     # X is [time, subdomain, feature]
-
-    # Initialize hidden state
-    if reservoir.state is None:
-        reservoir.reset_state(input_shape=X[0].shape)
 
     # Increment and save the reservoir state after each timestep
     reservoir_state_time_series: List[Optional[np.ndarray]] = []

--- a/external/fv3fit/fv3fit/reservoir/train_multiple_dataset_sequence.py
+++ b/external/fv3fit/fv3fit/reservoir/train_multiple_dataset_sequence.py
@@ -1,0 +1,229 @@
+import argparse
+import logging
+import os
+from typing import Optional, Sequence, Tuple
+import tensorflow as tf
+from fv3fit._shared.config import CacheConfig
+from fv3fit._shared.training_config import (
+    get_arg_updated_config_dict,
+    to_flat_dict,
+    to_nested_dict,
+)
+from fv3fit._shared import put_dir
+
+import yaml
+import fsspec
+
+import fv3fit.keras
+import fv3fit.sklearn
+import fv3fit
+from ..data import tfdataset_loader_from_dict, TFDatasetLoader
+from fv3fit.dataclasses import asdict_with_enum
+import wandb
+import sys
+import shutil
+
+from fv3net.artifacts.metadata import StepMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "training_config", type=str, help="path of fv3fit.TrainingConfig yaml file",
+    )
+    parser.add_argument(
+        "training_data_config",
+        type=str,
+        help="path of loaders.BatchesLoader training data yaml file",
+    )
+    parser.add_argument(
+        "output_path", type=str, help="path to save config and trained model"
+    )
+    parser.add_argument(
+        "--validation-data-config",
+        type=str,
+        default=None,
+        help=(
+            "path of loaders.BatchesLoader validation data yaml file, "
+            "by default an empty sequence is used"
+        ),
+    )
+    parser.add_argument(
+        "--no-wandb",
+        help=(
+            "Disable logging of run to wandb. Uses environment variables WANDB_ENTITY, "
+            "WANDB_PROJECT, WANDB_JOB_TYPE as wandb.init options."
+        ),
+        action="store_true",
+    )
+    return parser
+
+
+def dump_dataclass(obj, yaml_filename):
+    with fsspec.open(yaml_filename, "a") as f:
+        yaml.safe_dump(asdict_with_enum(obj), f)
+
+
+def maybe_join_path(base: Optional[str], append: str) -> Optional[str]:
+    if base is not None:
+        return os.path.join(base, append)
+    else:
+        return None
+
+
+def load_data(
+    variables: Sequence[str],
+    training_data_configs: Sequence[TFDatasetLoader],
+    validation_data_config: Optional[TFDatasetLoader],
+    cache_config: CacheConfig,
+) -> Tuple[tf.data.Dataset, Optional[tf.data.Dataset]]:
+    for training_data_config in training_data_configs:
+        print(training_data_config)
+    train_tfdatasets = [
+        training_data_config.open_tfdataset(
+            local_download_path=maybe_join_path(
+                cache_config.local_download_path, "train_data"
+            ),
+            variable_names=variables,
+        )
+        for training_data_config in training_data_configs
+    ]
+
+    if cache_config.in_memory:
+        train_tfdatasets = [
+            train_tfdataset.cache() for train_tfdataset in train_tfdatasets
+        ]
+    if validation_data_config is not None:
+        validation_tfdataset = validation_data_config.open_tfdataset(
+            local_download_path=maybe_join_path(
+                cache_config.local_download_path, "validation_data"
+            ),
+            variable_names=variables,
+        )
+        if cache_config.in_memory:
+            validation_tfdataset = validation_tfdataset.cache()
+    else:
+        validation_tfdataset = None
+    return train_tfdatasets, validation_tfdataset
+
+
+def main(args, unknown_args=None):
+
+    with open(args.training_config, "r") as f:
+        config_dict = yaml.safe_load(f)
+        if unknown_args is not None:
+            # converting to TrainingConfig and then back to dict allows command line to
+            # update fields that are not present in original configuration file
+            config_dict = asdict_with_enum(fv3fit.TrainingConfig.from_dict(config_dict))
+            config_dict = get_arg_updated_config_dict(
+                args=unknown_args, config_dict=config_dict
+            )
+        if args.no_wandb is False:
+            wandb.init(
+                # workaround for
+                # https://docs.wandb.ai/guides/track/launch#init-start-error
+                settings=wandb.Settings(start_method="fork"),
+                # hyperparameters are repeated as flattened top level keys so they can
+                # be referenced in the sweep configuration parameters
+                # https://github.com/wandb/client/issues/982
+                config=to_flat_dict(config_dict["hyperparameters"]),
+            )
+            # hyperparameters should be accessed throughthe wandb config so that
+            # sweeps use the wandb-provided hyperparameter values
+            config_dict["hyperparameters"] = to_nested_dict(wandb.config)
+            logger.info(
+                f"hyperparameters from wandb config: {config_dict['hyperparameters']}"
+            )
+            wandb.config["training_config"] = config_dict
+            wandb.config["env"] = {"COMMIT_SHA": os.getenv("COMMIT_SHA", "")}
+
+        training_config = fv3fit.TrainingConfig.from_dict(config_dict)
+
+    with open(args.training_data_config, "r") as f:
+        config_ = yaml.safe_load(f)
+        if isinstance(config_, Sequence):
+            training_data_configs = [
+                tfdataset_loader_from_dict(config_dict) for config_dict in config_
+            ]
+        else:
+            training_data_configs = [tfdataset_loader_from_dict(config_)]
+        if args.no_wandb is False:
+            wandb.config["training_data_config"] = config_
+
+    if args.validation_data_config is not None:
+        with open(args.validation_data_config, "r") as f:
+            config_dict = yaml.safe_load(f)
+            validation_data_config = tfdataset_loader_from_dict(config_dict)
+            if args.no_wandb is False:
+                wandb.config["validation_data_config"] = config_dict
+    else:
+        validation_data_config = None
+
+    fv3fit.set_random_seed(training_config.random_seed)
+
+    dump_dataclass(training_config, os.path.join(args.output_path, "train.yaml"))
+    with fsspec.open(os.path.join(args.output_path, "training_data.yaml"), "w") as f:
+        yaml.safe_dump(config_, f)
+
+    train_tfdatasets, validation_tfdataset = load_data(
+        training_config.variables,
+        training_data_configs,
+        validation_data_config,
+        training_config.cache,
+    )
+
+    train = fv3fit.get_training_function(training_config.model_type)
+
+    logger.info("calling train function")
+    model = train(
+        hyperparameters=training_config.hyperparameters,
+        train_batches=train_tfdatasets,
+        validation_batches=validation_tfdataset,
+    )
+    if len(training_config.derived_output_variables) > 0:
+        model = fv3fit.DerivedModel(model, training_config.derived_output_variables)
+    if len(training_config.output_transforms) > 0:
+        model = fv3fit.TransformedPredictor(model, training_config.output_transforms)
+    fv3fit.dump(model, args.output_path)
+    StepMetadata(
+        job_type="training", url=args.output_path, args=sys.argv[1:],
+    ).print_json()
+
+
+def disable_tensorflow_gpu_preallocation():
+    """
+    Enables "memory growth" option on all gpus for tensorflow.
+
+    Without this, tensorflow will eagerly allocate all gpu memory,
+    leaving none for pytorch.
+    """
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        # Currently, memory growth needs to be the same across GPUs
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        logical_gpus = tf.config.list_logical_devices("GPU")
+        logging.info("%d physical gpus, %d logical gpus", len(gpus), len(logical_gpus))
+
+
+if __name__ == "__main__":
+    logger.setLevel(logging.INFO)
+    parser = get_parser()
+    args, unknown_args = parser.parse_known_args()
+    disable_tensorflow_gpu_preallocation()
+    os.makedirs("artifacts", exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(filename)s::L%(lineno)d : %(message)s",
+        handlers=[
+            logging.FileHandler("artifacts/training.log"),
+            logging.StreamHandler(),
+        ],
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    main(args, unknown_args)
+
+    with put_dir(args.output_path) as path:
+        shutil.move("artifacts", os.path.join(path, "artifacts"))

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import tensorflow as tf
 from typing import Iterable, Mapping, Optional
@@ -10,6 +11,9 @@ from fv3fit.reservoir.transformers import (
 )
 from fv3fit.reservoir.domain2 import RankXYDivider
 from ._reshaping import stack_array_preserving_last_dim
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def assure_txyz_dims(var_data: tf.Tensor) -> tf.Tensor:
@@ -49,6 +53,10 @@ class SynchronziationTracker:
 
     def count_synchronization_steps(self, n_samples: int):
         self.n_steps_synchronized += n_samples
+        logger.info(
+            "Number of steps synchronized: "
+            f"{self.n_steps_synchronized}/{self.n_synchronize}"
+        )
 
     def trim_synchronization_samples_if_needed(self, arr: np.ndarray) -> np.ndarray:
         """ Removes samples from the input array if they fall within the

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -75,18 +75,25 @@ def maybe_join_path(base: Optional[str], append: str) -> Optional[str]:
 
 def load_data(
     variables: Sequence[str],
-    training_data_config: TFDatasetLoader,
+    training_data_configs: Sequence[TFDatasetLoader],
     validation_data_config: Optional[TFDatasetLoader],
     cache_config: CacheConfig,
 ) -> Tuple[tf.data.Dataset, Optional[tf.data.Dataset]]:
-    train_tfdataset = training_data_config.open_tfdataset(
-        local_download_path=maybe_join_path(
-            cache_config.local_download_path, "train_data"
-        ),
-        variable_names=variables,
-    )
+
+    train_tfdatasets = [
+        training_data_config.open_tfdataset(
+            local_download_path=maybe_join_path(
+                cache_config.local_download_path, "train_data"
+            ),
+            variable_names=variables,
+        )
+        for training_data_config in training_data_configs
+    ]
+
     if cache_config.in_memory:
-        train_tfdataset = train_tfdataset.cache()
+        train_tfdatasets = [
+            train_tfdataset.cache() for train_tfdataset in train_tfdatasets
+        ]
     if validation_data_config is not None:
         validation_tfdataset = validation_data_config.open_tfdataset(
             local_download_path=maybe_join_path(
@@ -98,7 +105,7 @@ def load_data(
             validation_tfdataset = validation_tfdataset.cache()
     else:
         validation_tfdataset = None
-    return train_tfdataset, validation_tfdataset
+    return train_tfdatasets, validation_tfdataset
 
 
 def main(args, unknown_args=None):
@@ -134,10 +141,15 @@ def main(args, unknown_args=None):
         training_config = fv3fit.TrainingConfig.from_dict(config_dict)
 
     with open(args.training_data_config, "r") as f:
-        config_dict = yaml.safe_load(f)
-        training_data_config = tfdataset_loader_from_dict(config_dict)
+        config_ = yaml.safe_load(f)
+        if isinstance(config_, Sequence):
+            training_data_configs = [
+                tfdataset_loader_from_dict(config_dict) for config_dict in config_
+            ]
+        else:
+            training_data_configs = [tfdataset_loader_from_dict(config_dict)]
         if args.no_wandb is False:
-            wandb.config["training_data_config"] = config_dict
+            wandb.config["training_data_config"] = config_
     if args.validation_data_config is not None:
         with open(args.validation_data_config, "r") as f:
             config_dict = yaml.safe_load(f)
@@ -151,12 +163,12 @@ def main(args, unknown_args=None):
 
     dump_dataclass(training_config, os.path.join(args.output_path, "train.yaml"))
     dump_dataclass(
-        training_data_config, os.path.join(args.output_path, "training_data.yaml")
+        training_data_configs, os.path.join(args.output_path, "training_data.yaml")
     )
 
-    train_tfdataset, validation_tfdataset = load_data(
+    train_tfdatasets, validation_tfdataset = load_data(
         training_config.variables,
-        training_data_config,
+        training_data_configs,
         validation_data_config,
         training_config.cache,
     )
@@ -166,7 +178,7 @@ def main(args, unknown_args=None):
     logger.info("calling train function")
     model = train(
         hyperparameters=training_config.hyperparameters,
-        train_batches=train_tfdataset,
+        train_batches=train_tfdatasets,
         validation_batches=validation_tfdataset,
     )
     if len(training_config.derived_output_variables) > 0:

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -27,6 +27,7 @@ spec:
           - {name: wandb-project, value: "argo-default"}
           - {name: wandb-tags, value: ""}
           - {name: wandb-group, value: ""}
+          - {name: reservoir, value: "false"}
       container: &training-container
         image: us.gcr.io/vcm-ml/fv3fit
         command: &training-container-cmd ["bash", "-c", "-x"]
@@ -90,8 +91,16 @@ spec:
             else
               wandb_flag="--no-wandb"
             fi
+
+            if  "{{inputs.parameters.reservoir}}" == "false" ];
+            then
+              training_routine="fv3fit.train"
+            else
+              training_routine="fv3fit.reservoir.train_multiple_dataset_sequence"
+            fi
+
             python3 -m torch.utils.collect_env
-            python3 -m fv3fit.train \
+            python3 -m $training_routine \
               training_config.yaml \
               training_data.yaml \
               {{inputs.parameters.output}} \

--- a/workflows/argo/training.yaml
+++ b/workflows/argo/training.yaml
@@ -92,7 +92,7 @@ spec:
               wandb_flag="--no-wandb"
             fi
 
-            if  "{{inputs.parameters.reservoir}}" == "false" ];
+            if [ "{{inputs.parameters.reservoir}}" == "false" ];
             then
               training_routine="fv3fit.train"
             else


### PR DESCRIPTION
This adds the option to train a reservoir model on multiple time series. New, larger training datasets consist of an ensemble of simulations with different initial conditions in the C384 reference data. Reservoir model training requires specialized handling of multiple time series since each must have its own synchronization period at the start.

The main adjustment is that the `reservoir` training function can now take in either a `tf.Dataset` or `Sequence[tf.Dataset]`. If a sequence of datasets is provided it is assumed that each member in the sequence is a time series of training data, and synchronization will be done at the start of each time series before the sequence of hidden states used in training is generated.

In order to minimize change to the existing training code in `fv3fit.train` I just copied that script to the reservoir subdirectory and updated the parts relevant to data loading.  The adjusted training script allows a sequence of datasets to be loaded from a training config file if it contains multiple configuration entries. This avoids a lot of edits to deal with typing issues (other training functions only allow a single `tf.Dataset` for training batches).

Added public API:
- `fv3fit.reservoir.train_multiple_dataset_sequence`
- optional parameter `reservoir` in argo `training` WorkflowTemplate- if "true", will use the above training script to load sequence of datasets. Defaults to 'false', which preserves prior behavior of using `fv3fit.train`.
 