### PR TITLE
Reservoir warm start

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -137,7 +137,6 @@ class ReservoirDatasetAdapter(Predictor):
     @classmethod
     def load(cls, path: str) -> "ReservoirDatasetAdapter":
         model = ReservoirComputingModel.load(os.path.join(path, cls.MODEL_DIR))
-        model.reset_state()
         adapter = cls(
             input_variables=model.input_variables,
             output_variables=model.output_variables,
@@ -216,7 +215,6 @@ class HybridReservoirDatasetAdapter(Predictor):
     @classmethod
     def load(cls, path: str) -> "HybridReservoirDatasetAdapter":
         model = HybridReservoirComputingModel.load(os.path.join(path, cls.MODEL_DIR))
-        model.reset_state()
         adapter = cls(
             input_variables=model.input_variables,
             output_variables=model.output_variables,

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -129,6 +129,14 @@ class Reservoir:
 
         return scaling * W_res
 
+    def dump_state(self, path: str) -> None:
+        fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
+        fs.makedirs(path, exist_ok=True)
+
+        if self.state is not None:
+            with fs.open(os.path.join(path, self._STATE_NAME), "wb") as f:
+                np.save(f, self.state)
+
     def dump(self, path: str) -> None:
         fs: fsspec.AbstractFileSystem = fsspec.get_fs_token_paths(path)[0]
         fs.makedirs(path, exist_ok=True)
@@ -141,10 +149,6 @@ class Reservoir:
             scipy.sparse.save_npz(f, self.W_in)
         with fs.open(os.path.join(path, self._RESERVOIR_WEIGHTS_NAME), "wb") as f:
             scipy.sparse.save_npz(f, self.W_res)
-
-        if self.state is not None:
-            with fs.open(os.path.join(path, self._STATE_NAME), "wb") as f:
-                np.save(f, self.state)
 
         if self.input_mask_array is not None:
             with fsspec.open(os.path.join(path, self._INPUT_MASK_NAME), "wb") as f:

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -156,6 +156,29 @@ def test_prediction_after_load(tmpdir):
     np.testing.assert_array_almost_equal(prediction0[0], prediction1[0])
 
 
+def test_state_preserved_after_load(tmpdir):
+
+    predictor = get_reservoir_computing_model()
+    predictor.reset_state()
+
+    n_times = 20
+
+    rng = np.random.RandomState(0)
+    ts_sync = [
+        rng.randn(n_times, *predictor.rank_divider.rank_extent, 1)
+        for v in predictor.input_variables
+    ]
+    predictor.synchronize(ts_sync)
+
+    output_path = f"{str(tmpdir)}/predictor"
+    predictor.dump(output_path)
+    loaded_predictor = ReservoirComputingModel.load(output_path)
+
+    np.testing.assert_array_equal(
+        predictor.reservoir.state, loaded_predictor.reservoir.state
+    )
+
+
 @pytest.mark.skip(reason="HybridReservoirComputingModel for different variables broken")
 def test_HybridReservoirComputingModel_dump_load(tmpdir):
     state_size = 1000

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -172,6 +172,7 @@ def test_state_preserved_after_load(tmpdir):
 
     output_path = f"{str(tmpdir)}/predictor"
     predictor.dump(output_path)
+    predictor.reservoir.dump_state(f"{output_path}/reservoir")
     loaded_predictor = ReservoirComputingModel.load(output_path)
 
     np.testing.assert_array_equal(

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -170,7 +170,13 @@ class _ReservoirStepper:
         self._state_machine = state_machine
 
         if self.warm_start:
-            self.synchronize_steps = 0
+            if self.synchronize_steps != 0:
+                raise ValueError(
+                    "Warm start specified with non-zero sync steps.  Ensure that"
+                    " the reservoir model is pre-synchronized and set sync steps to 0"
+                    " in the configuration."
+                )
+
             # allows for immediate predict
             self._state_machine(self._state_machine.INCREMENT)
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -169,6 +169,11 @@ class _ReservoirStepper:
             state_machine = _FiniteStateMachine()
         self._state_machine = state_machine
 
+        if self.warm_start:
+            self.synchronize_steps = 0
+            # allows for immediate predict
+            self._state_machine(self._state_machine.INCREMENT)
+
         if rename_mapping is None:
             rename_mapping = cast(NameDict, {})
         self.rename_mapping = rename_mapping

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -40,6 +40,7 @@ class ReservoirConfig:
             to match the reservoir timestep.
         diagnostic_only: Whether to run the reservoir in diagnostic mode (no
             state updates)
+        warm_start: Whether to use the saved state from a pre-synced reservoir
         rename_mapping: mapping from field names used in the underlying
             reservoir model to names used in fv3gfs wrapper
     """
@@ -49,6 +50,7 @@ class ReservoirConfig:
     reservoir_timestep: str = "3h"  # TODO: Could this be inferred?
     time_average_inputs: bool = False
     diagnostic_only: bool = False
+    warm_start: bool = False
     rename_mapping: NameDict = dataclasses.field(default_factory=dict)
 
 
@@ -153,6 +155,7 @@ class _ReservoirStepper:
         diagnostic_only: bool = False,
         input_averager: Optional[TimeAverageInputs] = None,
         rename_mapping: Optional[NameDict] = None,
+        warm_start: bool = False,
     ):
         self.model = model
         self.synchronize_steps = synchronize_steps
@@ -160,6 +163,7 @@ class _ReservoirStepper:
         self.timestep = reservoir_timestep
         self.diagnostic = diagnostic_only
         self.input_averager = input_averager
+        self.warm_start = warm_start
 
         if state_machine is None:
             state_machine = _FiniteStateMachine()
@@ -229,7 +233,7 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
     def increment_reservoir(self, inputs):
         """Should be called at beginning of time loop"""
 
-        if self.completed_sync_steps == 0:
+        if self.completed_sync_steps == 0 and not self.warm_start:
             self.model.reset_state()
         self._state_machine(self._state_machine.INCREMENT)
         self.model.increment_state(inputs)
@@ -391,6 +395,7 @@ def get_reservoir_steppers(
         state_machine=state_machine,
         input_averager=increment_averager,
         rename_mapping=config.rename_mapping,
+        warm_start=config.warm_start,
     )
     predictor = ReservoirPredictStepper(
         model,
@@ -401,5 +406,6 @@ def get_reservoir_steppers(
         diagnostic_only=config.diagnostic_only,
         input_averager=predict_averager,
         rename_mapping=config.rename_mapping,
+        warm_start=config.warm_start,
     )
     return incrementer, predictor

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression[reservoir].out
@@ -446,6 +446,7 @@ reservoir_corrector:
   reservoir_timestep: 900s
   synchronize_steps: 12
   time_average_inputs: false
+  warm_start: false
 scikit_learn: null
 tendency_prescriber: null
 zhao_carr_emulation:

--- a/workflows/prognostic_c48_run/tests/prepare_config_test_data/reservoir.yml
+++ b/workflows/prognostic_c48_run/tests/prepare_config_test_data/reservoir.yml
@@ -28,3 +28,4 @@ reservoir_corrector:
   synchronize_steps: 12
   reservoir_timestep: "900s"
   diagnostic_only: False
+  warm_start: False


### PR DESCRIPTION
With the long-diagnostic runs we now have the ability to pre-synchronize a model.  This PR adds the ability to load models at runtime without resetting the reservoir state.  Additionally, the state is now a field dumped/loaded with a reservoir model.

Refactored public API:
- The runtime config for reservoirs now includes a `warm_start` option which will forego state resets on the first increment

- [x] Tests added

Coverage reports (updated automatically):
