### PR TITLE
Allow for more ranks than reservoir models during fv3 runtime

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -462,7 +462,10 @@ class TimeLoop(
         if config.reservoir_corrector is not None:
             res_config = config.reservoir_corrector
             incrementer, predictor = get_reservoir_steppers(
-                res_config, MPI.COMM_WORLD.Get_rank(), init_time=init_time
+                res_config,
+                MPI.COMM_WORLD.Get_rank(),
+                init_time=init_time,
+                communicator=self._get_communicator(),
             )
         else:
             incrementer, predictor = None, None

--- a/workflows/prognostic_c48_run/runtime/scatter.py
+++ b/workflows/prognostic_c48_run/runtime/scatter.py
@@ -8,7 +8,7 @@ from runtime.types import State
 from runtime.conversions import quantity_state_to_dataset, dataset_to_quantity_state
 
 
-def scatter_within_tile(
+def scatter_within_tile_for_prescriber(
     time: cftime.DatetimeJulian,
     time_lookup_function: Callable[[cftime.DatetimeJulian], State],
     communicator: pace.util.CubedSphereCommunicator,
@@ -28,6 +28,21 @@ def scatter_within_tile(
         state: State = time_lookup_function(time)
     else:
         state = {}
+
+    return scatter_within_tile(communicator, state)
+
+
+def scatter_within_tile(
+    communicator: pace.util.CubedSphereCommunicator, state: State,
+) -> xr.Dataset:
+    """Scatter data from each tile's master rank to its subranks.
+
+    Args:
+        communicator: model cubed sphere communicator
+
+    Returns:
+        Dataset of scattered data arrays
+    """
 
     tile = communicator.partitioner.tile_index(communicator.rank)
     if communicator.tile.rank == 0:

--- a/workflows/prognostic_c48_run/runtime/scatter.py
+++ b/workflows/prognostic_c48_run/runtime/scatter.py
@@ -52,3 +52,23 @@ def scatter_within_tile(
         scattered_state = communicator.tile.scatter_state()
 
     return quantity_state_to_dataset(scattered_state)
+
+
+def gather_from_subtiles(
+    communicator: pace.util.CubedSphereCommunicator, state: State,
+) -> xr.Dataset:
+    """Gather data from each sub rank onto the root tile.
+
+    Args:
+        communicator: model cubed sphere communicator
+
+    Returns:
+        Dataset of gathered data arrays
+    """
+
+    tile = communicator.partitioner.tile_index(communicator.rank)
+    gathered_state = communicator.tile.gather_state(state)
+    if communicator.tile.rank == 0:
+        return quantity_state_to_dataset(gathered_state).isel(tile=tile)
+    else:
+        return None

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -4,7 +4,7 @@ import logging
 import cftime
 import xarray as xr
 from runtime.types import State, Diagnostics, Tendencies
-from runtime.scatter import scatter_within_tile
+from runtime.scatter import scatter_within_tile_for_prescriber
 from runtime.names import SST, TSFC, MASK
 
 import pace.util
@@ -76,7 +76,9 @@ class Prescriber:
         self._tendency_variables = tendency_variables or {}
 
     def _open_prescribed_timestep(self, time: cftime.DatetimeJulian) -> xr.Dataset:
-        ds = scatter_within_tile(time, self._time_lookup_function, self._communicator)
+        ds = scatter_within_tile_for_prescriber(
+            time, self._time_lookup_function, self._communicator
+        )
         return ds.rename(**self._variables, **self._tendency_variables)
 
     def __call__(self, time, state):

--- a/workflows/prognostic_c48_run/runtime/transformers/tendency_prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/transformers/tendency_prescriber.py
@@ -10,7 +10,7 @@ import loaders
 from runtime.monitor import Monitor
 from runtime.types import Diagnostics, Step, State
 from runtime.derived_state import DerivedFV3State
-from runtime.scatter import scatter_within_tile
+from runtime.scatter import scatter_within_tile_for_prescriber
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class TendencyPrescriber:
 
     def _open_tendencies_timestep(self, time: cftime.DatetimeJulian) -> xr.Dataset:
         # https://github.com/python/mypy/issues/5485
-        return scatter_within_tile(
+        return scatter_within_tile_for_prescriber(
             time, self.time_lookup_function, self.communicator  # type: ignore
         )
 


### PR DESCRIPTION
Running the SST reservoir with a single model per tile drastically slows down operation for runs that need to be 6+ months to see results.  This PR adds the ability to run with fewer reservoir models than ranks used for fv3gfs by implementing gather/scatter operations for the inputs and outputs from those steppers.

Refactored public API:
- `get_reservoir_steppers`: now takes in a `CubedSphereCommunicator` object to determine if more ranks than models are available and initializes the steppers depending on that.

Significant internal changes:
- For non-root ranks of each tile, we now use `_GatherScatterStepper` for the increment and prediction steppers, the tile roots use the original steppers with gather/scatter embedded

Coverage reports (updated automatically):
