### PR TITLE
Use ultra-node-pool for fv3gfs-run if memory exceeds cutoff

### DIFF
--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -75,6 +75,11 @@ sequential segments.
 | `online-diags-flags` | (optional) `flags` for `prognostic-run-diags` workflow                        |
 | `online-diags`       | (optional) Run online diagostics if "true"; default "true"                     |
 
+If the number of requested CPUs is greater than 24, the job will be run on the `ultra-sim-pool` node pool (more expensive).
+If the requested memory is greater than 30 Gi, the job will run on the `highmem-sim-pool` unless the number of CPUs
+is greater than 24, in which case the `ultra-sim-pool` will be used.
+Runs with requested CPUs < 24 and memory < 30Gi will use the `climate-sim-pool` nodes.
+
 #### Command line interfaces used by workflow
 This workflow first resolves the output location for the run according to:
 ```

--- a/workflows/argo/restart-prognostic-run.yaml
+++ b/workflows/argo/restart-prognostic-run.yaml
@@ -32,6 +32,8 @@ spec:
             parameters:
               - {name: cpu-request, value: "{{inputs.parameters.cpu}}"}
               - {name: cpu-cutoff, value: "24"}
+              - {name: memory-request, value: "{{inputs.parameters.memory}}"}
+              - {name: memory-cutoff, value: "30"}
       - - name: restart-run
           templateRef:
             name: run-fv3gfs

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -29,6 +29,8 @@ spec:
             parameters:
             - {name: cpu-request, value: "{{inputs.parameters.cpu}}"}
             - {name: cpu-cutoff, value: "24"}
+            - {name: memory-request, value: "{{inputs.parameters.memory}}"}
+            - {name: memory-cutoff, value: "30"}
       # loop over segments implemented through recursion so that a failed segment will
       # terminate the workflow. Argo loops by default run in parallel and do not fail fast.
       - - name: run-first-segment
@@ -113,6 +115,9 @@ spec:
       parameters:
         - name: cpu-request
         - name: cpu-cutoff
+        - name: memory-request
+        - name: memory-cutoff
+
     script:
       image: python:alpine3.6
       command: [python]
@@ -122,7 +127,17 @@ spec:
             cpus = float(cpu_request[:-1])/1000.0
         else:
             cpus = float(cpu_request)
-        node_pool = 'climate-sim-pool' if cpus <= {{inputs.parameters.cpu-cutoff}} else 'ultra-sim-pool'
+
+        memory_request = "{{inputs.parameters.memory-request}}".lower()
+        if memory_request.endswith('gi') or memory_request.endswith('gb'):
+            memory = float(memory_request[:-2])
+        else:
+            raise ValueError("memory request must be in Gi or Gb")
+
+        if cpus <= {{inputs.parameters.cpu-cutoff}} and memory <= {{inputs.parameters.memory-cutoff}}:
+            node_pool = 'climate-sim-pool'
+        else:
+            node_pool = 'ultra-sim-pool'
         print(node_pool)
   - name: append-segment
     inputs:

--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -134,8 +134,11 @@ spec:
         else:
             raise ValueError("memory request must be in Gi or Gb")
 
-        if cpus <= {{inputs.parameters.cpu-cutoff}} and memory <= {{inputs.parameters.memory-cutoff}}:
+        if cpus <= {{inputs.parameters.cpu-cutoff}}:
+          if memory <= {{inputs.parameters.memory-cutoff}}:
             node_pool = 'climate-sim-pool'
+          else:
+            node_pool = 'highmem-sim-pool'
         else:
             node_pool = 'ultra-sim-pool'
         print(node_pool)

--- a/workflows/argo/scream-prognostic-run.yaml
+++ b/workflows/argo/scream-prognostic-run.yaml
@@ -29,6 +29,8 @@ spec:
             parameters:
             - {name: cpu-request, value: "{{inputs.parameters.cpu}}"}
             - {name: cpu-cutoff, value: "30"}
+            - {name: memory-request, value: "{{inputs.parameters.memory}}"}
+            - {name: memory-cutoff, value: "30"}
       - - name: run-scream
           template: run-scream
           arguments:


### PR DESCRIPTION
This edits the `choose-node-pool` step to use the highmem-sim-pool (N2 highmem w/ 32 cores and 256 GB memory) if a larger amount of memory than available on climate-sim-pool (>30Gi) is requested.
 