### PR TITLE
Time shift hybrid data during preprocessing

### DIFF
--- a/docker/prognostic_scream_run/Dockerfile
+++ b/docker/prognostic_scream_run/Dockerfile
@@ -132,6 +132,10 @@ RUN pip install -e /fv3net/workflows/prognostic_scream_run
 RUN pip uninstall -y tensorflow h5py
 RUN pip install tensorflow==2.8.0
 
+# this is a workaround because python does not recognize the already installed py package
+RUN pip uninstall -y py
+RUN pip install py==1.11.0
+
 COPY docker/prognostic_scream_run/precompile_scream.sh /src/precompile_scream.sh
 ENV CC=/opt/conda/bin/mpicc
 ENV CXX=/opt/conda/bin/mpicxx

--- a/docker/prognostic_scream_run/requirements.in
+++ b/docker/prognostic_scream_run/requirements.in
@@ -99,7 +99,7 @@ pybind11==2.9.1
 pycparser==2.20
 pyparsing==2.4.7
 pytest-regtest==1.4.4
-pytest==4.6.11
+pytest==7.4.0
 python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0

--- a/projects/reservoir/fv3/save_ranks.py
+++ b/projects/reservoir/fv3/save_ranks.py
@@ -13,11 +13,6 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Shift hybrid data by this number of timesteps.
-# -1 is common use case for saving the next timestep's ML prediction at
-# the same sample index as reservoir input.
-TIME_SHIFT_HYBRID_DATA = -1
-
 
 def _get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
@@ -90,7 +85,16 @@ def _get_parser() -> argparse.ArgumentParser:
             "All datasets loaded must have the same space and time coordinates."
         ),
     )
-
+    parser.add_argument(
+        "--hybrid-data-time-shift",
+        type=int,
+        default=-1,
+        help=(
+            "Number of timesteps to shift hybrid data by. "
+            "-1 is common use case for saving the next timestep's ML prediction at "
+            "the same sample index as reservoir input."
+        ),
+    )
     return parser
 
 
@@ -119,7 +123,7 @@ if __name__ == "__main__":
     if len(args.hybrid_data_paths) > 0:
         for path in args.hybrid_data_paths:
             _hybrid_data = intake.open_zarr(path).to_dask()
-            _hybrid_data = _hybrid_data.shift(time=TIME_SHIFT_HYBRID_DATA)
+            _hybrid_data = _hybrid_data.shift(time=args.hybrid_data_time_shift)
             rename_hybrid_time_shifted_vars.update(
                 {var: f"{var}_at_next_time_step" for var in _hybrid_data.data_vars}
             )


### PR DESCRIPTION
The hybrid reservoir model takes in the state at time t, updates its hidden state, and then uses its hidden state plus the 'imperfect' (i.e. coarse model FV3GFS) prediction at time **t+1** to predict the corrected state at time t+1. We [previously discussed](https://github.com/ai2cm/fv3net/pull/2288#discussion_r1270052043) how the hybrid inputs should be shifted by an index -1 to match up with the hidden states at time t. However, I did not merge the agreed upon solution (do the shifting in the preprocessing) so my latest results from hybrid models have the incorrect time index of hybrid inputs.

This PR corrects the issue by shifting hybrid inputs in the preprocessing step.
 
It also includes a fix to only reset the reservoir state at the start of each initial condition's time series. Previously it was resetting every batch. Previously trained models used a branch with this fix so they weren't affected. 