### PR TITLE
Tidy prognostic run loop file

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/__init__.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/__init__.py
@@ -4,4 +4,5 @@ from .compute import (
     compute_ml_momentum_diagnostics,
     compute_baseline_diagnostics,
     rename_diagnostics,
+    enforce_heating_and_moistening_tendency_constraints,
 )

--- a/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
@@ -81,9 +81,7 @@ def enforce_heating_and_moistening_tendency_constraints(
 
     if "dQ2" in tendency:
         moistening = vcm.mass_integrate(
-            temperature_tendency_updated - tendency[humidity_tendency_name],
-            delp,
-            dim="z",
+            humidity_tendency_updated - tendency[humidity_tendency_name], delp, dim="z",
         )
         moistening = moistening.assign_attrs(
             units="kg/m^2/s",
@@ -94,7 +92,7 @@ def enforce_heating_and_moistening_tendency_constraints(
             "column_integrated_dQ2_change_non_neg_sphum_constraint"
         ] = moistening
 
-        tendency_updates[humidity_tendency_name] = temperature_tendency_updated
+        tendency_updates[humidity_tendency_name] = humidity_tendency_updated
 
     diagnostics_updates["specific_humidity_limiter_active"] = xr.where(
         humidity_tendency_initial != humidity_tendency_updated, 1, 0

--- a/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
@@ -18,6 +18,91 @@ cp = 1004
 KG_PER_M2_PER_M = 1000.0
 
 
+def enforce_heating_and_moistening_tendency_constraints(
+    state: State,
+    tendency: State,
+    timestep: float,
+    hydrostatic: bool,
+    mse_conserving: bool,
+    temperature_tendency_name="dQ1",
+    humidity_tendency_name="dQ2",
+):
+    temperature_tendency_initial = tendency.get(
+        temperature_tendency_name, xr.zeros_like(state[SPHUM])
+    )
+    humidity_tendency_initial = tendency.get(
+        humidity_tendency_name, xr.zeros_like(state[SPHUM])
+    )
+    delp = state[DELP]
+    tendency_updates, diagnostics_updates = {}, {}
+
+    if mse_conserving is True:
+        (
+            humidity_tendency_updated,
+            temperature_tendency_updated,
+        ) = vcm.non_negative_sphum_mse_conserving(
+            state[SPHUM],
+            humidity_tendency_initial,
+            timestep,
+            q1=temperature_tendency_initial,
+        )
+    else:
+        (
+            temperature_tendency_updated,
+            humidity_tendency_updated,
+        ) = vcm.non_negative_sphum(
+            state[SPHUM],
+            dQ1=temperature_tendency_initial,
+            dQ2=humidity_tendency_initial,
+            dt=timestep,
+        )
+
+    if temperature_tendency_name in tendency:
+        if hydrostatic:
+            heating = vcm.column_integrated_heating_from_isobaric_transition(
+                temperature_tendency_updated - tendency[temperature_tendency_name],
+                delp,
+                "z",
+            )
+        else:
+            heating = vcm.column_integrated_heating_from_isochoric_transition(
+                temperature_tendency_updated - tendency[temperature_tendency_name],
+                delp,
+                "z",
+            )
+        heating = heating.assign_attrs(
+            long_name="Change in ML column heating due to non-negative specific "
+            "humidity limiter"
+        )
+        diagnostics_updates[
+            "column_integrated_dQ1_change_non_neg_sphum_constraint"
+        ] = heating
+        tendency_updates[temperature_tendency_name] = temperature_tendency_updated
+
+    if "dQ2" in tendency:
+        moistening = vcm.mass_integrate(
+            temperature_tendency_updated - tendency[humidity_tendency_name],
+            delp,
+            dim="z",
+        )
+        moistening = moistening.assign_attrs(
+            units="kg/m^2/s",
+            long_name="Change in ML column moistening due to non-negative specific "
+            "humidity limiter",
+        )
+        diagnostics_updates[
+            "column_integrated_dQ2_change_non_neg_sphum_constraint"
+        ] = moistening
+
+        tendency_updates[humidity_tendency_name] = temperature_tendency_updated
+
+    diagnostics_updates["specific_humidity_limiter_active"] = xr.where(
+        humidity_tendency_initial != humidity_tendency_updated, 1, 0
+    )
+
+    return tendency_updates, diagnostics_updates
+
+
 def precipitation_sum(
     physics_precip: xr.DataArray, column_dq2: xr.DataArray, dt: float
 ) -> xr.DataArray:
@@ -120,7 +205,7 @@ def compute_diagnostics(
             f"{TENDENCY_TO_STATE_NAME[k]}_tendency_due_to_nudging": v
             for k, v in tendency.items()
         }
-    elif label == "machine_learning":
+    elif label in {"machine_learning", "reservoir"}:
         diags_3d = {
             "dQ1": temperature_tendency.assign_attrs(units="K/s").assign_attrs(
                 description=f"air temperature tendency due to {label}"
@@ -129,6 +214,7 @@ def compute_diagnostics(
                 description=f"specific humidity tendency due to {label}"
             ),
         }
+
     diags.update(diags_3d)
 
     # add 3D state to diagnostics for backwards compatibility

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -34,16 +34,14 @@ from runtime.diagnostics.compute import (
 import runtime.diagnostics.tracers
 from runtime.monitor import Monitor
 from runtime.names import (
-    TENDENCY_TO_STATE_NAME,
     TOTAL_PRECIP_RATE,
     PREPHYSICS_OVERRIDES,
     SURFACE_FLUX_OVERRIDES,
-    A_GRID_WIND_TENDENCIES,
-    D_GRID_WIND_TENDENCIES,
-    EASTWARD_WIND_TENDENCY,
-    NORTHWARD_WIND_TENDENCY,
-    X_WIND_TENDENCY,
-    Y_WIND_TENDENCY,
+)
+from runtime.tendency import (
+    add_tendency,
+    prepare_tendencies_for_dynamical_core,
+    state_updates_from_tendency,
 )
 from runtime.steppers.machine_learning import (
     MachineLearningConfig,
@@ -79,126 +77,6 @@ def _replace_precip_rate_with_accumulation(  # type: ignore
         state_updates.pop(TOTAL_PRECIP_RATE)
 
 
-def fillna_tendency(tendency: xr.DataArray) -> Tuple[xr.DataArray, xr.DataArray]:
-    tendency_filled = tendency.fillna(0.0)
-    tendency_filled_frac = (
-        xr.where(tendency != tendency_filled, 1, 0).sum("z") / tendency.sizes["z"]
-    )
-    tendency_filled_frac_name = f"{tendency_filled.name}_filled_frac"
-    tendency_filled_frac = tendency_filled_frac.rename(tendency_filled_frac_name)
-    return tendency_filled, tendency_filled_frac
-
-
-def fillna_tendencies(tendencies: State) -> Tuple[State, State]:
-    filled_tendencies: State = {}
-    filled_fractions: State = {}
-
-    for name, tendency in tendencies.items():
-        (
-            filled_tendencies[name],
-            filled_fractions[f"{name}_filled_frac"],
-        ) = fillna_tendency(tendency)
-
-    return filled_tendencies, filled_fractions
-
-
-def prepare_agrid_wind_tendencies(
-    tendencies: State,
-) -> Tuple[xr.DataArray, xr.DataArray]:
-    """Ensure A-grid wind tendencies are defined, have the proper units, and
-    data type before being passed to the wrapper.
-
-    Assumes that at least one of dQu or dQv appears in the tendencies input
-    dictionary.
-    """
-    dQu = tendencies.get(EASTWARD_WIND_TENDENCY)
-    dQv = tendencies.get(NORTHWARD_WIND_TENDENCY)
-
-    if dQu is None:
-        dQu = xr.zeros_like(dQv)
-    if dQv is None:
-        dQv = xr.zeros_like(dQu)
-
-    dQu = dQu.assign_attrs(units="m/s/s").astype(np.float64, casting="same_kind")
-    dQv = dQv.assign_attrs(units="m/s/s").astype(np.float64, casting="same_kind")
-    return dQu, dQv
-
-
-def transform_agrid_wind_tendencies(tendencies: State) -> State:
-    """Transforms available A-grid wind tendencies to the D-grid.
-
-    Currently this does not support the case that both A-grid and D-grid
-    tendencies are provided and will raise an error in that situation.  It would
-    be straightforward to enable support of that, however.
-    """
-    if contains_dgrid_tendencies(tendencies):
-        raise ValueError(
-            "Simultaneously updating A-grid and D-grid winds is currently not "
-            "supported."
-        )
-
-    dQu, dQv = prepare_agrid_wind_tendencies(tendencies)
-    dQx_wind, dQy_wind = transform_from_agrid_to_dgrid(dQu, dQv)
-    tendencies[X_WIND_TENDENCY] = dQx_wind
-    tendencies[Y_WIND_TENDENCY] = dQy_wind
-    return dissoc(tendencies, *A_GRID_WIND_TENDENCIES)
-
-
-def contains_agrid_tendencies(tendencies):
-    return any(k in tendencies for k in A_GRID_WIND_TENDENCIES)
-
-
-def contains_dgrid_tendencies(tendencies):
-    return any(k in tendencies for k in D_GRID_WIND_TENDENCIES)
-
-
-def prepare_tendencies_for_dynamical_core(tendencies: State) -> Tuple[State, State]:
-    # Filled fraction diagnostics are recorded on the original grid, since that
-    # is where the na-filling occurs.
-    filled_tendencies, tendencies_filled_frac = fillna_tendencies(tendencies)
-    if contains_agrid_tendencies(filled_tendencies):
-        filled_tendencies = transform_agrid_wind_tendencies(filled_tendencies)
-    return filled_tendencies, tendencies_filled_frac
-
-
-def transform_from_agrid_to_dgrid(
-    u: xr.DataArray, v: xr.DataArray
-) -> Tuple[xr.DataArray, xr.DataArray]:
-    """Transform a vector field on the A-grid in latitude-longitude coordinates
-    to the D-grid in cubed-sphere coordinates.
-
-    u and v must have double precision and contain units attributes.
-    """
-    u_quantity = pace.util.Quantity.from_data_array(u)
-    v_quantity = pace.util.Quantity.from_data_array(v)
-    (
-        x_wind_quantity,
-        y_wind_quantity,
-    ) = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(u_quantity, v_quantity)
-    return x_wind_quantity.data_array, y_wind_quantity.data_array
-
-
-def add_tendency(state: Any, tendencies: State, dt: float) -> State:
-    """Given state and tendency prediction, return updated state, which only includes
-    variables updated by tendencies.  Tendencies cannot contain null values.
-    """
-    with xr.set_options(keep_attrs=True):
-        updated: State = {}
-        for name, tendency in tendencies.items():
-            try:
-                state_name = str(TENDENCY_TO_STATE_NAME[name])
-            except KeyError:
-                raise KeyError(
-                    f"Tendency variable '{name}' does not have an entry mapping it "
-                    "to a corresponding state variable to add to. "
-                    "Existing tendencies with mappings to state are "
-                    f"{list(TENDENCY_TO_STATE_NAME.keys())}"
-                )
-
-            updated[state_name] = state[state_name] + tendency * dt
-    return updated
-
-
 class LoggingMixin:
 
     rank: int
@@ -214,18 +92,6 @@ class LoggingMixin:
     def _print(self, message: str):
         if self.rank == 0:
             print(message)
-
-
-def state_updates_from_tendency(tendency_updates):
-    # Prescriber can overwrite the state updates predicted by ML tendencies
-    # Sometimes this is desired and we want to save both the overwritten updated state
-    # as well as the ML-predicted state that was overwritten, ex. reservoir updates.
-
-    updates = {
-        f"{k}_state_from_postphysics_tendency": v for k, v in tendency_updates.items()
-    }
-
-    return updates
 
 
 def _check_surface_flux_overrides_exist(namelist_override_flag, state_update_keys):

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -221,6 +221,8 @@ class PureMLStepper:
         for name in state_updates.keys():
             diagnostics[name] = state_updates[name]
 
+        # Adjust dQ1 and dQ2 to ensure non-negative humidity and optionally conserve MSE
+        # and add diagnostics tracking the tendency adjustments related to this step
         (
             tendency_updates,
             diagnostics_updates,

--- a/workflows/prognostic_c48_run/runtime/tendency.py
+++ b/workflows/prognostic_c48_run/runtime/tendency.py
@@ -1,0 +1,148 @@
+from typing import Any, Tuple
+import pace.util
+import fv3gfs.wrapper
+import numpy as np
+import xarray as xr
+from runtime.names import (
+    TENDENCY_TO_STATE_NAME,
+    A_GRID_WIND_TENDENCIES,
+    D_GRID_WIND_TENDENCIES,
+    EASTWARD_WIND_TENDENCY,
+    NORTHWARD_WIND_TENDENCY,
+    X_WIND_TENDENCY,
+    Y_WIND_TENDENCY,
+)
+from runtime.types import State
+from toolz import dissoc
+
+
+def state_updates_from_tendency(tendency_updates):
+    # Prescriber can overwrite the state updates predicted by ML tendencies
+    # Sometimes this is desired and we want to save both the overwritten updated state
+    # as well as the ML-predicted state that was overwritten, ex. reservoir updates.
+
+    updates = {
+        f"{k}_state_from_postphysics_tendency": v for k, v in tendency_updates.items()
+    }
+
+    return updates
+
+
+def transform_from_agrid_to_dgrid(
+    u: xr.DataArray, v: xr.DataArray
+) -> Tuple[xr.DataArray, xr.DataArray]:
+    """Transform a vector field on the A-grid in latitude-longitude coordinates
+    to the D-grid in cubed-sphere coordinates.
+
+    u and v must have double precision and contain units attributes.
+    """
+    u_quantity = pace.util.Quantity.from_data_array(u)
+    v_quantity = pace.util.Quantity.from_data_array(v)
+    (
+        x_wind_quantity,
+        y_wind_quantity,
+    ) = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(u_quantity, v_quantity)
+    return x_wind_quantity.data_array, y_wind_quantity.data_array
+
+
+def contains_agrid_tendencies(tendencies):
+    return any(k in tendencies for k in A_GRID_WIND_TENDENCIES)
+
+
+def contains_dgrid_tendencies(tendencies):
+    return any(k in tendencies for k in D_GRID_WIND_TENDENCIES)
+
+
+def fillna_tendency(tendency: xr.DataArray) -> Tuple[xr.DataArray, xr.DataArray]:
+    tendency_filled = tendency.fillna(0.0)
+    tendency_filled_frac = (
+        xr.where(tendency != tendency_filled, 1, 0).sum("z") / tendency.sizes["z"]
+    )
+    tendency_filled_frac_name = f"{tendency_filled.name}_filled_frac"
+    tendency_filled_frac = tendency_filled_frac.rename(tendency_filled_frac_name)
+    return tendency_filled, tendency_filled_frac
+
+
+def add_tendency(state: Any, tendencies: State, dt: float) -> State:
+    """Given state and tendency prediction, return updated state, which only includes
+    variables updated by tendencies.  Tendencies cannot contain null values.
+    """
+    with xr.set_options(keep_attrs=True):
+        updated: State = {}
+        for name, tendency in tendencies.items():
+            try:
+                state_name = str(TENDENCY_TO_STATE_NAME[name])
+            except KeyError:
+                raise KeyError(
+                    f"Tendency variable '{name}' does not have an entry mapping it "
+                    "to a corresponding state variable to add to. "
+                    "Existing tendencies with mappings to state are "
+                    f"{list(TENDENCY_TO_STATE_NAME.keys())}"
+                )
+
+            updated[state_name] = state[state_name] + tendency * dt
+    return updated
+
+
+def fillna_tendencies(tendencies: State) -> Tuple[State, State]:
+    filled_tendencies: State = {}
+    filled_fractions: State = {}
+
+    for name, tendency in tendencies.items():
+        (
+            filled_tendencies[name],
+            filled_fractions[f"{name}_filled_frac"],
+        ) = fillna_tendency(tendency)
+
+    return filled_tendencies, filled_fractions
+
+
+def prepare_agrid_wind_tendencies(
+    tendencies: State,
+) -> Tuple[xr.DataArray, xr.DataArray]:
+    """Ensure A-grid wind tendencies are defined, have the proper units, and
+    data type before being passed to the wrapper.
+
+    Assumes that at least one of dQu or dQv appears in the tendencies input
+    dictionary.
+    """
+    dQu = tendencies.get(EASTWARD_WIND_TENDENCY)
+    dQv = tendencies.get(NORTHWARD_WIND_TENDENCY)
+
+    if dQu is None:
+        dQu = xr.zeros_like(dQv)
+    if dQv is None:
+        dQv = xr.zeros_like(dQu)
+
+    dQu = dQu.assign_attrs(units="m/s/s").astype(np.float64, casting="same_kind")
+    dQv = dQv.assign_attrs(units="m/s/s").astype(np.float64, casting="same_kind")
+    return dQu, dQv
+
+
+def transform_agrid_wind_tendencies(tendencies: State) -> State:
+    """Transforms available A-grid wind tendencies to the D-grid.
+
+    Currently this does not support the case that both A-grid and D-grid
+    tendencies are provided and will raise an error in that situation.  It would
+    be straightforward to enable support of that, however.
+    """
+    if contains_dgrid_tendencies(tendencies):
+        raise ValueError(
+            "Simultaneously updating A-grid and D-grid winds is currently not "
+            "supported."
+        )
+
+    dQu, dQv = prepare_agrid_wind_tendencies(tendencies)
+    dQx_wind, dQy_wind = transform_from_agrid_to_dgrid(dQu, dQv)
+    tendencies[X_WIND_TENDENCY] = dQx_wind
+    tendencies[Y_WIND_TENDENCY] = dQy_wind
+    return dissoc(tendencies, *A_GRID_WIND_TENDENCIES)
+
+
+def prepare_tendencies_for_dynamical_core(tendencies: State) -> Tuple[State, State]:
+    # Filled fraction diagnostics are recorded on the original grid, since that
+    # is where the na-filling occurs.
+    filled_tendencies, tendencies_filled_frac = fillna_tendencies(tendencies)
+    if contains_agrid_tendencies(filled_tendencies):
+        filled_tendencies = transform_agrid_wind_tendencies(filled_tendencies)
+    return filled_tendencies, tendencies_filled_frac

--- a/workflows/prognostic_c48_run/tests/test_tendency.py
+++ b/workflows/prognostic_c48_run/tests/test_tendency.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from runtime.loop import (
+from runtime.tendency import (
     add_tendency,
     fillna_tendencies,
     prepare_agrid_wind_tendencies,


### PR DESCRIPTION
I was working on adding a specific humidity limiter and precipitation update to the reservoir stepper and the long length and number of helpers at the top of the file was getting cumbersome. 

The main changes here are 
- refactored out the code in the postphysics stepper that handles T/q constraints into a separate function so it can be used in the reservoir stepper as well
- move tendency-related helper functions to `tendency.py`

No code is changed, just moved. It might be easier to review by looking at the individual commits.
