### PR TITLE
Fix reservoir renaming duplication

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -103,6 +103,7 @@ class ReservoirDatasetAdapter(Predictor):
         self.model = model
         self.input_variables = model.input_variables
         self.output_variables = model.output_variables
+        self.nonhybrid_input_variables = model.input_variables
         self.model_adapter = DatasetAdapter(
             input_variables=self.input_variables,
             output_variables=self.output_variables,
@@ -175,6 +176,8 @@ class HybridReservoirDatasetAdapter(Predictor):
         self.input_variables = list(
             set(model.input_variables).union(model.hybrid_variables)
         )
+        self.nonhybrid_input_variables = model.input_variables
+        self.hybrid_variables = model.hybrid_variables
         self.output_variables = model.output_variables
         self.model_adapter = DatasetAdapter(
             input_variables=self.input_variables,

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -69,15 +69,12 @@ def invert_dict(d: Mapping) -> Mapping:
 
 
 def rename_dataset_members(ds: xr.Dataset, rename: NameDict) -> xr.Dataset:
-    logger.info(f'renaming original ds: {ds}')
     all_names = set(ds.dims) & set(rename)
     rename_restricted = {key: rename[key] for key in all_names}
     redimed = ds.rename_dims(rename_restricted)
 
     all_names = set(ds.data_vars) & set(rename)
     rename_restricted = {key: rename[key] for key in all_names}
-    logger.info(f"rename_restricted: {rename_restricted}")
-    logger.info(f"redimed: {list(redimed.keys())}")
     return redimed.rename(rename_restricted)
 
 

--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -69,12 +69,15 @@ def invert_dict(d: Mapping) -> Mapping:
 
 
 def rename_dataset_members(ds: xr.Dataset, rename: NameDict) -> xr.Dataset:
+    logger.info(f'renaming original ds: {ds}')
     all_names = set(ds.dims) & set(rename)
     rename_restricted = {key: rename[key] for key in all_names}
     redimed = ds.rename_dims(rename_restricted)
 
     all_names = set(ds.data_vars) & set(rename)
     rename_restricted = {key: rename[key] for key in all_names}
+    logger.info(f"rename_restricted: {rename_restricted}")
+    logger.info(f"redimed: {list(redimed.keys())}")
     return redimed.rename(rename_restricted)
 
 

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -222,11 +222,9 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
         reservoir_inputs = xr.Dataset(
             {
                 k: state[self.rename_mapping.get(k, k)]
-                for k in self.model.input_variables
+                for k in self.model.nonhybrid_input_variables
             }
         )
-        logger.info(f'model input variables: {self.model.input_variables}')
-        logger.info(f'model rename mapping: {self.rename_mapping}')
 
         n_halo_points = self.model.input_overlap
         if n_halo_points > 0:
@@ -271,12 +269,6 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             diags = rename_dataset_members(
                 inputs, {k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs}
             )
-
-            logger.info(f"reservoir increment inputs: {list(inputs.keys())}")
-            logger.info(f'self.rename_mapping: {self.rename_mapping}')
-            logger.info({k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs})
-
-
 
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:
@@ -343,7 +335,7 @@ class ReservoirPredictStepper(_ReservoirStepper):
             inputs = xr.Dataset(
                 {
                     k: state[self.rename_mapping.get(k, k)]
-                    for k in self.model.model.hybrid_variables
+                    for k in self.model.hybrid_variables
                 }
             )
         else:

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -225,6 +225,8 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
                 for k in self.model.input_variables
             }
         )
+        logger.info(f'model input variables: {self.model.input_variables}')
+        logger.info(f'model rename mapping: {self.rename_mapping}')
 
         n_halo_points = self.model.input_overlap
         if n_halo_points > 0:
@@ -269,6 +271,12 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
             diags = rename_dataset_members(
                 inputs, {k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs}
             )
+
+            logger.info(f"reservoir increment inputs: {list(inputs.keys())}")
+            logger.info(f'self.rename_mapping: {self.rename_mapping}')
+            logger.info({k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs})
+
+
 
             # prevent conflict with non-halo diagnostics
             if self.model.input_overlap > 0:

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -225,7 +225,6 @@ class ReservoirIncrementOnlyStepper(_ReservoirStepper):
                 for k in self.model.nonhybrid_input_variables
             }
         )
-
         n_halo_points = self.model.input_overlap
         if n_halo_points > 0:
             try:
@@ -368,7 +367,7 @@ def _get_time_averagers(model, do_time_average):
         increment_averager = TimeAverageInputs(model.model.input_variables)
         predict_averager: Optional[TimeAverageInputs]
         if model.is_hybrid:
-            hybrid_inputs = model.model.hybrid_variables
+            hybrid_inputs = model.hybrid_variables
             variables = hybrid_inputs if hybrid_inputs is not None else []
             predict_averager = TimeAverageInputs(variables)
         else:

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -108,8 +108,9 @@ def get_mock_reservoir_model():
     mock_model = MagicMock()
     mock_model.input_variables = ["a"]
     mock_model.output_variables = ["a"]
+    mock_model.nonhybrid_input_variables = ["a"]
     mock_model.model.input_variables = ["a"]
-    mock_model.model.hybrid_variables = ["a"]
+    mock_model.hybrid_variables = ["a"]
     mock_model.is_hybrid.return_value = True
     mock_model.input_overlap = 1
     out_data = xr.DataArray(np.ones(1), dims=["x"])


### PR DESCRIPTION
While testing a hybrid reservoir model locally, I was running into an issue during the increment stepper's renaming of inputs where the hybrid input variables `[air_temperature_before_interval_update, ...]` and reservoir input variables `[air_temperature, ...]` loaded and then the renaming would fail because both sets would try rename to `[air_temperature_rc_in, ...]`.

The problem occurs because underlying model expects "air_temperature" for the reservoir input and "air_temperature_before_interval_update" for the hybrid input. The same field air_temperature is used for both cases but is renamed to "air_temperature_before_interval_update" before the model uses it as the hybrid input. However, the increment stepper loads both sets of input variables and does `rename_dataset_members(inputs, {k: f"{self.rename_mapping.get(k, k)}_rc_in" for k in inputs})` which results in a renaming mapping with collisions when creating some of its diagnostics e.g. ` {'specific_humidity_before_interval_update': 'specific_humidity_rc_in', 'air_temperature': 'air_temperature_rc_in', 'air_temperature_before_interval_update': 'air_temperature_rc_in', 'specific_humidity': 'specific_humidity_rc_in'}`. If we only load the nonhybrid/hybrid inputs that the respective increment/predict steppers need then we can avoid this name collision

This PR adjusts the increment stepper to only load the reservoir input variables and not the hybrid inputs. This necessitated adding an additional `nonhybrid_input_variables` attribute to the adapter.

I'm not sure why this error occurs in the current master but not the older image (4e893f5) I was using in my vcm-workflow-control experiments- maybe one of the components changed in the meantime.