### PR TITLE
Update offline diagnostic's use of temporary direcotry

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -310,11 +310,11 @@ def get_prediction(
 
 
 def _daskify_sequence(batches):
-    temp_data_dir = temporary_directory()
-    for i, batch in enumerate(batches):
-        logger.info(f"Locally caching batch {i+1}/{len(batches)+1}")
-        batch.to_netcdf(os.path.join(temp_data_dir.name, f"{i}.nc"))
-    dask_ds = xr.open_mfdataset(os.path.join(temp_data_dir.name, "*.nc"))
+    with temporary_directory() as td:
+        for i, batch in enumerate(batches):
+            logger.info(f"Locally caching batch {i+1}/{len(batches)+1}")
+            batch.to_netcdf(os.path.join(td, f"{i}.nc"))
+        dask_ds = xr.open_mfdataset(os.path.join(td, "*.nc"))
     return dask_ds
 
 


### PR DESCRIPTION
The current way of calling temporary directory caused inconsistent behavior. Most of the time it works fine when the input number of timesteps is small but crashes for large number of timesteps. I suspect the temporary directory gets cleaned out somewhat automatically after `temporary_directory()`. Moving the call to the with context fixes this inconsistency and we're able to read the batches from the temp dir regardless of timesteps.

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
