### PR TITLE
Add input mask option for hybrid readout data

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -204,8 +204,11 @@ def train_reservoir_model(
                         _hybrid_rank_divider_w_overlap,
                     )
                     hybrid_time_series = hybrid_time_series * hybrid_input_mask_array
+                else:
+                    hybrid_input_mask_array = None
             else:
                 hybrid_time_series = None
+                hybrid_input_mask_array = None
 
             readout_input, readout_output = _construct_readout_inputs_outputs(
                 reservoir_state_time_series,
@@ -265,6 +268,7 @@ def train_reservoir_model(
             square_half_hidden_state=hyperparameters.square_half_hidden_state,
             rank_divider=rank_divider,  # type: ignore
             transformers=transformers,
+            hybrid_input_mask=hybrid_input_mask_array,
         )
         adapter = HybridReservoirDatasetAdapter(  # type: ignore
             model=model,

--- a/external/fv3fit/tests/reservoir/helpers.py
+++ b/external/fv3fit/tests/reservoir/helpers.py
@@ -47,7 +47,10 @@ def get_reservoir_computing_model(
     )
     transformers = TransformerGroup(input=encoder, output=encoder, hybrid=encoder)
     if hybrid:
-        input_mask = np.ones(divider.flat_subdomain_len)
+        no_overlap_divider = divider.get_no_overlap_rank_divider()
+        input_mask = np.ones(
+            (no_overlap_divider.n_subdomains, no_overlap_divider.flat_subdomain_len)
+        )
         predictor = HybridReservoirComputingModel(
             input_variables=variables,
             output_variables=variables,

--- a/external/fv3fit/tests/reservoir/helpers.py
+++ b/external/fv3fit/tests/reservoir/helpers.py
@@ -47,6 +47,7 @@ def get_reservoir_computing_model(
     )
     transformers = TransformerGroup(input=encoder, output=encoder, hybrid=encoder)
     if hybrid:
+        input_mask = np.ones(divider.flat_subdomain_len)
         predictor = HybridReservoirComputingModel(
             input_variables=variables,
             output_variables=variables,
@@ -55,6 +56,7 @@ def get_reservoir_computing_model(
             readout=readout,
             rank_divider=divider,
             transformers=transformers,
+            hybrid_input_mask=input_mask,
         )
     else:
         predictor = ReservoirComputingModel(

--- a/external/fv3fit/tests/reservoir/helpers.py
+++ b/external/fv3fit/tests/reservoir/helpers.py
@@ -73,5 +73,3 @@ def get_reservoir_computing_model(
     predictor.reset_state()
 
     return predictor
-
-    return predictor

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -128,6 +128,7 @@ def test_nonhybrid_adapter_predict(regtest):
     print(result, file=regtest)
 
 
+@pytest.mark.filterwarnings("ignore:Model type is not located at")
 def test_adapter_dump_and_load(tmpdir):
     predictor = get_8x8_overlapped_model(hybrid=False)
     data = get_single_rank_xarray_data()
@@ -203,6 +204,7 @@ def test_generate_subdomain_models_for_all_class_types(is_hybrid, use_adapter):
     assert len(split_models) == 4
 
 
+@pytest.mark.filterwarnings("ignore:Model type is not located at")
 def test_generate_subdomain_models_for_saved_single_tile(tmpdir):
     model = get_8x8_overlapped_model(hybrid=True)
     save_path = str(tmpdir.join("model0"))
@@ -215,6 +217,7 @@ def test_generate_subdomain_models_for_saved_single_tile(tmpdir):
         fv3fit.load(str(tmpdir.join("new_models").join(f"subdomain_{i}")))
 
 
+@pytest.mark.filterwarnings("ignore:Model type is not located at")
 def test_generate_subdomain_models_for_saved_all_tiles(tmpdir):
     model = get_8x8_overlapped_model(hybrid=True)
     model_map = {}

--- a/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
+++ b/external/fv3fit/tests/reservoir/test_reservoir_computing_model.py
@@ -203,3 +203,28 @@ def test_HybridReservoirComputingModel_dump_load(tmpdir):
     np.testing.assert_array_equal(
         model._hybrid_input_mask, loaded_predictor._hybrid_input_mask
     )
+
+
+def test_HybridReservoirComputingModel_hybrid_mask():
+    model = get_reservoir_computing_model(hybrid=True)
+
+    model.reset_state()
+    model._hybrid_input_mask = np.zeros_like(model._hybrid_input_mask)
+
+    n_times = 20
+
+    ts_sync = [
+        np.random.randn(n_times, *model.rank_divider.rank_extent, 1)
+        for v in model.input_variables
+    ]
+    model.synchronize(ts_sync)
+    prediction0 = model.predict([ts[-1] for ts in ts_sync])
+
+    model.reset_state()
+    model.synchronize(ts_sync)
+    ts_sync = [
+        np.random.randn(n_times, *model.rank_divider.rank_extent, 1)
+        for v in model.input_variables
+    ]
+    prediction1 = model.predict([ts[-1] for ts in ts_sync])
+    np.testing.assert_array_almost_equal(prediction0[0], prediction1[0])


### PR DESCRIPTION
In the reservoir models, we have options to mask the reservoir inputs using a specified mask (used for SST runs, currently) but the hybrid inputs had no such option.  This PR takes that same mask and also applies it to the readout training by multiplication with the post-encoded spatial gridpoints.  It is then saved as a field with the hybrid model which is loaded and applied to any hybrid input data for prediction.  This allows us to explore how much of the model behavior is tied to continental atmospheric information vs. the ocean areas where the model should actually experience the coupling.

- [ ] Tests added


Coverage reports (updated automatically):
