### PR TITLE
Prognostic run: centralize wrapper import to a single place

### DIFF
--- a/workflows/prognostic_c48_run/runtime/derived_state.py
+++ b/workflows/prognostic_c48_run/runtime/derived_state.py
@@ -17,8 +17,11 @@ class FV3StateMapper(Mapping):
     By default adds mapping {"lon": "longitude", "lat": "latitude"}
     """
 
-    def __init__(self, getter, alternate_keys: Mapping[str, str] = None):
+    def __init__(
+        self, getter, tracer_metadata, alternate_keys: Mapping[str, str] = None
+    ):
         self._getter = getter
+        self._tracer_metadata = tracer_metadata
         self._alternate_keys = alternate_keys or {
             "lon": "longitude",
             "lat": "latitude",
@@ -66,13 +69,13 @@ class FV3StateMapper(Mapping):
         physics_names = set(
             v["name"] for v in self._getter._properties.PHYSICS_PROPERTIES
         )
-        tracer_names = set(v for v in self._getter.get_tracer_metadata())
+        tracer_names = set(v for v in self._tracer_metadata)
         # see __getitem__
         local_names = {"latent_heat_flux", "total_water"}
         return dynamics_names | physics_names | tracer_names | local_names
 
     def _total_water(self):
-        a = self._getter.get_tracer_metadata()
+        a = self._tracer_metadata
         water_species = [name for name in a if a[name]["is_water"]]
         return sum(self[name] for name in water_species)
 
@@ -87,13 +90,15 @@ class DerivedFV3State(MutableMapping):
 
     """
 
-    def __init__(self, getter):
+    def __init__(self, getter, tracer_metadata):
         """
         Args:
             getter: the fv3gfs object or a mock of it.
         """
         self._getter = getter
-        self._mapper = DerivedMapping(FV3StateMapper(getter, alternate_keys=None))
+        self._mapper = DerivedMapping(
+            FV3StateMapper(getter, tracer_metadata, alternate_keys=None)
+        )
 
     @property
     def time(self) -> cftime.DatetimeJulian:

--- a/workflows/prognostic_c48_run/runtime/derived_state.py
+++ b/workflows/prognostic_c48_run/runtime/derived_state.py
@@ -2,8 +2,6 @@ from typing import Hashable, Mapping, MutableMapping, Set
 
 import cftime
 import pace.util
-import fv3gfs.wrapper
-import fv3gfs.wrapper._properties
 import numpy as np
 import xarray as xr
 from runtime.names import DELP, PHYSICS_PRECIP_RATE, TIME_KEYS
@@ -63,10 +61,10 @@ class FV3StateMapper(Mapping):
 
     def keys(self):
         dynamics_names = set(
-            v["name"] for v in fv3gfs.wrapper._properties.DYNAMICS_PROPERTIES
+            v["name"] for v in self._getter._properties.DYNAMICS_PROPERTIES
         )
         physics_names = set(
-            v["name"] for v in fv3gfs.wrapper._properties.PHYSICS_PROPERTIES
+            v["name"] for v in self._getter._properties.PHYSICS_PROPERTIES
         )
         tracer_names = set(v for v in self._getter.get_tracer_metadata())
         # see __getitem__

--- a/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
@@ -6,11 +6,11 @@ from runtime.names import DELP
 
 
 def compute_column_integrated_tracers(
-    wrapper: Any, state: Mapping[str, xarray.DataArray]
+    tracer_metadata: Mapping[str, Mapping[str, Any]],
+    state: Mapping[str, xarray.DataArray],
 ) -> dict:
     out = {}
-    tracers = wrapper.get_tracer_metadata()
-    for tracer in tracers:
+    for tracer in tracer_metadata:
         path = vcm.mass_integrate(state[tracer], state[DELP], dim="z").assign_attrs(
             description=f"column integrated {tracer}"
         )

--- a/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/tracers.py
@@ -1,14 +1,15 @@
-from typing import Mapping
+from typing import Any, Mapping
 
-import fv3gfs.wrapper
 import vcm
 import xarray
 from runtime.names import DELP
 
 
-def compute_column_integrated_tracers(state: Mapping[str, xarray.DataArray]) -> dict:
+def compute_column_integrated_tracers(
+    wrapper: Any, state: Mapping[str, xarray.DataArray]
+) -> dict:
     out = {}
-    tracers = fv3gfs.wrapper.get_tracer_metadata()
+    tracers = wrapper.get_tracer_metadata()
     for tracer in tracers:
         path = vcm.mass_integrate(state[tracer], state[DELP], dim="z").assign_attrs(
             description=f"column integrated {tracer}"

--- a/workflows/prognostic_c48_run/runtime/logs.py
+++ b/workflows/prognostic_c48_run/runtime/logs.py
@@ -79,10 +79,8 @@ def captured_stream(func):
     return myfunc
 
 
-def capture_fv3gfs_funcs():
+def capture_fv3gfs_funcs(wrapper: Any):
     """Surpress stderr and stdout from all fv3gfs functions"""
-    import fv3gfs.wrapper as wrapper  # noqa
-
     for func in ["step_dynamics", "step_physics", "initialize", "cleanup"]:
         setattr(wrapper, func, captured_stream(getattr(wrapper, func)))
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -131,8 +131,8 @@ class TimeLoop(
         if comm is None:
             comm = MPI.COMM_WORLD
 
-        self._fv3gfs = wrapper
-        self._state: DerivedFV3State = MergedState(DerivedFV3State(self._fv3gfs), {})
+        self._wrapper = wrapper
+        self._state: DerivedFV3State = MergedState(DerivedFV3State(self._wrapper), {})
         self.comm = comm
         self._timer = pace.util.Timer()
         self.rank: int = comm.rank
@@ -174,7 +174,7 @@ class TimeLoop(
             self._reservior_increment_stepper,
             self._reservoir_predict_stepper,
         ] = self._get_reservoir_stepper(config, init_time)
-        self._log_info(self._fv3gfs.get_tracer_metadata())
+        self._log_info(self._wrapper.get_tracer_metadata())
         MPI.COMM_WORLD.barrier()  # wait for initialization to finish
 
     def _use_diagnostic_ml_prephysics(self, prephysics_config):
@@ -251,7 +251,10 @@ class TimeLoop(
         elif isinstance(base_stepper_config, NudgingConfig):
             self._log_info(f"Using NudgingStepper for step {step}")
             stepper = PureNudger(
-                self._fv3gfs, base_stepper_config, self._get_communicator(), hydrostatic
+                self._wrapper,
+                base_stepper_config,
+                self._get_communicator(),
+                hydrostatic,
             )
         else:
             self._log_info(
@@ -323,7 +326,7 @@ class TimeLoop(
                 namelist,
                 self._timestep,
                 self._state["initialization_time"].item(),
-                self._fv3gfs.get_tracer_metadata(),
+                self._wrapper.get_tracer_metadata(),
                 radiation_input_generator,
             )
         else:
@@ -368,13 +371,13 @@ class TimeLoop(
 
     def _step_dynamics(self) -> Diagnostics:
         self._log_debug(f"Dynamics Step")
-        self._fv3gfs.step_dynamics()
+        self._wrapper.step_dynamics()
         # no diagnostics are computed by default
         return {}
 
     def _step_pre_radiation_physics(self) -> Diagnostics:
         self._log_debug(f"Pre-radiation Physics Step")
-        self._fv3gfs.step_pre_radiation()
+        self._wrapper.step_pre_radiation()
         return {
             f"{name}_pre_radiation": self._state[name]
             for name in self._states_to_output
@@ -386,24 +389,24 @@ class TimeLoop(
             _, diagnostics, _ = self._radiation_stepper(self.time, self._state,)
         else:
             diagnostics = {}
-        self._fv3gfs.step_radiation()
+        self._wrapper.step_radiation()
         return diagnostics
 
     def _step_post_radiation_physics(self) -> Diagnostics:
         self._log_debug(f"Post-radiation Physics Step")
-        self._fv3gfs.step_post_radiation_physics()
+        self._wrapper.step_post_radiation_physics()
         return {}
 
     @property
     def _water_species(self) -> List[str]:
-        a = self._fv3gfs.get_tracer_metadata()
+        a = self._wrapper.get_tracer_metadata()
         return [name for name in a if a[name]["is_water"]]
 
     def _apply_physics(self) -> Diagnostics:
         self._log_debug(f"Physics Step (apply)")
-        self._fv3gfs.apply_physics()
+        self._wrapper.apply_physics()
 
-        micro = self._fv3gfs.get_diagnostic_by_name(
+        micro = self._wrapper.get_diagnostic_by_name(
             "tendency_of_specific_humidity_due_to_microphysics"
         ).data_array
         delp = self._state[DELP]
@@ -412,7 +415,7 @@ class TimeLoop(
                 micro, delp, "z"
             ),
             "evaporation": self._state["evaporation"],
-            "cnvprcp_after_physics": self._fv3gfs.get_diagnostic_by_name(
+            "cnvprcp_after_physics": self._wrapper.get_diagnostic_by_name(
                 "cnvprcp"
             ).data_array,
             "total_precip_after_physics": self._state[TOTAL_PRECIP],
@@ -474,7 +477,7 @@ class TimeLoop(
             k: v for k, v in self._state_updates.items() if k in PREPHYSICS_OVERRIDES
         }
         _check_surface_flux_overrides_exist(
-            self._fv3gfs.flags.override_surface_radiative_fluxes,
+            self._wrapper.flags.override_surface_radiative_fluxes,
             list(state_updates.keys()),
         )
         self._state_updates = dissoc(self._state_updates, *PREPHYSICS_OVERRIDES)
@@ -530,7 +533,7 @@ class TimeLoop(
                     filled_tendencies,
                     tendencies_filled_frac,
                 ) = prepare_tendencies_for_dynamical_core(
-                    self._fv3gfs, self._tendencies
+                    self._wrapper, self._tendencies
                 )
                 updated_state_from_tendency = add_tendency(
                     self._state, filled_tendencies, dt=self._timestep
@@ -557,7 +560,7 @@ class TimeLoop(
         diagnostics.update(
             {
                 "area": self._state[AREA],
-                "cnvprcp_after_python": self._fv3gfs.get_diagnostic_by_name(
+                "cnvprcp_after_python": self._wrapper.get_diagnostic_by_name(
                     "cnvprcp"
                 ).data_array,
                 TOTAL_PRECIP_RATE: precipitation_rate(
@@ -605,7 +608,7 @@ class TimeLoop(
             diags.update(
                 {
                     "area": self._state[AREA],
-                    "cnvprcp_after_python": self._fv3gfs.get_diagnostic_by_name(
+                    "cnvprcp_after_python": self._wrapper.get_diagnostic_by_name(
                         "cnvprcp"
                     ).data_array,
                     TOTAL_PRECIP_RATE: precipitation_rate(
@@ -620,20 +623,20 @@ class TimeLoop(
 
     def _intermediate_restarts(self) -> Diagnostics:
         self._log_info("Saving intermediate restarts if enabled.")
-        self._fv3gfs.save_intermediate_restart_if_enabled()
+        self._wrapper.save_intermediate_restart_if_enabled()
         return {}
 
     def __iter__(
         self,
     ) -> Iterator[Tuple[cftime.DatetimeJulian, Dict[str, xr.DataArray]]]:
 
-        for i in range(self._fv3gfs.get_step_count()):
+        for i in range(self._wrapper.get_step_count()):
             diagnostics: Diagnostics = {}
             # clear the state updates in case some updates are on intervals
             self._state_updates = {}
             for substep in [
                 lambda: runtime.diagnostics.tracers.compute_column_integrated_tracers(
-                    self._fv3gfs, self._state
+                    self._wrapper, self._state
                 ),
                 self._increment_reservoir,
                 self.monitor("dynamics", self._step_dynamics),

--- a/workflows/prognostic_c48_run/runtime/main.py
+++ b/workflows/prognostic_c48_run/runtime/main.py
@@ -23,7 +23,7 @@ logging.getLogger("fsspec").setLevel(logging.WARN)
 logging.getLogger("urllib3").setLevel(logging.WARN)
 
 # Fortran logs are output as python DEBUG level
-runtime.capture_fv3gfs_funcs()
+runtime.capture_fv3gfs_funcs(wrapper)
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def main():
     for name in [STATISTICS_LOG_NAME, PROFILES_LOG_NAME]:
         runtime.setup_file_logger(name)
 
-    loop = TimeLoop(config, comm=comm)
+    loop = TimeLoop(config, wrapper, comm=comm)
 
     diag_files = runtime.get_diagnostic_files(
         config.diagnostics, partitioner, comm, initial_time=loop.time

--- a/workflows/prognostic_c48_run/runtime/steppers/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/nudging.py
@@ -1,7 +1,7 @@
 import functools
 
 import pace.util
-from typing import Any
+from typing import Any, Mapping
 from runtime.nudging import (
     NudgingConfig,
     get_nudging_tendency,
@@ -19,7 +19,7 @@ class PureNudger:
 
     def __init__(
         self,
-        wrapper: Any,
+        tracer_metadata: Mapping[str, Mapping[str, Any]],
         config: NudgingConfig,
         communicator: pace.util.CubedSphereCommunicator,
         hydrostatic: bool,
@@ -35,7 +35,7 @@ class PureNudger:
         self._get_reference_state = setup_get_reference_state(
             config,
             variables_to_nudge + [SST, TSFC, MASK],
-            wrapper.get_tracer_metadata(),
+            tracer_metadata,
             communicator,
         )
 

--- a/workflows/prognostic_c48_run/runtime/steppers/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/nudging.py
@@ -1,7 +1,7 @@
 import functools
 
 import pace.util
-import fv3gfs.wrapper
+from typing import Any
 from runtime.nudging import (
     NudgingConfig,
     get_nudging_tendency,
@@ -19,6 +19,7 @@ class PureNudger:
 
     def __init__(
         self,
+        wrapper: Any,
         config: NudgingConfig,
         communicator: pace.util.CubedSphereCommunicator,
         hydrostatic: bool,
@@ -34,7 +35,7 @@ class PureNudger:
         self._get_reference_state = setup_get_reference_state(
             config,
             variables_to_nudge + [SST, TSFC, MASK],
-            fv3gfs.wrapper.get_tracer_metadata(),
+            wrapper.get_tracer_metadata(),
             communicator,
         )
 

--- a/workflows/prognostic_c48_run/tests/test_derived_state.py
+++ b/workflows/prognostic_c48_run/tests/test_derived_state.py
@@ -8,9 +8,31 @@ import xarray as xr
 from runtime.derived_state import DerivedFV3State, FV3StateMapper, MergedState
 
 
+class MockProperties:
+    def __init__(self):
+        self.DYNAMICS_PROPERTIES = []
+        self.PHYSICS_PROPERTIES = [
+            {
+                "name": "latitude",
+                "fortran_name": "xlat",
+                "units": "radians",
+                "container": "Grid",
+                "dims": ["y", "x"],
+            },
+            {
+                "name": "longitude",
+                "fortran_name": "xlon",
+                "units": "radians",
+                "container": "Grid",
+                "dims": ["y", "x"],
+            },
+        ]
+
+
 class MockFV3GFS:
     def __init__(self):
         self.set_state_called = False
+        self._properties = MockProperties()
         np.random.seed(0)
 
         nx, ny = 10, 10

--- a/workflows/prognostic_c48_run/tests/test_derived_state.py
+++ b/workflows/prognostic_c48_run/tests/test_derived_state.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any, Mapping
 import cftime
 import pace.util
 import numpy as np
@@ -6,6 +7,10 @@ import pytest
 import xarray as xr
 
 from runtime.derived_state import DerivedFV3State, FV3StateMapper, MergedState
+
+
+# Empty placeholder metadata for testing
+TRACER_METADATA: Mapping[str, Mapping[str, Any]] = {}
 
 
 class MockProperties:
@@ -71,9 +76,6 @@ class MockFV3GFS:
     def get_diagnostic_by_name(self, diagnostic):
         return self.get_state([diagnostic])[diagnostic]
 
-    def get_tracer_metadata(self):
-        return []
-
 
 class Getters(Enum):
     original = 1
@@ -83,7 +85,7 @@ class Getters(Enum):
 @pytest.fixture(params=Getters)
 def getter(request):
     fv3gfs = MockFV3GFS()
-    state = DerivedFV3State(fv3gfs)
+    state = DerivedFV3State(fv3gfs, TRACER_METADATA)
     if request.param == Getters.original:
         return state
     elif request.param == Getters.merged:
@@ -127,26 +129,28 @@ def test_DerivedFV3State_setitem(getter):
 
 def test_FV3StateMapper():
     fv3gfs = MockFV3GFS()
-    mapper = FV3StateMapper(fv3gfs)
+    mapper = FV3StateMapper(fv3gfs, TRACER_METADATA)
     assert isinstance(mapper["latitude"], xr.DataArray)
 
 
 def test_FV3StateMapper_alternate_keys():
     fv3gfs = MockFV3GFS()
-    mapper = FV3StateMapper(fv3gfs, alternate_keys={"lon": "longitude"})
+    mapper = FV3StateMapper(
+        fv3gfs, TRACER_METADATA, alternate_keys={"lon": "longitude"}
+    )
     np.testing.assert_array_almost_equal(mapper["lon"], mapper["longitude"])
 
 
 def test_FV3StateMapper_raises_key_error_on_get():
     fv3gfs = MockFV3GFS()
-    mapper = FV3StateMapper(fv3gfs)
+    mapper = FV3StateMapper(fv3gfs, TRACER_METADATA)
     with pytest.raises(KeyError):
         assert "not in fv3" not in mapper
         mapper["not in fv3"]
 
 
 def test_DerivedFV3State_raises_key_error_on_set():
-    mapper = DerivedFV3State(MockFV3GFS())
+    mapper = DerivedFV3State(MockFV3GFS(), TRACER_METADATA)
     assert "not in fv3" not in mapper
     with pytest.raises(KeyError):
         mapper["not in fv3"] = xr.DataArray(0, attrs=dict(units=""))
@@ -154,7 +158,7 @@ def test_DerivedFV3State_raises_key_error_on_set():
 
 def _get_merged_state():
     fv3gfs = MockFV3GFS()
-    getter = DerivedFV3State(fv3gfs)
+    getter = DerivedFV3State(fv3gfs, TRACER_METADATA)
     python_state = {}
     return getter, python_state, MergedState(getter, python_state)
 

--- a/workflows/prognostic_c48_run/tests/test_tendency.py
+++ b/workflows/prognostic_c48_run/tests/test_tendency.py
@@ -90,9 +90,10 @@ def test_prepare_agrid_wind_tendencies(tendencies, expected_dQu, expected_dQv):
 
 
 def test_transform_agrid_wind_tendencies_mixed_coordinates_error():
+    wrapper = None  # This test does not depend on having a functional wrapper.
     tendencies = {
         EASTWARD_WIND_TENDENCY: xr.DataArray([1.0, np.nan, 2.0], dims=["z"]),
         X_WIND_TENDENCY: xr.DataArray([1.0, np.nan, 3.0], dims=["z"]),
     }
     with pytest.raises(ValueError, match="Simultaneously"):
-        transform_agrid_wind_tendencies(tendencies)
+        transform_agrid_wind_tendencies(wrapper, tendencies)


### PR DESCRIPTION
The code was approximately set up for this already, but this PR cleans up a few loose ends and ensures that we only import the wrapper within `runtime.main.py`.  This refactor will facilitate using a different wrapper, i.e. `shield.wrapper`, with the same time loop infrastructure.  I am splitting this PR out from further changes in that direction, since I think these initial changes should be easy to review and fairly uncontroversial.

Refactored public API:
- `wrapper` is now a required positional argument in the `TimeLoop` constructor.  

Internal changes:
- Rename `TimeLoop._fv3gfs` to `TimeLoop._wrapper` to indicate that it is not necessarily specific to FV3GFS.
- Add a `_tracer_metadata` attribute to the `TimeLoop` class, which gets populated upon initialization.  Since this cannot change throughout the prognostic run, this is safe to do, and prevents us from needing to query the wrapper for this at multiple points in the time loop.

Coverage reports (updated automatically):
