### PR TITLE
Allow reservoir model keys to be string repr of integers

### DIFF
--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -68,15 +68,17 @@ class ReservoirConfig:
     def __post_init__(self):
         # This handles cases in automatic config writing where json/yaml
         # do not allow integer keys
+        _models = {}
         for key, url in self.models.items():
             try:
-                int_key = int(self.models.pop(key))
-                self.models[int_key] = url
+                int_key = int(key)
+                _models[int_key] = url
             except (ValueError) as e:
                 raise ValueError(
                     "Keys in reservoir_corrector.models must be integers "
                     "or string representation of integers."
                 ) from e
+        self.models = _models
 
 
 class _FiniteStateMachine:

--- a/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/reservoir.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
     Sequence,
     Dict,
+    Union,
 )
 
 import fv3fit
@@ -54,7 +55,7 @@ class ReservoirConfig:
             limiter. Defaults to false.
     """
 
-    models: Mapping[int, str]
+    models: Mapping[Union[int, str], str]
     synchronize_steps: int = 1
     reservoir_timestep: str = "3h"  # TODO: Could this be inferred?
     time_average_inputs: bool = False
@@ -63,6 +64,19 @@ class ReservoirConfig:
     rename_mapping: NameDict = dataclasses.field(default_factory=dict)
     hydrostatic: bool = False
     mse_conserving_limiter: bool = False
+
+    def __post_init__(self):
+        # This handles cases in automatic config writing where json/yaml
+        # do not allow integer keys
+        for key, url in self.models.items():
+            try:
+                int_key = int(self.models.pop(key))
+                self.models[int_key] = url
+            except (ValueError) as e:
+                raise ValueError(
+                    "Keys in reservoir_corrector.models must be integers "
+                    "or string representation of integers."
+                ) from e
 
 
 class _FiniteStateMachine:

--- a/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
+++ b/workflows/prognostic_c48_run/tests/test_reservoir_stepper.py
@@ -307,3 +307,8 @@ def test_model_paths_and_rank_index_mismatch_on_load():
         reservoir.get_reservoir_steppers(
             config, 1, datetime(2020, 1, 1), MODEL_TIMESTEP
         )
+
+
+def test_reservoir_config_raises_error_on_invalid_key():
+    with pytest.raises(ValueError):
+        ReservoirConfig({"a": "model"}, 1, reservoir_timestep="10m")


### PR DESCRIPTION
JSON and YAML don't write integer keys. This is an issue when autogenerating configs for prognostic runs where the script fills in the rank models in the resevoir corrector field with integer keys but `json.dump` saves the keys as strings. This PR allows these keys to be string representations of integers, which are converted to integers after the config is loaded.

