### PR TITLE
SST reservoir training validation for sweeps

### DIFF
--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -126,8 +126,8 @@ def open_netcdf_file(path: str) -> xr.Dataset:
 
 
 class _BaseNCLoader(TFDatasetLoader):
-    @abstractmethod
     @property
+    @abstractmethod
     def dim_order(self) -> Optional[Sequence[str]]:
         pass
 

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -188,7 +188,7 @@ class NCFileLoader(_BaseNCLoader):
 
 @register_tfdataset_loader
 @dataclass
-class NCDirLoader(TFDatasetLoader):
+class NCDirLoader(_BaseNCLoader):
     """Loads a folder of netCDF files at given path
 
     Each file must have identical CDL scheme returned by ``ncdump -h``.

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -1,8 +1,10 @@
 import logging
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, Sequence
 
 from pathlib import Path
+import fsspec
 import numpy as np
 import re
 import tensorflow as tf
@@ -116,6 +118,74 @@ def to_tensor(
     return {key: tf.convert_to_tensor(ds[key], dtype=dtype) for key in variable_names}
 
 
+def open_netcdf_file(path: str) -> xr.Dataset:
+    """Open a netcdf from a local/remote path"""
+    with fsspec.open(path) as f:
+        ds = xr.open_dataset(f, engine="h5netcdf")
+        return ds.load()
+
+
+class _BaseNCLoader(TFDatasetLoader):
+    @abstractmethod
+    @property
+    def dim_order(self) -> Optional[Sequence[str]]:
+        pass
+
+    @property
+    def dtype(self):
+        return tf.float32
+
+    def convert(
+        self, ds: xr.Dataset, variables: Sequence[str]
+    ) -> Mapping[str, tf.Tensor]:
+        tensors = {}
+        for key in variables:
+            data_array = self._ensure_consistent_dims(ds[key])
+            tensors[key] = tf.convert_to_tensor(data_array, dtype=self.dtype)
+        return tensors
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TFDatasetLoader":
+        return dacite.from_dict(cls, d, config=dacite.Config(strict=True))
+
+    def _ensure_consistent_dims(self, data_array: xr.DataArray):
+        if self.dim_order:
+            extra_dims_in_data_array = set(data_array.dims) - set(self.dim_order)
+            missing_dims_in_data_array = set(self.dim_order) - set(data_array.dims)
+            if len(extra_dims_in_data_array) > 0:
+                raise ValueError(
+                    f"Extra dimensions {extra_dims_in_data_array} in data that are not "
+                    f"included in configured dimension order {self.dim_order}."
+                    "Make sure these are included in the configuration dim_order."
+                )
+            for missing_dim in missing_dims_in_data_array:
+                data_array = data_array.expand_dims(dim=missing_dim)
+            data_array = data_array.transpose(*self.dim_order)
+        return data_array
+
+
+@register_tfdataset_loader
+@dataclass
+class NCFileLoader(_BaseNCLoader):
+    """
+    Loads a single remote/local netCDF file into a dataset
+    """
+
+    filepath: str = ""
+    dim_order: Optional[Sequence[str]] = None
+
+    def open_tfdataset(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        def convert(x):
+            return self.convert(x, variable_names)
+
+        transform = compose_left(open_netcdf_file, convert)
+        return iterable_to_tfdataset(
+            [self.filepath], transform, varying_first_dim=False
+        ).prefetch(tf.data.AUTOTUNE)
+
+
 @register_tfdataset_loader
 @dataclass
 class NCDirLoader(TFDatasetLoader):
@@ -151,26 +221,14 @@ class NCDirLoader(TFDatasetLoader):
 
     """
 
-    url: str
+    url: str = ""
+    dim_order: Optional[Sequence[str]] = None
     nfiles: Optional[int] = None
     shuffle: bool = True
     seed: int = 0
-    dim_order: Optional[Sequence[str]] = None
     varying_first_dim: bool = False
     sort_files: bool = False
-
-    @property
-    def dtype(self):
-        return tf.float32
-
-    def convert(
-        self, ds: xr.Dataset, variables: Sequence[str]
-    ) -> Mapping[str, tf.Tensor]:
-        tensors = {}
-        for key in variables:
-            data_array = self._ensure_consistent_dims(ds[key])
-            tensors[key] = tf.convert_to_tensor(data_array, dtype=self.dtype)
-        return tensors
+    match: Optional[str] = None
 
     def open_tfdataset(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -187,23 +245,5 @@ class NCDirLoader(TFDatasetLoader):
             cache=local_download_path,
             varying_first_dim=self.varying_first_dim,
             sort_files=self.sort_files,
+            match=self.match,
         )
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "TFDatasetLoader":
-        return dacite.from_dict(cls, d, config=dacite.Config(strict=True))
-
-    def _ensure_consistent_dims(self, data_array: xr.DataArray):
-        if self.dim_order:
-            extra_dims_in_data_array = set(data_array.dims) - set(self.dim_order)
-            missing_dims_in_data_array = set(self.dim_order) - set(data_array.dims)
-            if len(extra_dims_in_data_array) > 0:
-                raise ValueError(
-                    f"Extra dimensions {extra_dims_in_data_array} in data that are not "
-                    f"included in configured dimension order {self.dim_order}."
-                    "Make sure these are included in the configuration dim_order."
-                )
-            for missing_dim in missing_dims_in_data_array:
-                data_array = data_array.expand_dims(dim=missing_dim)
-            data_array = data_array.transpose(*self.dim_order)
-        return data_array

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -135,9 +135,6 @@ class ReservoirDatasetAdapter(Predictor):
     def reset_state(self):
         self.model.reset_state()
 
-    def set_state(self, new_state: np.ndarray):
-        self.model.set_state(new_state)
-
     def get_model_from_subdomain(self, subdomain_index: int) -> ReservoirDatasetAdapter:
         model = self.model.get_model_from_subdomain(subdomain_index)
         return ReservoirDatasetAdapter(
@@ -215,9 +212,6 @@ class HybridReservoirDatasetAdapter(Predictor):
 
     def reset_state(self):
         self.model.reset_state()
-
-    def set_state(self, new_state: np.ndarray):
-        self.model.set_state(new_state)
 
     def get_model_from_subdomain(
         self, subdomain_index: int

--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -58,12 +58,13 @@ class DatasetAdapter:
         self, outputs: Sequence[np.ndarray], output_dims: Sequence[str]
     ) -> xr.Dataset:
 
-        return xr.Dataset(
+        ds = xr.Dataset(
             {
                 var: self._ndarray_to_dataarray(output)
                 for var, output in zip(self.output_variables, outputs)
             }
-        ).transpose(*output_dims)
+        )
+        return ds.transpose(*[dim for dim in output_dims if dim in ds.dims])
 
     def input_dataset_to_arrays(
         self, inputs: xr.Dataset, variables: Iterable[Hashable]
@@ -133,6 +134,9 @@ class ReservoirDatasetAdapter(Predictor):
 
     def reset_state(self):
         self.model.reset_state()
+
+    def set_state(self, new_state: np.ndarray):
+        self.model.set_state(new_state)
 
     def get_model_from_subdomain(self, subdomain_index: int) -> ReservoirDatasetAdapter:
         model = self.model.get_model_from_subdomain(subdomain_index)
@@ -211,6 +215,9 @@ class HybridReservoirDatasetAdapter(Predictor):
 
     def reset_state(self):
         self.model.reset_state()
+
+    def set_state(self, new_state: np.ndarray):
+        self.model.set_state(new_state)
 
     def get_model_from_subdomain(
         self, subdomain_index: int

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -1,6 +1,6 @@
 import dacite
 from dataclasses import dataclass, asdict
-from typing import Sequence, Optional, Set
+from typing import Sequence, Tuple, Optional, Set
 import fsspec
 import yaml
 from .._shared.training_config import Hyperparameters
@@ -8,14 +8,9 @@ from .._shared.training_config import Hyperparameters
 
 @dataclass
 class CubedsphereSubdomainConfig:
-    layout: Sequence[int]
+    layout: Tuple[int, int]
     overlap: int
     rank_dims: Sequence[str]
-
-    def __post_init__(self):
-        self.layout = tuple(self.layout)
-        if len(self.layout) != 2:
-            raise ValueError(f"layout must be a tuple of length 2, got {self.layout}")
 
 
 @dataclass
@@ -111,6 +106,7 @@ class ReservoirTrainingConfig(Hyperparameters):
     square_half_hidden_state: bool = False
     hybrid_variables: Optional[Sequence[str]] = None
     mask_variable: Optional[str] = None
+    validate_sst_only: bool = False
     _METADATA_NAME = "reservoir_training_config.yaml"
 
     def __post_init__(self):

--- a/external/fv3fit/fv3fit/reservoir/config.py
+++ b/external/fv3fit/fv3fit/reservoir/config.py
@@ -1,6 +1,6 @@
 import dacite
 from dataclasses import dataclass, asdict
-from typing import Sequence, Optional, Set, Tuple
+from typing import Sequence, Optional, Set
 import fsspec
 import yaml
 from .._shared.training_config import Hyperparameters
@@ -8,9 +8,14 @@ from .._shared.training_config import Hyperparameters
 
 @dataclass
 class CubedsphereSubdomainConfig:
-    layout: Tuple[int, int]
+    layout: Sequence[int]
     overlap: int
     rank_dims: Sequence[str]
+
+    def __post_init__(self):
+        self.layout = tuple(self.layout)
+        if len(self.layout) != 2:
+            raise ValueError(f"layout must be a tuple of length 2, got {self.layout}")
 
 
 @dataclass

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -129,6 +129,14 @@ class HybridReservoirComputingModel(Predictor):
     def reset_state(self):
         self.reservoir_model.reset_state()
 
+    def set_state(self, state: np.ndarray) -> None:
+        """Set the state of the reservoir model
+
+        Args:
+            state: state array of shape (n_subdomains, state_size)
+        """
+        self.reservoir_model.set_state(state)
+
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         self.reservoir_model.increment_state(prediction_with_overlap)
 
@@ -246,6 +254,14 @@ class ReservoirComputingModel(Predictor):
             self.reservoir.hyperparameters.state_size,
         )
         self.reservoir.reset_state(input_shape)
+
+    def set_state(self, state: np.ndarray) -> None:
+        """Set the state of the reservoir model
+
+        Args:
+            state: state array of shape (n_subdomains, state_size)
+        """
+        self.reservoir.set_state(state)
 
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         # input array is in native x, y, z_feature coordinates

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -129,14 +129,6 @@ class HybridReservoirComputingModel(Predictor):
     def reset_state(self):
         self.reservoir_model.reset_state()
 
-    def set_state(self, state: np.ndarray) -> None:
-        """Set the state of the reservoir model
-
-        Args:
-            state: state array of shape (n_subdomains, state_size)
-        """
-        self.reservoir_model.set_state(state)
-
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         self.reservoir_model.increment_state(prediction_with_overlap)
 
@@ -254,14 +246,6 @@ class ReservoirComputingModel(Predictor):
             self.reservoir.hyperparameters.state_size,
         )
         self.reservoir.reset_state(input_shape)
-
-    def set_state(self, state: np.ndarray) -> None:
-        """Set the state of the reservoir model
-
-        Args:
-            state: state array of shape (n_subdomains, state_size)
-        """
-        self.reservoir.set_state(state)
 
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         # input array is in native x, y, z_feature coordinates

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 import os
 import scipy
-from typing import Optional
+from typing import cast, Optional
 import yaml
 
 from .config import ReservoirHyperparameters
@@ -75,7 +75,9 @@ class Reservoir:
             masked_input = input * self.input_mask_array
         else:
             masked_input = input
-        self.state = np.tanh(masked_input @ self.W_in.T + self.state @ self.W_res.T)
+        self.state: np.ndarray = np.tanh(
+            masked_input @ self.W_in.T + self.state @ self.W_res.T
+        )
 
     def reset_state(self, input_shape: tuple):
         logger.info("Resetting reservoir state.")
@@ -184,7 +186,7 @@ class Reservoir:
 
         try:
             with fsspec.open(os.path.join(path, cls._STATE_NAME), "rb") as f:
-                state = np.load(f)
+                state = cast(np.ndarray, np.load(f))
         except (FileNotFoundError):
             state = None
 

--- a/external/fv3fit/fv3fit/reservoir/reservoir.py
+++ b/external/fv3fit/fv3fit/reservoir/reservoir.py
@@ -92,6 +92,12 @@ class Reservoir:
             raise ValueError("Input shape tuple must describe either a 1D or 2D array.")
         self.state = state_after_reset
 
+    def set_state(self, new_state: np.ndarray):
+        if self.state is not None:
+            if self.state.shape != new_state.shape:
+                raise ValueError("Provided state does not match reservoir state shape")
+        self.state = new_state
+
     def synchronize(self, synchronization_time_series):
         self.reset_state(input_shape=synchronization_time_series[0].shape)
         for input in synchronization_time_series:

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -299,7 +299,8 @@ def train_reservoir_model(
         )
         target_data = process_validation_batch_data_to_dataset(
             data, adapter_model.output_variables
-        ).isel(z=0)
+        ).squeeze()
+
         if "mask_field" in data:
             mask = data["mask_field"]
             mask = mask[0, ..., 0]

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -96,6 +96,7 @@ def _get_input_mask_array(
     mask_variable: str,
     sample_batch: Mapping[str, tf.Tensor],
     rank_divider: RankXYDivider,
+    trim_halo: bool = False,
 ) -> np.ndarray:
     if mask_variable not in sample_batch:
         raise KeyError(
@@ -106,6 +107,11 @@ def _get_input_mask_array(
     mask = mask * np.ones(
         rank_divider._rank_extent_all_features
     )  # broadcast feature dim
+
+    if trim_halo:
+        mask = rank_divider.trim_halo_from_rank_data(mask)
+        rank_divider = rank_divider.get_no_overlap_rank_divider()
+
     mask = rank_divider.get_all_subdomains_with_flat_feature(mask[0])
     if set(np.unique(mask)) != {0, 1}:
         raise ValueError(
@@ -217,6 +223,7 @@ def train_reservoir_model(
                         hyperparameters.mask_variable,
                         batch_data,
                         _hybrid_rank_divider_w_overlap,
+                        trim_halo=True,
                     )
                     hybrid_time_series = hybrid_time_series * hybrid_input_mask_array
                 else:

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -80,6 +80,18 @@ def _get_transformers(
     return TransformerGroup(**transformers)
 
 
+def _expand_mask_zdim(mask: tf.Tensor, z_dim_len: int) -> tf.Tensor:
+    if mask.shape[-1] != z_dim_len and mask.shape[-1] == 1:
+        mask = mask * tf.ones(shape=(*mask.shape[:-1], z_dim_len))
+    else:
+        raise ValueError(
+            f"Mask variable must have trailing dim of 1 or {z_dim_len}",
+            f"but has len {mask.shape[-1]}.",
+        )
+
+    return mask
+
+
 def _get_input_mask_array(
     mask_variable: str,
     sample_batch: Mapping[str, tf.Tensor],
@@ -99,6 +111,7 @@ def _get_input_mask_array(
         raise ValueError(
             f"Mask variable values in field {mask_variable} are not " "all in {0, 1}."
         )
+
     return mask
 
 

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -85,6 +85,7 @@ def log_tile_time_avgs(time_avg_fields: Mapping[Hashable, xr.Dataset]) -> None:
         wandb.log({f"timeseries/{name}": wandb.Image(plot_to_image(fig))})
         plt.close(fig)
 
+
 from fv3fit.reservoir.utils import get_ordered_X
 from fv3fit.reservoir import (
     ReservoirComputingModel,
@@ -378,8 +379,6 @@ def validate_model(
         )
 
     if wandb.run is not None:
-        if metrics["combined_score"] > 15.0:
-            wandb.run.tags = list(wandb.run.tags) + ["blowup"]
 
         log_metrics(metrics)
         log_metric_plots(spatial_metrics)

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -28,6 +28,58 @@ def _run_one_step_predictions(synced_model, inputs, hybrid):
     return predictions
 
 
+def _get_slice(src_len, dst_len):
+    """
+    src_len: length of previous state dimension to be inserted into current state
+    dst_len: length of current state dimension
+    """
+    if src_len == dst_len:
+        sl = slice(None)
+    elif src_len < dst_len:
+        diff = dst_len - src_len
+        overlap = diff // 2
+        sl = slice(overlap, -overlap)
+    else:
+        raise ValueError("src_len must be <= dst_len")
+
+    return sl
+
+
+def _insert_tile_to_overlap(current: xr.DataArray, previous: xr.DataArray):
+    # we can't grab the halos for offline rollouts because there is no prediction
+    # for other tiles.  Instead just grab the original overlap, which is *very*
+    # optimistic for forecasting...
+
+    slices = []
+    try:
+        for src_len, dst_len in zip(previous.shape, current.shape):
+            slices.append(_get_slice(src_len, dst_len))
+    except ValueError:
+        raise ValueError(
+            f"Expected overlap for current state ({current.shape}) to be larger than "
+            f"or equal to overlap for previous predicted state ({previous.shape})."
+        )
+
+    current = current.copy(deep=True)
+    current.values[slices] = previous.values
+    return current
+
+
+def _insert_previous_state(current: xr.Dataset, previous: xr.Dataset):
+    if "z" not in previous.dims:
+        previous = previous.expand_dims(dim="z", axis=-1)
+
+    for key, previous_field in previous.items():
+        current_field = current[key]
+        if current_field.shape != previous_field.shape:
+            updated_field = _insert_tile_to_overlap(current_field, previous_field)
+        else:
+            updated_field = previous_field
+        current[key] = updated_field
+
+    return current
+
+
 def _run_rollout_predictions(synced_model, inputs, hybrid):
 
     # run one steps
@@ -35,7 +87,7 @@ def _run_rollout_predictions(synced_model, inputs, hybrid):
     previous_state = xr.Dataset()
     for i in range(len(inputs.time)):
         current_input = inputs.isel(time=i)
-        current_input = xr.Dataset({**current_input, **previous_state})
+        current_input = _insert_previous_state(current_input, previous_state)
         synced_model.increment_state(current_input)
         current_hybrid = hybrid.isel(time=i) if hybrid else {}
         previous_state = synced_model.predict(current_hybrid)
@@ -322,11 +374,11 @@ def validate_model(
     post_sync_hybrid = (
         hybrid_inputs.isel(time=slice(n_sync_steps, -1)) if hybrid_inputs else None
     )
+    persistence = targets.isel(time=slice(n_sync_steps, -1))
     targets = targets.isel(time=slice(n_sync_steps + 1, None))
 
     # for baseline comparison
-    persistence = post_sync_inputs.copy().isel(z=0)
-    persistence = persistence.assign_coords(time=targets.time)
+    persistence.assign_coords(time=targets.time)
     persistence_errors = (persistence - targets).compute()
 
     def _run_validation_experiment(_step_func, prefix):

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -1,8 +1,12 @@
 import numpy as np
+<<<<<<< HEAD
 from typing import Union, Optional, Sequence
 import xarray as xr
 import tensorflow as tf
 import wandb
+=======
+
+>>>>>>> d8b43153e (Add metric function)
 from toolz import curry
 
 from fv3fit.reservoir.utils import get_ordered_X
@@ -214,7 +218,7 @@ def validate_model(model, inputs, n_sync_steps, targets, mask=None, area=None):
         raise ValueError("Inputs and targets must have the same number of time steps.")
 
     global_mean = _mean(dim=targets.dims, mask=mask, area=area)
-    # temporal_mean = _mean(dim="time", mask=mask, area=area)
+    temporal_mean = _mean(dim="time", mask=mask, area=area)
 
     # synchronize
     model.reset_state()
@@ -234,9 +238,14 @@ def validate_model(model, inputs, n_sync_steps, targets, mask=None, area=None):
     predictions.assign_coords(time=targets.time)
 
     metrics = _calculate_scores(predictions - targets, targets, mean_func=global_mean)
-    wandb.log(metrics)
+    metrics = {f"one_step_{key}": value for key, value in metrics.items()}
 
-    # spatial_metrics = _calculate_scores(predictions - targets, targets, mean_func=temporal_mean) # noqa
+    spatial_metrics = _calculate_scores(
+        predictions - targets, targets, mean_func=temporal_mean
+    )
+    spatial_metrics = {
+        f"one_step_spatial_{key}": value for key, value in spatial_metrics.items()
+    }
 
     # Run rollout
     model.reset_state()
@@ -255,8 +264,21 @@ def validate_model(model, inputs, n_sync_steps, targets, mask=None, area=None):
     predictions = xr.concat(predictions, dim="time")
     predictions.assign_coords(time=targets.time)
 
-    metrics = _calculate_scores(predictions - targets, targets, mean_func=global_mean)
-    wandb.log(metrics)
+    rollout_metrics = _calculate_scores(
+        predictions - targets, targets, mean_func=global_mean
+    )
+    metrics.update({f"rollout_{key}": value for key, value in rollout_metrics.items()})
+    spatial_rollout_metrics = _calculate_scores(
+        predictions - targets, targets, mean_func=temporal_mean
+    )
+    spatial_metrics.update(
+        {
+            f"rollout_spatial_{key}": value
+            for key, value in spatial_rollout_metrics.items()
+        }
+    )
+
+    return metrics, spatial_metrics
 
 
 @curry

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -249,14 +249,12 @@ def validate_model(
     predictions_ds = xr.concat(predictions, dim="time")
     predictions_ds.assign_coords(time=targets.time)
 
-    metrics = _calculate_scores(
-        predictions_ds - targets, targets, mean_func=global_mean
-    )
+    errors = (predictions_ds - targets).compute()
+
+    metrics = _calculate_scores(errors, targets, mean_func=global_mean)
     metrics = {f"one_step_{key}": value for key, value in metrics.items()}
 
-    spatial_metrics = _calculate_scores(
-        predictions_ds - targets, targets, mean_func=temporal_mean
-    )
+    spatial_metrics = _calculate_scores(errors, targets, mean_func=temporal_mean)
     spatial_metrics = {
         f"one_step_spatial_{key}": value for key, value in spatial_metrics.items()
     }
@@ -276,12 +274,11 @@ def validate_model(
     predictions_ds = xr.concat(predictions, dim="time")
     predictions_ds.assign_coords(time=targets.time)
 
-    rollout_metrics = _calculate_scores(
-        predictions_ds - targets, targets, mean_func=global_mean
-    )
+    errors = (predictions_ds - targets).compute()
+    rollout_metrics = _calculate_scores(errors, targets, mean_func=global_mean)
     metrics.update({f"rollout_{key}": value for key, value in rollout_metrics.items()})
     spatial_rollout_metrics = _calculate_scores(
-        predictions_ds - targets, targets, mean_func=temporal_mean
+        errors, targets, mean_func=temporal_mean
     )
     spatial_metrics.update(
         {

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -1,14 +1,65 @@
 import numpy as np
-<<<<<<< HEAD
-from typing import Union, Optional, Sequence
+from typing import Union, Optional, Sequence, Hashable, Mapping
 import xarray as xr
 import tensorflow as tf
 import wandb
-=======
-
->>>>>>> d8b43153e (Add metric function)
+import matplotlib.pyplot as plt
 from toolz import curry
+
 from fv3fit.reservoir.adapters import ReservoirAdapterType
+from fv3fit.tensorboard import plot_to_image
+
+
+def _run_one_step_predictions(synced_model, inputs):
+
+    # run one steps
+    predictions = []
+    for i in range(len(inputs.time)):
+        current_input = inputs.isel(time=i)
+        predictions.append(synced_model.predict(current_input))
+
+    return predictions
+
+
+def _run_rollout_predictions(synced_model, inputs):
+
+    # run one steps
+    predictions = []
+    previous_state = xr.Dataset()
+    for i in range(len(inputs.time)):
+        current_input = inputs.isel(time=i)
+        current_input.update(previous_state)
+        previous_state = synced_model.predict(current_input)
+        predictions.append(previous_state)
+
+    return predictions
+
+
+def log_metrics(metrics: Mapping[Hashable, xr.Dataset]) -> None:
+    for name, metric in metrics.items():
+        for field, value in metric.items():
+            wandb.log({f"{name}/{field}": value.values})
+
+
+def log_metric_plots(plottable_metrics: Mapping[Hashable, xr.Dataset]) -> None:
+    # TODO: I can used rotate in vcm.cubedsphere to rotate if I have tile number
+    # just grab the origin from the tile spec
+    for name, metric in plottable_metrics.items():
+        for field, value in metric.items():
+            fig = plt.figure(dpi=120)
+            value.plot()
+            wandb.log({f"{name}/{field}": wandb.Image(plot_to_image(fig))})
+            plt.close(fig)
+
+
+def log_tile_time_avgs(time_avg_fields: Mapping[Hashable, xr.Dataset]) -> None:
+    for name, field in time_avg_fields.items():
+        fig = plt.figure(dpi=120)
+        ax = plt.gca()
+        for timeseries_source, values in field.items():
+            values.plot(ax=ax, label=timeseries_source)
+        wandb.log({f"timeseries/{name}": wandb.Image(plot_to_image(fig))})
+        plt.close(fig)
 
 from fv3fit.reservoir.utils import get_ordered_X
 from fv3fit.reservoir import (
@@ -227,6 +278,7 @@ def validate_model(
 
     global_mean = _mean(dim=targets.dims, mask=mask, area=area)
     temporal_mean = _mean(dim="time", mask=mask, area=area)
+    spatial_mean = _mean(dim=["x", "y"], mask=mask, area=area)
 
     # synchronize
     model.reset_state()
@@ -240,56 +292,73 @@ def validate_model(
     post_sync_inputs = inputs.isel(time=slice(n_sync_steps, -1))
     targets = targets.isel(time=slice(n_sync_steps + 1, None))
 
-    # run one steps
-    predictions = []
-    for i in range(len(post_sync_inputs.time)):
-        current_input = post_sync_inputs.isel(time=i)
-        model.increment_state(current_input)
-        predictions.append(model.predict(current_input))
-    predictions_ds = xr.concat(predictions, dim="time")
-    predictions_ds.assign_coords(time=targets.time)
+    # for baseline comparison
+    persistence = post_sync_inputs.copy().isel(z=0)
+    persistence = persistence.assign_coords(time=targets.time)
+    persistence_errors = (persistence - targets).compute()
 
-    errors = (predictions_ds - targets).compute()
+    def _run_validation_experiment(_step_func, prefix):
+        model.model.reservoir.set_state(synced_state)
+        predictions = _step_func(model, post_sync_inputs)
+        predictions_ds = xr.concat(predictions, dim="time")
+        predictions_ds.assign_coords(time=targets.time)
 
-    metrics = _calculate_scores(errors, targets, mean_func=global_mean)
-    metrics = {f"one_step_{key}": value for key, value in metrics.items()}
+        errors = (predictions_ds - targets).compute()
 
-    spatial_metrics = _calculate_scores(errors, targets, mean_func=temporal_mean)
-    spatial_metrics = {
-        f"one_step_spatial_{key}": value for key, value in spatial_metrics.items()
-    }
+        metrics = _calculate_scores(errors, persistence_errors, mean_func=global_mean)
+        metrics = {f"{prefix}_{key}": value for key, value in metrics.items()}
 
-    # Run rollout
-    model.model.reservoir.set_state(synced_state)
-
-    predictions = []
-    output_for_auto_regressive = xr.Dataset()
-    for i in range(len(post_sync_inputs.time)):
-        current_input = post_sync_inputs.isel(time=i)
-        current_input.update(output_for_auto_regressive)
-        model.increment_state(current_input)
-        output_for_auto_regressive = model.predict(current_input)
-        predictions.append(output_for_auto_regressive)
-
-    predictions_ds = xr.concat(predictions, dim="time")
-    predictions_ds.assign_coords(time=targets.time)
-
-    errors = (predictions_ds - targets).compute()
-    rollout_metrics = _calculate_scores(errors, targets, mean_func=global_mean)
-    metrics.update({f"rollout_{key}": value for key, value in rollout_metrics.items()})
-    spatial_rollout_metrics = _calculate_scores(
-        errors, targets, mean_func=temporal_mean
-    )
-    spatial_metrics.update(
-        {
-            f"rollout_spatial_{key}": value
-            for key, value in spatial_rollout_metrics.items()
+        spatial_metrics = _calculate_scores(
+            errors, persistence_errors, mean_func=temporal_mean
+        )
+        spatial_metrics = {
+            f"{prefix}_spatial_{key}": value for key, value in spatial_metrics.items()
         }
-    )
+
+        temporal_metrics = _calculate_scores(
+            errors, persistence_errors, mean_func=spatial_mean
+        )
+        temporal_metrics = {
+            f"{prefix}_temporal_{key}": value for key, value in temporal_metrics.items()
+        }
+
+        return metrics, spatial_metrics, temporal_metrics, predictions_ds
+
+    (
+        metrics,
+        spatial_metrics,
+        temporal_metrics,
+        one_step_predictions,
+    ) = _run_validation_experiment(_run_one_step_predictions, "one_step")
+    (
+        _metrics,
+        _spatial_metrics,
+        _temporal_metrics,
+        rollout_predictions,
+    ) = _run_validation_experiment(_run_rollout_predictions, "rollout")
+
+    metrics.update(_metrics)
+    spatial_metrics.update(_spatial_metrics)
+    temporal_metrics.update(_temporal_metrics)
 
     metrics["combined_score"] = metrics["one_step_rmse"] + metrics["rollout_rmse"]
 
-    return metrics, spatial_metrics
+    field_tile_avgs = {}
+    for field, value in one_step_predictions.items():
+        field_tile_avgs[field] = xr.Dataset(
+            {
+                "one_step": spatial_mean(value).compute(),
+                "rollout": spatial_mean(rollout_predictions[field]).compute(),
+                "target": spatial_mean(targets[field]).compute(),
+            }
+        )
+
+    print(field_tile_avgs)
+
+    if wandb.run is not None:
+        log_metrics(metrics)
+        log_metric_plots(spatial_metrics)
+        log_tile_time_avgs(field_tile_avgs)
 
 
 @curry
@@ -303,18 +372,19 @@ def _mean(data, dim, mask=None, area=None):
     return data.mean(dim=dim).compute()
 
 
-def _calculate_scores(errors, target, mean_func):
+def _calculate_scores(errors, baseline_errors, mean_func):
     bias = mean_func(errors)
     mse = mean_func(errors ** 2)
     rmse = np.sqrt(mse)
     mae = mean_func(np.abs(errors))
-    rms = mean_func(target ** 2)
-    skill = 1 - rms / rmse
+    baseline_rmse = np.sqrt(mean_func(baseline_errors ** 2))
+    skill = 1 - rmse / baseline_rmse
 
     return {
         "bias": bias,
         "mse": mse,
         "rmse": rmse,
+        "baseline_rmse": baseline_rmse,
         "mae": mae,
         "skill": skill,
     }

--- a/external/fv3fit/fv3fit/reservoir/validation.py
+++ b/external/fv3fit/fv3fit/reservoir/validation.py
@@ -3,6 +3,7 @@ from typing import Union, Optional, Sequence
 import xarray as xr
 import tensorflow as tf
 import wandb
+from toolz import curry
 
 from fv3fit.reservoir.utils import get_ordered_X
 from fv3fit.reservoir import (
@@ -204,3 +205,83 @@ def log_rmse_scalar_metrics(ds_val, variables):
         pass
 
     wandb.log(log_data)
+
+
+def validate_model(model, inputs, n_sync_steps, targets, mask=None, area=None):
+
+    # want to do the index handling in this function
+    if len(inputs.time) != len(targets.time):
+        raise ValueError("Inputs and targets must have the same number of time steps.")
+
+    global_mean = _mean(dim=targets.dims, mask=mask, area=area)
+    # temporal_mean = _mean(dim="time", mask=mask, area=area)
+
+    # synchronize
+    model.reset_state()
+    for i in range(n_sync_steps):
+        model.increment(inputs.isel(time=i))
+
+    post_sync_inputs = inputs.isel(time=slice(n_sync_steps, -1))
+    targets = targets.isel(time=slice(n_sync_steps + 1, None))
+
+    # run one steps
+    predictions = []
+    for i in range(len(post_sync_inputs.time)):
+        current_input = post_sync_inputs.isel(time=i)
+        model.increment(current_input)
+        predictions.append(model.predict(current_input))
+    predictions = xr.concat(predictions, dim="time")
+    predictions.assign_coords(time=targets.time)
+
+    metrics = _calculate_scores(predictions - targets, targets, mean_func=global_mean)
+    wandb.log(metrics)
+
+    # spatial_metrics = _calculate_scores(predictions - targets, targets, mean_func=temporal_mean) # noqa
+
+    # Run rollout
+    model.reset_state()
+    for i in range(n_sync_steps):
+        model.increment(inputs.isel(time=i))
+
+    predictions = []
+    output_for_auto_regressive = {}
+    for i in range(len(post_sync_inputs.time)):
+        current_input = post_sync_inputs.isel(time=i)
+        current_input.update(output_for_auto_regressive)
+        model.increment(current_input)
+        output_for_auto_regressive = model.predict(current_input)
+        predictions.append(output_for_auto_regressive)
+
+    predictions = xr.concat(predictions, dim="time")
+    predictions.assign_coords(time=targets.time)
+
+    metrics = _calculate_scores(predictions - targets, targets, mean_func=global_mean)
+    wandb.log(metrics)
+
+
+@curry
+def _mean(data, dim, mask=None, area=None):
+    if mask is not None:
+        data = data.where(mask)
+
+    if area is not None:
+        data = data.weighted(area)
+
+    return data.mean(dim=dim)
+
+
+def _calculate_scores(errors, target, mean_func):
+    bias = mean_func(errors)
+    mse = mean_func(errors ** 2)
+    rmse = np.sqrt(mse)
+    mae = mean_func(np.abs(errors))
+    rms = mean_func(target ** 2)
+    skill = 1 - rms / rmse
+
+    return {
+        "bias": bias,
+        "mse": mse,
+        "rmse": rmse,
+        "mae": mae,
+        "skill": skill,
+    }

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -34,7 +34,8 @@ def test_train_reservoir():
         .transpose("time", "x", "y", "z")
     )
     train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(4)])
-    val_tfdataset = tfdataset_from_batches([test_dataset])
+    # val_tfdataset = tfdataset_from_batches([test_dataset])
+    # TODO: validation is currently broken for multiple z-dim inputs
     variables = ["var_in_3d", "var_in_2d"]
 
     subdomain_config = CubedsphereSubdomainConfig(
@@ -59,7 +60,7 @@ def test_train_reservoir():
         n_timesteps_synchronize=5,
         input_noise=0.01,
     )
-    adapter = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)
+    adapter = train_reservoir_model(hyperparameters, train_tfdataset, None)
     model = adapter.model
     model.reset_state()
 

--- a/projects/reservoir/sweep/argo.yaml
+++ b/projects/reservoir/sweep/argo.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: sweep-agent
     container:
-      image: us.gcr.io/vcm-ml/fv3fit:8f708055863cc76bf18ed957484e36ce35678d24
+      image: us.gcr.io/vcm-ml/fv3fit:b901b0b27deedd144eb86e9168e5138d27419a87
       command: ["bash", "-c"]
       args:
         - |

--- a/projects/reservoir/sweep/argo.yaml
+++ b/projects/reservoir/sweep/argo.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: sweep-agent
     container:
-      image: us.gcr.io/vcm-ml/fv3fit:89885867350cb0e9600d053859762fa89b45663a
+      image: us.gcr.io/vcm-ml/fv3fit:8f708055863cc76bf18ed957484e36ce35678d24
       command: ["bash", "-c"]
       args:
         - |

--- a/projects/reservoir/sweep/argo.yaml
+++ b/projects/reservoir/sweep/argo.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: sweep-agent
     container:
-      image: us.gcr.io/vcm-ml/fv3fit:47d09597cd3a88ac98ea47dc93b3da312b0e9748
+      image: us.gcr.io/vcm-ml/fv3fit:89885867350cb0e9600d053859762fa89b45663a
       command: ["bash", "-c"]
       args:
         - |

--- a/projects/reservoir/sweep/argo.yaml
+++ b/projects/reservoir/sweep/argo.yaml
@@ -1,0 +1,59 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: reservoir-sweep-agents-
+spec:
+  entrypoint: sweep-agent
+  arguments:
+    parameters:
+    - name: sweep-id
+    - name: sweep-config
+    - name: training-config
+    - name: training-data-config
+    - name: validation-data-config
+  templates:
+  - name: sweep-agent
+    container:
+      image: us.gcr.io/vcm-ml/fv3fit:47d09597cd3a88ac98ea47dc93b3da312b0e9748
+      command: ["bash", "-c"]
+      args:
+        - |
+          cat <<EOF > sweep-config.yaml
+          {{inputs.parameters.sweep-config}}
+          EOF
+          cat <<EOF > training-config.yaml
+          {{inputs.parameters.training-config}}
+          EOF
+          cat <<EOF > training-data.yaml
+          {{inputs.parameters.training-data-config}}
+          EOF
+          cat <<EOF > validation-data.yaml
+          {{inputs.parameters.validation-data-config}}
+          EOF
+
+          echo "Starting sweep agent"
+          wandb agent {{inputs.parameters.sweep-id}}
+      envFrom:
+        - secretRef:
+            name: wandb-service-token
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 8
+          memory: 12Gi
+    inputs:
+      parameters:
+      - name: sweep-id
+      - name: sweep-config
+      - name: training-config
+      - name: training-data-config
+      - name: validation-data-config
+    tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "med-sim-pool"
+      effect: "NoSchedule"
+
+

--- a/projects/reservoir/sweep/format_for_tile.py
+++ b/projects/reservoir/sweep/format_for_tile.py
@@ -1,0 +1,50 @@
+import argparse
+
+import yaml
+
+
+def get_single_variable(data, keys):
+    value = data
+    for key in keys:
+        value = value[key]
+    return value
+
+
+def set_single_variable(data, keys, new_value):
+    value = data
+    for key in keys[:-1]:
+        value = value[key]
+    value[keys[-1]] = new_value
+
+
+def main(path, tile_number, variables):
+    # Load the YAML file
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+
+    # Loop through the mapping members and format the strings with the tile number
+    for key_path in variables:
+        keys = key_path.split(".")
+        value = get_single_variable(data, keys)
+        new_value = value.format(tile_number)
+        set_single_variable(data, keys, new_value)
+
+    # Print the updated YAML
+    print(yaml.dump(data))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Format YAML file for a specific tile number"
+    )
+    parser.add_argument("yaml_path", type=str, help="Path to the YAML file to format")
+    parser.add_argument(
+        "tile_number", type=int, help="Tile number to format the YAML file for"
+    )
+    parser.add_argument(
+        "variables",
+        nargs="+",
+        help="List of specific variables in the yaml to update with the tile number",
+    )
+    args = parser.parse_args()
+    main(args.yaml_path, args.tile_number, args.variables)

--- a/projects/reservoir/sweep/local-tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/local-tile-train-sweep.yaml
@@ -1,0 +1,25 @@
+entity: ai2cm
+project:  sst-reservoir-tuning
+name: 2023-10-13-tile0-sweep
+command:
+  - ${env}
+  - python3
+  - -m
+  - fv3fit.train
+  - training-config.yaml
+  - local-training.yaml
+  - trained_model
+  - --validation-data-config
+  - local-validation.yaml
+method: random
+metric:
+  goal: minimize
+  name: combined_score/sst
+parameters:
+  subdomain.layout:
+    values:
+      - [1, 1]
+      - [2, 2]
+      - [4, 4]
+  reservoir_hyperparameters.state_size:
+    values: [100, 300, 500, 1000, 3000]

--- a/projects/reservoir/sweep/local-training.yaml
+++ b/projects/reservoir/sweep/local-training.yaml
@@ -1,2 +1,2 @@
-filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_era_mask_sst/test_tile0.nc
+filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_mask_halo_4/test_tile0.nc
 dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/local-training.yaml
+++ b/projects/reservoir/sweep/local-training.yaml
@@ -1,0 +1,2 @@
+filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_era_mask_sst/test_tile0.nc
+dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/local-validation.yaml
+++ b/projects/reservoir/sweep/local-validation.yaml
@@ -1,0 +1,2 @@
+filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_era_mask_sst/val_tile0.nc
+dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/local-validation.yaml
+++ b/projects/reservoir/sweep/local-validation.yaml
@@ -1,2 +1,2 @@
-filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_era_mask_sst/val_tile0.nc
+filepath: /home/andrep/repos/explore/andrep/reservoir/consistent_fv3_mask_halo_4/val_tile0.nc
 dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/submit-sweep.sh
+++ b/projects/reservoir/sweep/submit-sweep.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Define the number of jobs to submit for each tile
+num_jobs=6
+
+sweep_config=tile-train-sweep.yaml
+training_data=training-data.yaml
+validation_data=validation-data.yaml
+
+temp_config=temporary_config_files
+
+# Loop through each tile and submit the specified number of jobs
+for tile in {0..5}; do
+  # Create a temporary directory for the updated configuration files
+  mkdir -p $temp_config
+  python format_for_tile.py $sweep_config $tile name > $temp_config/$sweep_config
+  python format_for_tile.py $training_data $tile filepath > $temp_config/$training_data
+  python format_for_tile.py $validation_data $tile filepath > $temp_config/$validation_data
+
+  cd $temp_config
+  wandb sweep $sweep_config &> sweep.log
+  sweep_id=$(tail -n 1 sweep.log | grep -oP '(?<=wandb agent ).*')
+  echo $sweep_id
+  cd ..
+
+  # Submit the specified number of jobs for the current tile using the updated configuration files
+  for ((i=1; i<=num_jobs; i++)); do
+    argo submit argo.yaml \
+      -p sweep-id="$sweep_id" \
+      -p sweep-config="$(cat $temp_config/$sweep_config)" \
+      -p training-config="$(cat training-config.yaml)" \
+      -p training-data-config="$(cat $temp_config/$training_data)" \
+      -p validation-data-config="$(cat $temp_config/$validation_data)" > /dev/null
+    echo "Submitting job $i for tile $tile"
+  done
+done
+

--- a/projects/reservoir/sweep/tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/tile-train-sweep.yaml
@@ -1,6 +1,6 @@
 entity: ai2cm
 project:  sst-reservoir-tuning
-name: 2023-10-13-tile{}-sweep
+name: 2023-10-17-tile{}-mreadout-sweep
 command:
   - ${env}
   - python3
@@ -19,16 +19,12 @@ parameters:
   reservoir_hyperparameters.state_size:
     values: [100, 300, 500, 1000, 3000, 5000]
   readout_hyperparameters.l2:
-    values: [0, 0.1, 1, 10, 50, 100]
-  n_timesteps_synchronize:
-    values: [25, 50, 100, 200]
+    distribution: log_uniform_values
+    min: 0.0000001
+    max: 100
   subdomain.layout:
     values:
       - [1, 1]
       - [2, 2]
       - [4, 4]
-  input_noise:
-    distribution: log_uniform_values
-    min: 0.000001
-    max: 0.1
 

--- a/projects/reservoir/sweep/tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/tile-train-sweep.yaml
@@ -1,0 +1,34 @@
+entity: ai2cm
+project:  sst-reservoir-tuning
+name: 2023-10-13-tile{}-sweep
+command:
+  - ${env}
+  - python3
+  - -m
+  - fv3fit.train
+  - training-config.yaml
+  - training-data.yaml
+  - trained_model
+  - --validation-data-config
+  - validation-data.yaml
+method: random
+metric:
+  goal: minimize
+  name: combined_score/sst
+parameters:
+  reservoir_hyperparameters.state_size:
+    values: [100, 300, 500, 1000, 3000, 5000]
+  readout_hyperparameters.l2:
+    values: [0, 0.1, 1, 10, 50, 100]
+  n_timesteps_synchronize:
+    values: [25, 50, 100, 200]
+  subdomain.layout:
+    values:
+      - [1, 1]
+      - [2, 2]
+      - [4, 4]
+  input_noise:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.1
+

--- a/projects/reservoir/sweep/tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/tile-train-sweep.yaml
@@ -1,6 +1,6 @@
 entity: ai2cm
 project:  sst-reservoir-tuning
-name: 2023-10-18-tile{}-mreadout-sweep-v2
+name: 2023-10-18-tile{}-halo4-sweep
 command:
   - ${env}
   - python3

--- a/projects/reservoir/sweep/tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/tile-train-sweep.yaml
@@ -1,6 +1,6 @@
 entity: ai2cm
 project:  sst-reservoir-tuning
-name: 2023-10-17-tile{}-mreadout-sweep
+name: 2023-10-18-tile{}-mreadout-sweep-v2
 command:
   - ${env}
   - python3
@@ -20,7 +20,7 @@ parameters:
     values: [100, 300, 500, 1000, 3000, 5000]
   readout_hyperparameters.l2:
     distribution: log_uniform_values
-    min: 0.0000001
+    min: 0.0001
     max: 100
   subdomain.layout:
     values:

--- a/projects/reservoir/sweep/tile-train-sweep.yaml
+++ b/projects/reservoir/sweep/tile-train-sweep.yaml
@@ -1,6 +1,6 @@
 entity: ai2cm
 project:  sst-reservoir-tuning
-name: 2023-10-18-tile{}-halo4-sweep
+name: 2023-10-22-tile{}-halo4-sparsity-sweep
 command:
   - ${env}
   - python3
@@ -16,15 +16,20 @@ metric:
   goal: minimize
   name: combined_score/sst
 parameters:
-  reservoir_hyperparameters.state_size:
-    values: [100, 300, 500, 1000, 3000, 5000]
-  readout_hyperparameters.l2:
+  reservoir_hyperparameters.adjacency_matrix_sparsity:
+    distribution: inv_log_uniform_values
+    min: 0.5
+    max: 0.99999
+  reservoir_hyperparameters.spectral_radius:
+    distribution: uniform
+    min: 0.5
+    max: 1.2
+  reservoir_hyperparameters.input_coupling_sparsity:
     distribution: log_uniform_values
-    min: 0.0001
-    max: 100
-  subdomain.layout:
-    values:
-      - [1, 1]
-      - [2, 2]
-      - [4, 4]
+    min: 0.00000001
+    max: 0.3
+  reservoir_hyperparameters.input_coupling_scaling:
+    distribution: uniform
+    min: 0
+    max: 0.5
 

--- a/projects/reservoir/sweep/training-config.yaml
+++ b/projects/reservoir/sweep/training-config.yaml
@@ -12,20 +12,20 @@ hyperparameters:
   output_variables:
     - sst
   subdomain:
-    layout: [1,1]
+    layout: [4,4]
     overlap: 4
     rank_dims:
       - x
       - y
   reservoir_hyperparameters:
-    state_size: 3000
+    state_size: 1000
     adjacency_matrix_sparsity: 0.999
     spectral_radius: 0.99
     seed: 0
     input_coupling_sparsity: 0
     input_coupling_scaling: 0.1
   readout_hyperparameters:
-    l2: 30
+    l2: 10
   n_timesteps_synchronize: 50
   input_noise: 0.001
   square_half_hidden_state: False

--- a/projects/reservoir/sweep/training-config.yaml
+++ b/projects/reservoir/sweep/training-config.yaml
@@ -26,6 +26,7 @@ hyperparameters:
     input_coupling_scaling: 0.1
   readout_hyperparameters:
     l2: 30
-  n_timesteps_synchronize: 10
+  n_timesteps_synchronize: 50
   input_noise: 0.001
   square_half_hidden_state: False
+  validate_sst_only: True

--- a/projects/reservoir/sweep/training-config.yaml
+++ b/projects/reservoir/sweep/training-config.yaml
@@ -13,7 +13,7 @@ hyperparameters:
     - sst
   subdomain:
     layout: [1,1]
-    overlap: 0
+    overlap: 4
     rank_dims:
       - x
       - y

--- a/projects/reservoir/sweep/training-config.yaml
+++ b/projects/reservoir/sweep/training-config.yaml
@@ -1,0 +1,31 @@
+model_type: reservoir
+hyperparameters:
+  n_jobs: 1
+  seed: 0
+  mask_variable: mask_field
+  hybrid_variables:
+    - t2m_at_next_timestep
+    - u10_at_next_timestep
+    - v10_at_next_timestep
+  input_variables:
+    - sst
+  output_variables:
+    - sst
+  subdomain:
+    layout: [1,1]
+    overlap: 0
+    rank_dims:
+      - x
+      - y
+  reservoir_hyperparameters:
+    state_size: 3000
+    adjacency_matrix_sparsity: 0.999
+    spectral_radius: 0.99
+    seed: 0
+    input_coupling_sparsity: 0
+    input_coupling_scaling: 0.1
+  readout_hyperparameters:
+    l2: 30
+  n_timesteps_synchronize: 10
+  input_noise: 0.001
+  square_half_hidden_state: False

--- a/projects/reservoir/sweep/training-data.yaml
+++ b/projects/reservoir/sweep/training-data.yaml
@@ -1,2 +1,2 @@
-filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/train/train_tile{}.nc
+filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/halo4/train/train_tile{}.nc
 dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/training-data.yaml
+++ b/projects/reservoir/sweep/training-data.yaml
@@ -1,0 +1,2 @@
+filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/train/train_tile{}.nc
+dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/validation-data.yaml
+++ b/projects/reservoir/sweep/validation-data.yaml
@@ -1,0 +1,2 @@
+filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/test/test_tile{}.nc
+dim_order: ["time", "x", "y"]

--- a/projects/reservoir/sweep/validation-data.yaml
+++ b/projects/reservoir/sweep/validation-data.yaml
@@ -1,2 +1,2 @@
-filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/test/test_tile{}.nc
+filepath: gs://vcm-ml-scratch/andrep/reservoir/fv3_land/halo4/test/test_tile{}.nc
 dim_order: ["time", "x", "y"]


### PR DESCRIPTION
This PR adds a secondary style of validation specific to the SST reservoirs to the reservoir training.  It borrows from Paula's validation style but implements it to be compatible with wandb sweeps.  Currently, it is set to track the one-step and rollout RMSE (added together) as the primary metric to minimizae.  Other outputs include spatial measures of bias, MAE, RMSE, MSE, and skill compared against one-step persistence for both one-step and rollouts.

TODO: 
- [ ] add a link to an example wandb sweep
- [ ] Describe new single-file NetCDF to tf dataset loader
- [ ] New method for setting state (instead of just being able to load a saved state on init)
- [ ] Adds overlap trimming for hybrid mask (in case of reservoir inputs w/ overlap)
- [ ] Describe Sweep configuration and usage


Coverage reports (updated automatically):
