### PR TITLE
`IntervalStepper.n_calls` option 

### DIFF
--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -274,6 +274,7 @@ class TimeLoop(
                 stepper=stepper,
                 offset_seconds=stepper_config.offset_seconds,
                 record_fields_before_update=stepper_config.record_fields_before_update,
+                n_calls=stepper_config.n_calls,
             )
         else:
             return stepper

--- a/workflows/prognostic_c48_run/runtime/steppers/interval.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/interval.py
@@ -21,6 +21,7 @@ class IntervalConfig:
     apply_interval_seconds: int
     offset_seconds: int = 0
     record_fields_before_update: Optional[List[str]] = None
+    n_calls: Optional[int] = None
 
 
 class IntervalStepper:

--- a/workflows/prognostic_c48_run/runtime/steppers/interval.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/interval.py
@@ -17,6 +17,18 @@ logger = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class IntervalConfig:
+    """Configuration for interval steppers
+
+    base_config: config for the stepper used at the end of the interval
+    apply_interval_seconds: interval in seconds
+    offset_seconds: offset from the start of the run in seconds to count
+        as start of intervals
+    record_fields_before_update: fields listed here will have their values
+        immediately before the stepper update recorded in diagnostics
+    n_calls: if provided, stop after this many calls to the stepper
+        useful for synchronizing reservoir models at the start of runs
+    """
+
     base_config: Union[PrescriberConfig, MachineLearningConfig, NudgingConfig]
     apply_interval_seconds: int
     offset_seconds: int = 0


### PR DESCRIPTION
This adds the optional config arg n_calls to the IntervalStepper class. It can be used to prescribe the first N reservoir timesteps to a reference dataset during synchronization, after which the interval stepper will not be used to set the state.

It is up to the user to properly configure the interval stepper `n_calls` to be the same value as the synchronization steps for the reservoir. 
