### PR TITLE
Add Dockerfile for `prognostic_run_shield` image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
         enum:
           - prognostic_run
           - prognostic_run_gpu
+          - prognostic_run_shield
           - post_process_run
           - fv3net
           - fv3fit
@@ -312,6 +313,7 @@ workflows:
               image:
                 - prognostic_run
                 - prognostic_run_gpu
+                - prognostic_run_shield
                 - post_process_run
                 - fv3net
                 - artifacts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/fv3gfs-fortran"]
 	path = external/fv3gfs-fortran
 	url = https://github.com/ai2cm/fv3gfs-fortran.git
+[submodule "external/SHiELD-wrapper"]
+	path = external/SHiELD-wrapper
+	url = https://github.com/ai2cm/SHiELD-wrapper.git

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 PROGNOSTIC_RUN_WORKDIR ?= /fv3net/workflows/prognostic_c48_run
 
-IMAGES = fv3net post_process_run prognostic_run
+IMAGES = fv3net post_process_run prognostic_run prognostic_run_shield
 
 .PHONY: build_images push_image run_integration_tests image_name_explicit
 ############################################################
@@ -82,6 +82,9 @@ endif
 		--target prognostic-run \
 		--build-arg BASE_IMAGE=$(REGISTRY)/prognostic_run_base_gpu:$(PROGNOSTIC_BASE_VERSION) .
 
+# Use the identical Python requirements to the FV3GFS prognostic run
+build_image_prognostic_run_shield: docker/prognostic_run/requirements.txt
+
 build_image_dataflow: ARGS = --build-arg BEAM_VERSION=$(BEAM_VERSION)
 
 image_test_dataflow: push_image_dataflow
@@ -102,6 +105,12 @@ image_test_prognostic_run: image_test_emulation
 		--rm \
 		-w /fv3net/workflows/prognostic_c48_run \
 		$(REGISTRY)/prognostic_run:$(VERSION) pytest
+
+image_test_prognostic_run_shield:
+	tools/docker-run \
+		--rm \
+		-w /fv3net/workflows/prognostic_c48_run \
+		$(REGISTRY)/prognostic_run_shield:$(VERSION) pytest -vv
 
 image_test_%:
 	echo "No tests specified"
@@ -231,7 +240,9 @@ clean:
 update_submodules:
 	git submodule sync --recursive
 	git submodule update --init \
-		external/fv3gfs-fortran \
+		external/fv3gfs-fortran
+	git submodule update --init --recursive \
+		external/SHiELD-wrapper
 
 
 ############################################################

--- a/docker/prognostic_run_shield/Dockerfile
+++ b/docker/prognostic_run_shield/Dockerfile
@@ -1,0 +1,131 @@
+# Use identical base image (20.04) to what we use in the fv3net prognostic run:
+FROM ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
+
+ENV FV3NET_DIR=/fv3net
+ENV FV3NET_SCRIPTS=${FV3NET_DIR}/.environment-scripts
+
+# Install and use GNU version 10 compiliers instead of the default version 9,
+# since the latest version of FMS fails to build with GNU version 9
+# compilers.
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -y install \
+    cmake \
+    gcc-10 \
+    gfortran-10 \
+    g++-10 \
+    git \
+    libmpich-dev \
+    libnetcdf-dev \
+    libnetcdff-dev \
+    m4 \
+    make \
+    mpich \
+    pkg-config \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools
+
+# GNU version 9 compilers are unavoidably installed by default; using
+# update-alternatives ensures that gcc, gfortran, and g++ point to GNU version
+# 10 compilers, including within MPI-wrapped compilers.
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1
+RUN update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-10 1
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
+
+# Install google-cloud-sdk and a few other packages based on the original
+# prognostic run image.
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl gettext && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&\
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get install -y google-cloud-sdk jq python3-dev python3-pip kubectl gfortran graphviz
+
+ENV SHiELD_FC=mpif90
+ENV SHiELD_CC=mpicc
+ENV SHiELD_CXX=mpicxx
+ENV SHiELD_LD=mpif90
+ENV SHiELD_AVX_LEVEL=-mavx
+
+ENV SUBMODULE_DIR=/SHiELD
+COPY external/SHiELD-wrapper/submodules ${SUBMODULE_DIR}/
+
+# Build FMS, NCEPlibs, and SHiELD using SHiELD_build with position independent
+# code.  FMS_CPPDEFS is needed to address
+# https://github.com/NOAA-GFDL/FMS/issues/426
+RUN cd ${SUBMODULE_DIR}/SHiELD_build/Build && \
+    FMS_CPPDEFS="-DHAVE_GETTID" \
+    FC=${SHiELD_FC} \
+    CC=${SHiELD_CC} \
+    CXX=${SHiELD_CXX} \
+    LD=${SHiELD_LD} \
+    TEMPLATE=site/gnu.mk \
+    AVX_LEVEL=${SHiELD_AVX_LEVEL} \
+    ./COMPILE shield repro 64bit gnu pic
+
+# Install the Python requirements for the prognostic run.
+COPY docker/prognostic_run/requirements.txt ${FV3NET_DIR}/docker/prognostic_run/requirements.txt
+RUN CC=${SHiELD_CC} \
+    MPICC=${SHiELD_CC} \
+    pip install --no-cache-dir -r ${FV3NET_DIR}/docker/prognostic_run/requirements.txt
+
+# Prescribe LDSHARED as well to ensure that the wrapper is built with the GNU 10
+# compilers.  See https://github.com/ai2cm/fv3gfs-fortran/issues/330 for more
+# comprehensive discussion.  This may not be absolutely necessary (we do not
+# worry about this for the FV3GFS prognostic run), but it feels cleaner not to
+# mix compilers if we can avoid it.
+COPY external/SHiELD-wrapper/wrapper ${FV3NET_DIR}/external/SHiELD-wrapper/wrapper
+RUN make -C ${FV3NET_DIR}/external/SHiELD-wrapper/wrapper \
+    FC=${SHiELD_FC} \
+    CC=${SHiELD_CC} \
+    CXX=${SHiELD_CXX} \
+    LD=${SHiELD_LD} \
+    LDSHARED="${SHiELD_CC} -shared" \
+    AVX_LEVEL=${SHiELD_AVX_LEVEL} \
+    PIC=Y \
+    OPENMP=Y \
+    AVX=Y \
+    REPRO=Y \
+    build install
+RUN python3 -c "import shield.wrapper"
+
+# Install the fv3net packages.  Do this last, because these packages change the most
+# frequently during our development.  This allows us to get the most out of caching
+# the prior build steps.
+COPY .environment-scripts/install_fv3net_packages.sh ${FV3NET_SCRIPTS}/
+COPY external/vcm ${FV3NET_DIR}/external/vcm
+COPY external/artifacts ${FV3NET_DIR}/external/artifacts
+COPY external/loaders ${FV3NET_DIR}/external/loaders
+COPY external/fv3fit ${FV3NET_DIR}/external/fv3fit
+COPY external/fv3kube ${FV3NET_DIR}/external/fv3kube
+COPY workflows/post_process_run ${FV3NET_DIR}/workflows/post_process_run
+COPY workflows/prognostic_c48_run/ ${FV3NET_DIR}/workflows/prognostic_c48_run
+COPY external/emulation ${FV3NET_DIR}/external/emulation
+COPY external/radiation ${FV3NET_DIR}/external/radiation
+RUN bash ${FV3NET_SCRIPTS}/install_fv3net_packages.sh \
+    ${FV3NET_DIR}/external/vcm \
+    ${FV3NET_DIR}/external/artifacts \
+    ${FV3NET_DIR}/external/loaders \
+    ${FV3NET_DIR}/external/fv3fit \
+    ${FV3NET_DIR}/external/fv3kube \
+    ${FV3NET_DIR}/workflows/post_process_run \
+    ${FV3NET_DIR}/workflows/prognostic_c48_run \
+    ${FV3NET_DIR}/external/emulation \
+    ${FV3NET_DIR}/external/radiation
+
+RUN echo "ulimit -s unlimited" >> /etc/bash.bashrc && \
+    mkdir /outdir && \
+    chmod -R 777 /outdir
+
+# these are needed for "click" to work
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# Override microphysics emulation
+ENV VAR_META_PATH=${FV3NET_DIR}/external/emulation/microphysics_parameter_metadata.yaml
+ENV OUTPUT_FREQ_SEC=18000
+
+# Add fv3net packages to the PYTHONPATH
+ENV PYTHONPATH=${FV3NET_DIR}/workflows/prognostic_c48_run:${FV3NET_DIR}/external/fv3fit:${FV3NET_DIR}/external/emulation:${FV3NET_DIR}/external/vcm:${FV3NET_DIR}/external/artifacts:${FV3NET_DIR}/external/loaders:${FV3NET_DIR}/external/fv3kube:${FV3NET_DIR}/workflows/post_process_run:${FV3NET_DIR}/external/radiation:${PYTHONPATH}
+
+WORKDIR ${FV3NET_DIR}/workflows/prognostic_c48_run
+CMD ["bash"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ norecursedirs =
     workflows/prognostic_c48_run
     workflows/post_process_run
     tests/scream_run_integration
+    external/SHiELD-wrapper
 
 markers =
     regression: marks regression tests (deselect with '-m "not regression"')

--- a/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
+++ b/workflows/prognostic_c48_run/tests/segmented_run/test_append.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import subprocess
+from fv3post.gsutil import authenticate
 from runtime.segmented_run.append import read_last_segment
 from runtime.segmented_run.run import compose_simulation_command, runfile
 from vcm.cloud import get_fs
@@ -26,6 +27,12 @@ def test_read_last_segment_gcs(tmp_path: Path):
     # (https://cloud.google.com/storage/docs/consistency)
     # and also any integrations with fsspec which has several layers of internal
     # caching which can break this.
+
+    # Note that we must ensure that we are authenticated
+    # with gcloud, which can be accomplished by calling the authenticate
+    # function from fv3post.gsutil.
+    authenticate()
+
     id_ = uuid.uuid4().hex
     url = "gs://vcm-ml-scratch/test_data" + "/" + id_
     last_segment = None

--- a/workflows/prognostic_c48_run/tests/test_config.py
+++ b/workflows/prognostic_c48_run/tests/test_config.py
@@ -3,6 +3,7 @@ import pytest
 from runtime.config import get_model_urls, get_wrapper, UserConfig
 from runtime.names import FV3GFS_WRAPPER
 import dataclasses
+from testing_utils import requires_fv3gfs_wrapper
 from types import ModuleType
 
 dummy_prescriber = {"dataset_key": "data_url", "variables": {"a": "a"}}
@@ -42,6 +43,7 @@ def test_get_model_urls(config, model_urls):
     assert set(get_model_urls(validated_config)) == set(model_urls)
 
 
+@requires_fv3gfs_wrapper
 def test_get_wrapper():
     config = UserConfig(wrapper=FV3GFS_WRAPPER)
     wrapper = get_wrapper(config)

--- a/workflows/prognostic_c48_run/tests/test_radiation.py
+++ b/workflows/prognostic_c48_run/tests/test_radiation.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import dataclasses
 import os
+from testing_utils import requires_fv3gfs_wrapper
 
 
 @dataclasses.dataclass
@@ -152,12 +153,14 @@ def get_zarr(rundir, zarrname):
     return xr.open_zarr(zarrpath)
 
 
+@requires_fv3gfs_wrapper
 def test_radiation_diagnostics_output(completed_rundir):
     ds = get_zarr(completed_rundir, "radiation_diagnostics.zarr")
     for diagnostic in RADIATION_DIAGNOSTICS:
         assert diagnostic.python_name in ds.data_vars
 
 
+@requires_fv3gfs_wrapper
 def test_radiation_diagnostics_validate(completed_rundir):
     rtol = 1.0e-7
     python_radiation = get_zarr(completed_rundir, "radiation_diagnostics.zarr")

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -16,6 +16,7 @@ import vcm.testing
 import xarray as xr
 import yaml
 from machine_learning_mocks import get_mock_predictor
+from testing_utils import requires_fv3gfs_wrapper
 
 BASE_FV3CONFIG_CACHE = Path("vcm-fv3config", "data")
 IC_PATH = BASE_FV3CONFIG_CACHE.joinpath(
@@ -628,6 +629,7 @@ def completed_segment(completed_rundir):
     return completed_rundir.join("artifacts").join("20160801.000000")
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_checksum_restarts(completed_segment, regtest):
     """Please do not add more test cases here as this test slows image build time.
     Additional Predictor model types and configurations should be tested against
@@ -637,15 +639,18 @@ def test_fv3run_checksum_restarts(completed_segment, regtest):
     print(fv_core.computehash(), file=regtest)
 
 
+@requires_fv3gfs_wrapper
 @pytest.mark.parametrize("path", [LOG_PATH, STATISTICS_PATH, PROFILES_PATH])
 def test_fv3run_logs_present(completed_segment, path):
     assert completed_segment.join(path).exists()
 
 
+@requires_fv3gfs_wrapper
 def test_chunks_present(completed_segment):
     assert completed_segment.join(CHUNKS_PATH).exists()
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_diagnostic_outputs_check_variables(regtest, completed_rundir):
     """Please do not add more test cases here as this test slows image build time.
     Additional Predictor model types and configurations should be tested against
@@ -658,11 +663,13 @@ def test_fv3run_diagnostic_outputs_check_variables(regtest, completed_rundir):
         print(f"{variable}: " + checksum, file=regtest)
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_diagnostic_outputs_schema(regtest, completed_rundir):
     diagnostics = xr.open_zarr(str(completed_rundir.join("diags.zarr")))
     diagnostics.info(regtest)
 
 
+@requires_fv3gfs_wrapper
 def test_metrics_valid(completed_segment, configuration):
     if configuration == ConfigEnum.nudging:
         pytest.skip()
@@ -680,6 +687,7 @@ def test_metrics_valid(completed_segment, configuration):
 
 
 @pytest.mark.xfail
+@requires_fv3gfs_wrapper
 def test_fv3run_python_mass_conserving(completed_segment, configuration):
     if configuration == ConfigEnum.nudging:
         pytest.skip()
@@ -701,6 +709,7 @@ def test_fv3run_python_mass_conserving(completed_segment, configuration):
         )
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_vertical_profile_statistics(completed_segment, configuration):
     if (
         configuration == ConfigEnum.nudging
@@ -719,6 +728,7 @@ def test_fv3run_vertical_profile_statistics(completed_segment, configuration):
         assert len(profiles["specific_humidity_limiter_active_global_sum"]) == npz
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_emulation_zarr_out(completed_rundir, configuration, regtest):
 
     if configuration != ConfigEnum.microphys_emulation:
@@ -728,6 +738,7 @@ def test_fv3run_emulation_zarr_out(completed_rundir, configuration, regtest):
     emu_state_zarr.info(regtest)
 
 
+@requires_fv3gfs_wrapper
 def test_each_line_of_file_is_json(completed_segment):
     with completed_segment.join("logs.txt").open() as f:
         k = 0
@@ -738,6 +749,7 @@ def test_each_line_of_file_is_json(completed_segment):
     assert some_lines_read
 
 
+@requires_fv3gfs_wrapper
 def test_fv3run_emulation_nc_out(completed_segment, configuration, regtest):
 
     if configuration != ConfigEnum.microphys_emulation:

--- a/workflows/prognostic_c48_run/tests/testing_utils.py
+++ b/workflows/prognostic_c48_run/tests/testing_utils.py
@@ -1,0 +1,216 @@
+# Code in this module was derived from code in xarray.  A copy of xarray's
+# license is below.
+
+# Apache License
+# Version 2.0, January 2004
+# http://www.apache.org/licenses/
+
+# TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+# 1. Definitions.
+
+# "License" shall mean the terms and conditions for use, reproduction, and
+# distribution as defined by Sections 1 through 9 of this document.
+
+# "Licensor" shall mean the copyright owner or entity authorized by the copyright
+# owner that is granting the License.
+
+# "Legal Entity" shall mean the union of the acting entity and all other entities
+# that control, are controlled by, or are under common control with that entity.
+# For the purposes of this definition, "control" means (i) the power, direct or
+# indirect, to cause the direction or management of such entity, whether by
+# contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+# outstanding shares, or (iii) beneficial ownership of such entity.
+
+# "You" (or "Your") shall mean an individual or Legal Entity exercising
+# permissions granted by this License.
+
+# "Source" form shall mean the preferred form for making modifications, including
+# but not limited to software source code, documentation source, and configuration
+# files.
+
+# "Object" form shall mean any form resulting from mechanical transformation or
+# translation of a Source form, including but not limited to compiled object code,
+# generated documentation, and conversions to other media types.
+
+# "Work" shall mean the work of authorship, whether in Source or Object form, made
+# available under the License, as indicated by a copyright notice that is included
+# in or attached to the work (an example is provided in the Appendix below).
+
+# "Derivative Works" shall mean any work, whether in Source or Object form, that
+# is based on (or derived from) the Work and for which the editorial revisions,
+# annotations, elaborations, or other modifications represent, as a whole, an
+# original work of authorship. For the purposes of this License, Derivative Works
+# shall not include works that remain separable from, or merely link (or bind by
+# name) to the interfaces of, the Work and Derivative Works thereof.
+
+# "Contribution" shall mean any work of authorship, including the original version
+# of the Work and any modifications or additions to that Work or Derivative Works
+# thereof, that is intentionally submitted to Licensor for inclusion in the Work
+# by the copyright owner or by an individual or Legal Entity authorized to submit
+# on behalf of the copyright owner. For the purposes of this definition,
+# "submitted" means any form of electronic, verbal, or written communication sent
+# to the Licensor or its representatives, including but not limited to
+# communication on electronic mailing lists, source code control systems, and
+# issue tracking systems that are managed by, or on behalf of, the Licensor for
+# the purpose of discussing and improving the Work, but excluding communication
+# that is conspicuously marked or otherwise designated in writing by the copyright
+# owner as "Not a Contribution."
+
+# "Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+# of whom a Contribution has been received by Licensor and subsequently
+# incorporated within the Work.
+
+# 2. Grant of Copyright License.
+
+# Subject to the terms and conditions of this License, each Contributor hereby
+# grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+# irrevocable copyright license to reproduce, prepare Derivative Works of,
+# publicly display, publicly perform, sublicense, and distribute the Work and such
+# Derivative Works in Source or Object form.
+
+# 3. Grant of Patent License.
+
+# Subject to the terms and conditions of this License, each Contributor hereby
+# grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+# irrevocable (except as stated in this section) patent license to make, have
+# made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+# such license applies only to those patent claims licensable by such Contributor
+# that are necessarily infringed by their Contribution(s) alone or by combination
+# of their Contribution(s) with the Work to which such Contribution(s) was
+# submitted. If You institute patent litigation against any entity (including a
+# cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+# Contribution incorporated within the Work constitutes direct or contributory
+# patent infringement, then any patent licenses granted to You under this License
+# for that Work shall terminate as of the date such litigation is filed.
+
+# 4. Redistribution.
+
+# You may reproduce and distribute copies of the Work or Derivative Works thereof
+# in any medium, with or without modifications, and in Source or Object form,
+# provided that You meet the following conditions:
+
+# You must give any other recipients of the Work or Derivative Works a copy of
+# this License; and
+# You must cause any modified files to carry prominent notices stating that You
+# changed the files; and
+# You must retain, in the Source form of any Derivative Works that You distribute,
+# all copyright, patent, trademark, and attribution notices from the Source form
+# of the Work, excluding those notices that do not pertain to any part of the
+# Derivative Works; and
+# If the Work includes a "NOTICE" text file as part of its distribution, then any
+# Derivative Works that You distribute must include a readable copy of the
+# attribution notices contained within such NOTICE file, excluding those notices
+# that do not pertain to any part of the Derivative Works, in at least one of the
+# following places: within a NOTICE text file distributed as part of the
+# Derivative Works; within the Source form or documentation, if provided along
+# with the Derivative Works; or, within a display generated by the Derivative
+# Works, if and wherever such third-party notices normally appear. The contents of
+# the NOTICE file are for informational purposes only and do not modify the
+# License. You may add Your own attribution notices within Derivative Works that
+# You distribute, alongside or as an addendum to the NOTICE text from the Work,
+# provided that such additional attribution notices cannot be construed as
+# modifying the License.
+# You may add Your own copyright statement to Your modifications and may provide
+# additional or different license terms and conditions for use, reproduction, or
+# distribution of Your modifications, or for any such Derivative Works as a whole,
+# provided Your use, reproduction, and distribution of the Work otherwise complies
+# with the conditions stated in this License.
+
+# 5. Submission of Contributions.
+
+# Unless You explicitly state otherwise, any Contribution intentionally submitted
+# for inclusion in the Work by You to the Licensor shall be under the terms and
+# conditions of this License, without any additional terms or conditions.
+# Notwithstanding the above, nothing herein shall supersede or modify the terms of
+# any separate license agreement you may have executed with Licensor regarding
+# such Contributions.
+
+# 6. Trademarks.
+
+# This License does not grant permission to use the trade names, trademarks,
+# service marks, or product names of the Licensor, except as required for
+# reasonable and customary use in describing the origin of the Work and
+# reproducing the content of the NOTICE file.
+
+# 7. Disclaimer of Warranty.
+
+# Unless required by applicable law or agreed to in writing, Licensor provides the
+# Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+# including, without limitation, any warranties or conditions of TITLE,
+# NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+# solely responsible for determining the appropriateness of using or
+# redistributing the Work and assume any risks associated with Your exercise of
+# permissions under this License.
+
+# 8. Limitation of Liability.
+
+# In no event and under no legal theory, whether in tort (including negligence),
+# contract, or otherwise, unless required by applicable law (such as deliberate
+# and grossly negligent acts) or agreed to in writing, shall any Contributor be
+# liable to You for damages, including any direct, indirect, special, incidental,
+# or consequential damages of any character arising as a result of this License or
+# out of the use or inability to use the Work (including but not limited to
+# damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+# any and all other commercial damages or losses), even if such Contributor has
+# been advised of the possibility of such damages.
+
+# 9. Accepting Warranty or Additional Liability.
+
+# While redistributing the Work or Derivative Works thereof, You may choose to
+# offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+# other liability obligations and/or rights consistent with this License. However,
+# in accepting such obligations, You may act only on Your own behalf and on Your
+# sole responsibility, not on behalf of any other Contributor, and only if You
+# agree to indemnify, defend, and hold each Contributor harmless for any liability
+# incurred by, or claims asserted against, such Contributor by reason of your
+# accepting any such warranty or additional liability.
+
+# END OF TERMS AND CONDITIONS
+
+# APPENDIX: How to apply the Apache License to your work
+
+# To apply the Apache License to your work, attach the following boilerplate
+# notice, with the fields enclosed by brackets "[]" replaced with your own
+# identifying information. (Don't include the brackets!) The text should be
+# enclosed in the appropriate comment syntax for the file format. We also
+# recommend that a file or class name and description of purpose be included on
+# the same "printed page" as the copyright notice for easier identification within
+# third-party archives.
+
+#    Copyright [yyyy] [name of copyright owner]
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import importlib
+import pytest
+
+from packaging.version import Version
+from typing import Optional
+
+
+def _importorskip(modname: str, minversion: Optional[str] = None):
+    """See xarray/tests/__init__.py"""
+    try:
+        mod = importlib.import_module(modname)
+        has = True
+        if minversion is not None:
+            if Version(mod.__version__) < Version(minversion):  # type: ignore
+                raise ImportError("Minimum version not satisfied")
+    except ImportError:
+        has = False
+    func = pytest.mark.skipif(not has, reason=f"requires {modname}")
+    return has, func
+
+
+has_fv3gfs_wrapper, requires_fv3gfs_wrapper = _importorskip("fv3gfs.wrapper")


### PR DESCRIPTION
This PR adds a Dockerfile for building a `prognostic_run_shield` image, analogous to the `prognostic_run` image, but with SHiELD-wrapper instead of fv3gfs-wrapper installed.  There are a few differences from the `prognostic_run` image:

- GNU 10 compilers are used instead of GNU 9, since latest FMS / SHiELD require GNU 10+ compilers to build.
- SHiELD-wrapper (and its dependencies) are installed instead of fv3gfs-wrapper.  In terms of compiled dependencies, this happens under the hood within the `COMPILE` script in the SHiELD_build repo.
- call_py_fort is omitted, since we have not made an effort to port the microphysics-emulation-specific call_py_fort hooks into SHiELD, which are somewhat orthogonal to the Python wrapper.

To make things easier to review, for now I have just skipped any tests that require running prognostic simulations.  A preview of the changes required for doing that with SHiELD-wrapper can be found in #2350 (nothing major within the time loop; most changes are needed to parametrize / configure tests).  In a followup PR I will add the changes needed to actually test `shield.wrapper` simulations in the same way we test `fv3gfs.wrapper`, which will depend on this PR as well as the changes in #2362.

Added public API:
- Added a `prognostic_run_shield` image, which will eventually be used for prognostic runs using SHiELD-wrapper.

Significant internal changes:
- Added logic for skipping specific regression tests if `fv3gfs.wrapper` is not installed in the image.
- Added an `authenticate` call to the `test_read_last_segment_gcs` test such that it can be run without relying on previous regression tests being run before it; thanks @frodre for help debugging this.

Requirement changes:
- Added a SHiELD-wrapper submodule, pointing to latest main.

Coverage reports (updated automatically):
