### PR TITLE
Use encoder/decoder call directly

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/autoencoder.py
@@ -66,10 +66,10 @@ class Autoencoder(tf.keras.Model, Transformer):
 
     def encode(self, x: Sequence[ArrayLike]) -> ArrayLike:
         x = _ensure_all_items_have_sample_dim(x)
-        return self.encoder.predict(x)
+        return self.encoder(x)
 
     def decode(self, latent_x: ArrayLike) -> Sequence[ArrayLike]:
-        return to_list(self.decoder.predict(latent_x))
+        return to_list(self.decoder(latent_x))
 
     def dump(self, path: str) -> None:
         with put_dir(path) as path:

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -122,7 +122,7 @@ def decode_columns(
     leading_shape = encoded_output.shape[:-1]
     encoded_output = encoded_output.reshape(-1, feature_size)
     decoded = transformer.decode(encoded_output)
-    var_arrays = [arr.reshape(*leading_shape, -1) for arr in decoded]
+    var_arrays = [tf.reshape(arr, (*leading_shape, -1)) for arr in decoded]
     return var_arrays
 
 
@@ -138,4 +138,4 @@ def encode_columns(
     original_sample_shape = input_arrs[0].shape[:-1]
     reshaped = [stack_array_preserving_last_dim(var) for var in input_arrs]
     encoded_reshaped = transformer.encode(reshaped)
-    return encoded_reshaped.reshape(*original_sample_shape, -1)
+    return tf.reshape(encoded_reshaped, (*original_sample_shape, -1))

--- a/external/fv3fit/tests/reservoir/test_autoencoder.py
+++ b/external/fv3fit/tests/reservoir/test_autoencoder.py
@@ -25,7 +25,7 @@ def test_decode_single_output_returns_list():
 def test_build_concat_and_scale_only_autoencoder_normalize():
     model = build_concat_and_scale_only_autoencoder(["a", "b"], [a, b])
     np.testing.assert_array_almost_equal(
-        model.encode(test_inputs).reshape(-1), np.array([1, 1, 2, 2])
+        model.encode(test_inputs).numpy().reshape(-1), np.array([1, 1, 2, 2])
     )
 
 


### PR DESCRIPTION
Making a separate PR using @frodre 's commit that greatly speeds up training.
Directly calling the encoder vs `.predict` reduces batch fitting time by >2-10x.