### PR TITLE
Add capability for fv3fit training on Livermore-Computing machines

### DIFF
--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -58,6 +58,11 @@ def get_parser():
         ),
         action="store_true",
     )
+    parser.add_argument(
+        "--Livermore-Computing",
+        help=("This is a run on Livermore Computing HPC such as Quartz or Ruby."),
+        action="store_true",
+    )
     return parser
 
 
@@ -102,7 +107,8 @@ def load_data(
 
 
 def main(args, unknown_args=None):
-
+    if args.Livermore_Computing:
+        wandb.init(mode="disabled")
     with open(args.training_config, "r") as f:
         config_dict = yaml.safe_load(f)
         if unknown_args is not None:
@@ -211,6 +217,6 @@ if __name__ == "__main__":
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     main(args, unknown_args)
-
-    with put_dir(args.output_path) as path:
-        shutil.move("artifacts", os.path.join(path, "artifacts"))
+    if args.Livermore_Computing is False:
+        with put_dir(args.output_path) as path:
+            shutil.move("artifacts", os.path.join(path, "artifacts"))

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -195,17 +195,14 @@ def disable_tensorflow_gpu_preallocation():
         logging.info("%d physical gpus, %d logical gpus", len(gpus), len(logical_gpus))
 
 
-def copy_configs_to_tempdir(tempdir, args):
+def ensure_configs_in_abs_path(args):
     """
-    Copy config files to temporary directory and update args to point to them.
+    We need to change to a temporary directory, ensure config paths are absolute.
     """
-    temp_training_config = shutil.copy(args.training_config, tempdir)
-    args.training_config = temp_training_config
-    temp_training_data_config = shutil.copy(args.training_data_config, tempdir)
-    args.training_data_config = temp_training_data_config
+    args.training_config = os.path.abspath(args.training_config)
+    args.training_data_config = os.path.abspath(args.training_data_config)
     if args.validation_data_config is not None:
-        temp_val_data_config = shutil.copy(args.validation_data_config, tempdir)
-        args.validation_data_config = temp_val_data_config
+        args.validation_data_config = os.path.abspath(args.validation_data_config)
 
 
 if __name__ == "__main__":
@@ -214,7 +211,7 @@ if __name__ == "__main__":
     args, unknown_args = parser.parse_known_args()
     disable_tensorflow_gpu_preallocation()
     with tempfile.TemporaryDirectory() as tempdir:
-        copy_configs_to_tempdir(tempdir, args)
+        ensure_configs_in_abs_path(args)
         os.chdir(tempdir)
         os.makedirs(os.path.join(tempdir, "artifacts"), exist_ok=True)
         logging.basicConfig(

--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -1236,27 +1236,3 @@ sources:
     args:
       urlpath: "gs://vcm-scream/latLonArea/ne30/land_sea_mask_elm.zarr/"
       consolidated: true
-
-  grid/ne30_LC:
-    description: Lat, lon, and area of NE30 data
-    driver: zarr
-    metadata:
-      grid: ne30
-      variables:
-        - area
-        - lat
-        - lon
-    args:
-      urlpath: "/usr/gdata/climdat/eamxx-ml/vcm-scream/latLonArea/ne30/ne30.zarr/"
-      consolidated: true
-
-  landseamask/ne30_LC:
-    description: land_sea_mask of NE30 data
-    driver: zarr
-    metadata:
-      grid: ne30
-      variables:
-        - land_sea_mask
-    args:
-      urlpath: "/usr/gdata/climdat/eamxx-ml/vcm-scream/latLonArea/ne30/land_sea_mask_elm.zarr/"
-      consolidated: true

--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -1236,3 +1236,27 @@ sources:
     args:
       urlpath: "gs://vcm-scream/latLonArea/ne30/land_sea_mask_elm.zarr/"
       consolidated: true
+
+  grid/ne30_LC:
+    description: Lat, lon, and area of NE30 data
+    driver: zarr
+    metadata:
+      grid: ne30
+      variables:
+        - area
+        - lat
+        - lon
+    args:
+      urlpath: "/usr/gdata/climdat/eamxx-ml/vcm-scream/latLonArea/ne30/ne30.zarr/"
+      consolidated: true
+
+  landseamask/ne30_LC:
+    description: land_sea_mask of NE30 data
+    driver: zarr
+    metadata:
+      grid: ne30
+      variables:
+        - land_sea_mask
+    args:
+      urlpath: "/usr/gdata/climdat/eamxx-ml/vcm-scream/latLonArea/ne30/land_sea_mask_elm.zarr/"
+      consolidated: true


### PR DESCRIPTION
For training on HPC systems, we often run into issues with moving artifacts to a different filesystem. To mitigate this, we now use a temporary directory to save the artifacts.

Coverage reports (updated automatically):
