### PR TITLE
Make `prognostic_run_diags` compatible with scream dataset

### DIFF
--- a/external/loaders/loaders/batches/_batch.py
+++ b/external/loaders/loaders/batches/_batch.py
@@ -202,7 +202,7 @@ def batches_from_mapper(
 
     if needs_grid:
         transforms.append(add_grid_info(res, catalog_path))
-        if vcm.gsrm_name_from_resolution_string(res) == "fv3":
+        if vcm.gsrm_name_from_resolution_string(res) == "fv3gfs":
             transforms.append(add_wind_rotation_info(res, catalog_path))
     if data_transforms is not None:
         data_transform = dacite.from_dict(

--- a/external/vcm/tests/test_convenience.py
+++ b/external/vcm/tests/test_convenience.py
@@ -158,7 +158,7 @@ def test_round_time_numpy():
 
 
 @pytest.mark.parametrize(
-    "res, expected", [("c12", "fv3"), ("c48", "fv3"), ("ne30", "scream"),],
+    "res, expected", [("c12", "fv3gfs"), ("c48", "fv3gfs"), ("ne30", "scream"),],
 )
 def test_gsrm_name(res, expected):
     assert gsrm_name_from_resolution_string(res) == expected

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -17,6 +17,7 @@ from .convenience import (
     shift_timestamp,
     round_time,
     gsrm_name_from_resolution_string,
+    check_if_scream_dataset,
 )
 from .calc.calc import local_time, weighted_average, vertical_tapering_scale_factors
 from .calc._zenith_angle import cos_zenith_angle

--- a/external/vcm/vcm/convenience.py
+++ b/external/vcm/vcm/convenience.py
@@ -153,7 +153,7 @@ def gsrm_name_from_resolution_string(res: str):
     if res.startswith("ne"):
         gsrm = "scream"
     elif res.startswith("c"):
-        gsrm = "fv3"
+        gsrm = "fv3gfs"
     else:
         raise ValueError(
             f"This resolution {res} can not be mapped to either scream or fv3."

--- a/external/vcm/vcm/convenience.py
+++ b/external/vcm/vcm/convenience.py
@@ -159,3 +159,10 @@ def gsrm_name_from_resolution_string(res: str):
             f"This resolution {res} can not be mapped to either scream or fv3."
         )
     return gsrm
+
+
+def check_if_scream_dataset(ds: xr.Dataset) -> bool:
+    if "ncol" in ds.sizes:
+        return True
+    else:
+        return False

--- a/external/vcm/vcm/scream/__init__.py
+++ b/external/vcm/vcm/scream/__init__.py
@@ -1,0 +1,1 @@
+from .metadata import standardize_scream_diagnostics

--- a/external/vcm/vcm/scream/metadata.py
+++ b/external/vcm/vcm/scream/metadata.py
@@ -1,0 +1,58 @@
+import xarray as xr
+import logging
+import numpy as np
+from typing import Callable, Sequence
+
+TIME_DIM_NAME = "time"
+
+logger = logging.getLogger(__name__)
+
+
+def _mask_invalid_value(ds: xr.Dataset) -> xr.Dataset:
+    ds = xr.where(ds > 1e30, np.nan, ds)
+    return ds
+
+
+def _set_missing_attrs(ds: xr.Dataset) -> xr.Dataset:
+
+    for var in ds:
+        da = ds[var]
+
+        # True for some prognostic zarrs
+        if "description" in da.attrs and "long_name" not in da.attrs:
+            da.attrs["long_name"] = da.attrs["description"]
+
+        if "long_name" not in da.attrs:
+            da.attrs["long_name"] = var
+
+        if "units" not in da.attrs:
+            da.attrs["units"] = "unspecified"
+    return ds
+
+
+def standardize_scream_diagnostics(
+    ds: xr.Dataset, time: str = TIME_DIM_NAME
+) -> xr.Dataset:
+    """Standardize SCREAM diagnostics to a common format.
+
+    Args:
+        ds (xr.Dataset):
+            Dataset of scream diagnostics outputs,
+            presumably opened from disk via zarr.
+        time (str, optional):
+            Name of the time coordinate dimension in the dataset
+
+    Returns:
+        Data variable attributes ("long_name" and "units") are set.
+        Clean up invalid values that hasn't been fixed upstream.
+    """
+    if time in ds.coords:
+        ds[time].attrs["calendar"] = "julian"
+    funcs: Sequence[Callable[[xr.Dataset], xr.Dataset]] = [
+        xr.decode_cf,
+        _set_missing_attrs,
+        _mask_invalid_value,
+    ]
+    for func in funcs:
+        ds = func(ds)
+    return ds

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -1,6 +1,6 @@
 import xarray as xr
-from typing import Optional, List
-from dataclasses import dataclass, field
+from typing import Optional
+from dataclasses import dataclass
 import numpy as np
 
 HORIZONTAL_DIMS_FV3 = ["x", "y", "tile"]
@@ -29,5 +29,15 @@ class DiagArg:
     verification: xr.Dataset
     grid: xr.Dataset
     delp: Optional[xr.DataArray] = None
-    horizontal_dims: List[str] = field(default_factory=lambda: HORIZONTAL_DIMS_FV3)
+    gsrm: str = "fv3gfs"
     vertical_dim: str = VERTICAL_DIM
+
+    def __post_init__(self):
+        if self.gsrm == "fv3gfs":
+            self.horizontal_dims = HORIZONTAL_DIMS_FV3
+        elif self.gsrm == "scream":
+            self.horizontal_dims = HORIZONTAL_DIMS_SCREAM
+        else:
+            raise ValueError(
+                f"gsrm must be one of {['fv3gfs', 'scream']}, got {self.gsrm}"
+            )

--- a/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/_shared/constants.py
@@ -1,7 +1,8 @@
 import xarray as xr
-from typing import Optional
-from dataclasses import dataclass
+from typing import Optional, List
+from dataclasses import dataclass, field
 import numpy as np
+from vcm import check_if_scream_dataset
 
 HORIZONTAL_DIMS_FV3 = ["x", "y", "tile"]
 HORIZONTAL_DIMS_SCREAM = ["ncol"]
@@ -29,15 +30,9 @@ class DiagArg:
     verification: xr.Dataset
     grid: xr.Dataset
     delp: Optional[xr.DataArray] = None
-    gsrm: str = "fv3gfs"
+    horizontal_dims: List[str] = field(default_factory=lambda: HORIZONTAL_DIMS_FV3)
     vertical_dim: str = VERTICAL_DIM
 
     def __post_init__(self):
-        if self.gsrm == "fv3gfs":
-            self.horizontal_dims = HORIZONTAL_DIMS_FV3
-        elif self.gsrm == "scream":
+        if check_if_scream_dataset(self.grid):
             self.horizontal_dims = HORIZONTAL_DIMS_SCREAM
-        else:
-            raise ValueError(
-                f"gsrm must be one of {['fv3gfs', 'scream']}, got {self.gsrm}"
-            )

--- a/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/_helpers.py
@@ -153,7 +153,7 @@ def insert_rmse(ds: xr.Dataset):
 def load_grid_info(catalog: intake.Catalog, res: str = "c48"):
     if gsrm_name_from_resolution_string(res) == "scream":
         return load_grid_info_scream(catalog, res)
-    elif gsrm_name_from_resolution_string(res) == "fv3":
+    elif gsrm_name_from_resolution_string(res) == "fv3gfs":
         return load_grid_info_fv3(catalog, res)
     else:
         raise ValueError(f"Unknown evaluation grid {res}.")

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute.py
@@ -141,11 +141,7 @@ def _coord_to_var(coord: xr.DataArray, new_var_name: str) -> xr.DataArray:
 
 
 def _compute_diagnostics(
-    ds: xr.Dataset,
-    grid: xr.Dataset,
-    predicted_vars: List[str],
-    n_jobs: int,
-    gsrm: str = "fv3gfs",
+    ds: xr.Dataset, grid: xr.Dataset, predicted_vars: List[str], n_jobs: int,
 ) -> Tuple[xr.Dataset, xr.Dataset]:
     timesteps = []
 
@@ -162,9 +158,7 @@ def _compute_diagnostics(
     target = safe.get_variables(
         ds.sel({DERIVATION_DIM_NAME: TARGET_COORD}), full_predicted_vars
     )
-    ds_summary = compute_diagnostics(
-        prediction, target, grid, ds[DELP], gsrm=gsrm, n_jobs=n_jobs,
-    )
+    ds_summary = compute_diagnostics(prediction, target, grid, ds[DELP], n_jobs=n_jobs,)
 
     timesteps.append(ds["time"])
 
@@ -355,7 +349,6 @@ def main(args):
     ds_diagnostics, ds_scalar_metrics = _compute_diagnostics(
         ds_predicted,
         evaluation_grid,
-        gsrm=gsrm,
         predicted_vars=model.output_variables,
         n_jobs=args.n_jobs,
     )

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -9,7 +9,7 @@ from fv3net.diagnostics._shared.constants import (
 import logging
 import numpy as np
 import pandas as pd
-from typing import Sequence, Tuple, Dict, List
+from typing import Sequence, Tuple, Dict
 import xarray as xr
 
 import vcm
@@ -60,11 +60,11 @@ def compute_diagnostics(
     target: xr.Dataset,
     grid: xr.Dataset,
     delp: xr.DataArray,
-    horizontal_dims: List[str],
+    gsrm: str = "fv3gfs",
     n_jobs: int = -1,
 ):
     return diagnostics_registry.compute(
-        DiagArg(prediction, target, grid, delp, horizontal_dims), n_jobs=n_jobs,
+        DiagArg(prediction, target, grid, delp, gsrm), n_jobs=n_jobs,
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/offline/compute_diagnostics.py
@@ -60,11 +60,10 @@ def compute_diagnostics(
     target: xr.Dataset,
     grid: xr.Dataset,
     delp: xr.DataArray,
-    gsrm: str = "fv3gfs",
     n_jobs: int = -1,
 ):
     return diagnostics_registry.compute(
-        DiagArg(prediction, target, grid, delp, gsrm), n_jobs=n_jobs,
+        DiagArg(prediction, target, grid, delp), n_jobs=n_jobs,
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -81,7 +81,6 @@ def _merge_diag_computes(
     input_data: Mapping[str, Tuple[xr.Dataset, xr.Dataset, xr.Dataset]],
     registries: Mapping[str, Registry],
     n_jobs: int,
-    gsrm: str,
 ) -> Mapping[str, xr.DataArray]:
     # Flattens list of all computations across registries before
     # parallelizing the computation.
@@ -102,7 +101,7 @@ def _merge_diag_computes(
             )
             continue
 
-        diag_arg = DiagArg(prog, verif, grid, gsrm=gsrm)
+        diag_arg = DiagArg(prog, verif, grid)
         merged_input_data += [
             (func_name, func, registry_key, diag_arg)
             for func_name, func in registries[registry_key].funcs.items()
@@ -677,9 +676,7 @@ def main(args):
         prognostic, verification, grid
     )
 
-    computed_diags = _merge_diag_computes(
-        input_data, registries, args.n_jobs, args.gsrm
-    )
+    computed_diags = _merge_diag_computes(input_data, registries, args.n_jobs)
     diags.update(computed_diags)
 
     # add grid vars

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -60,7 +60,7 @@ def _get_area(ds: xr.Dataset, catalog: intake.catalog.Catalog) -> xr.DataArray:
         48: "grid/c48",
         96: "grid/c96",
         384: "grid/c384",
-        21600: "grid/ne30_LC",
+        21600: "grid/ne30",
     }
     if check_if_scream_dataset(ds):
         input_res = ds.sizes["ncol"]
@@ -126,9 +126,9 @@ def load_grid(catalog, gsrm="fv3gfs"):
         ls_mask = standardize_fv3_diagnostics(catalog["landseamask/c48"].to_dask())
         return xr.merge([grid_c48, ls_mask])
     elif gsrm == "scream":
-        grid_ne30 = standardize_scream_diagnostics(catalog["grid/ne30_LC"].to_dask())
+        grid_ne30 = standardize_scream_diagnostics(catalog["grid/ne30"].to_dask())
         ls_mask_ne30 = standardize_scream_diagnostics(
-            catalog["landseamask/ne30_LC"].to_dask()
+            catalog["landseamask/ne30"].to_dask()
         )
         return xr.merge([grid_ne30, ls_mask_ne30])
     else:

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -13,6 +13,8 @@ import vcm
 import xarray as xr
 from vcm.cloud import get_fs
 from vcm.fv3 import standardize_fv3_diagnostics
+from vcm.scream import standardize_scream_diagnostics
+from vcm import check_if_scream_dataset
 
 from fv3net.diagnostics.prognostic_run import config
 from fv3net.diagnostics.prognostic_run import derived_variables
@@ -54,15 +56,26 @@ def _load_standardized(path):
 
 
 def _get_area(ds: xr.Dataset, catalog: intake.catalog.Catalog) -> xr.DataArray:
-    grid_entries = {48: "grid/c48", 96: "grid/c96", 384: "grid/c384"}
-    input_res = ds.sizes["x"]
+    grid_entries = {
+        48: "grid/c48",
+        96: "grid/c96",
+        384: "grid/c384",
+        21600: "grid/ne30_LC",
+    }
+    if check_if_scream_dataset(ds):
+        input_res = ds.sizes["ncol"]
+    else:
+        input_res = ds.sizes["x"]
     if input_res not in grid_entries:
         raise KeyError(f"No grid defined in catalog for c{input_res} resolution")
     return catalog[grid_entries[input_res]].to_dask().area
 
 
 def _get_factor(ds: xr.Dataset, target_resolution: int) -> int:
-    input_res = ds.sizes["x"]
+    if check_if_scream_dataset(ds):
+        input_res = ds.sizes["ncol"]
+    else:
+        input_res = ds.sizes["x"]
     if input_res % target_resolution != 0:
         raise ValueError("Target resolution must evenly divide input resolution")
     return int(input_res / target_resolution)
@@ -106,11 +119,20 @@ def _load_3d(url: str, catalog: intake.catalog.Catalog) -> xr.Dataset:
     return ds_interp
 
 
-def load_grid(catalog):
+def load_grid(catalog, gsrm="fv3gfs"):
     logger.info("Opening Grid Spec")
-    grid_c48 = standardize_fv3_diagnostics(catalog["grid/c48"].to_dask())
-    ls_mask = standardize_fv3_diagnostics(catalog["landseamask/c48"].to_dask())
-    return xr.merge([grid_c48, ls_mask])
+    if gsrm == "fv3gfs":
+        grid_c48 = standardize_fv3_diagnostics(catalog["grid/c48"].to_dask())
+        ls_mask = standardize_fv3_diagnostics(catalog["landseamask/c48"].to_dask())
+        return xr.merge([grid_c48, ls_mask])
+    elif gsrm == "scream":
+        grid_ne30 = standardize_scream_diagnostics(catalog["grid/ne30_LC"].to_dask())
+        ls_mask_ne30 = standardize_scream_diagnostics(
+            catalog["landseamask/ne30_LC"].to_dask()
+        )
+        return xr.merge([grid_ne30, ls_mask_ne30])
+    else:
+        raise ValueError(f"Grid spec {gsrm} not supported")
 
 
 def load_coarse_data(path, catalog) -> xr.Dataset:
@@ -134,6 +156,20 @@ def load_coarse_data(path, catalog) -> xr.Dataset:
             ds, target_resolution=48, catalog=catalog
         )
 
+    return ds
+
+
+def load_scream_data(path) -> xr.Dataset:
+    logger.info(f"Opening prognostic run data at {path}")
+
+    try:
+        logger.info(f"Loading and standardizing {path}")
+        m = fsspec.get_mapper(path)
+        ds = xr.open_zarr(m, consolidated=True, decode_times=False)
+        ds = standardize_scream_diagnostics(ds)
+    except (FileNotFoundError, KeyError):
+        warnings.warn(UserWarning(f"{path} not found. Returning empty dataset."))
+        ds = xr.Dataset()
     return ds
 
 
@@ -255,18 +291,54 @@ class SegmentedRun:
         return self.url
 
 
+@dataclass
+class ScreamSimulation:
+    url: str
+
+    @property
+    def data_2d(self) -> xr.Dataset:
+        url = self.url
+        path = os.path.join(url, "data_2d.zarr")
+
+        return load_scream_data(path)
+
+    @property
+    def data_3d(self) -> xr.Dataset:
+        logger.info(f"Processing 3d data from run directory at {self.url}")
+        path = os.path.join(self.url, "data_3d.zarr")
+        ds = load_scream_data(path)
+
+        # interpolate 3d prognostic fields to pressure levels
+        ds_interp = xr.Dataset()
+        pressure_vars = [var for var in ds.data_vars if "z" in ds[var].dims]
+        for var in pressure_vars:
+            ds_interp[var] = vcm.interpolate_to_pressure_levels(
+                field=ds[var],
+                delp=ds["pressure_thickness_of_atmospheric_layer"],
+                dim="z",
+            )
+
+        return ds_interp
+
+    def __str__(self) -> str:
+        return self.url
+
+
 def evaluation_pair_to_input_data(
     prognostic: Simulation, verification: Simulation, grid: xr.Dataset
 ):
     # 3d data special handling
     data_3d = prognostic.data_3d
     verif_3d = verification.data_3d
-
+    if check_if_scream_dataset(data_3d):
+        dropped_grid_vars = ["land_sea_mask"]
+    else:
+        dropped_grid_vars = ["tile", "land_sea_mask"]
     return {
         "3d": (
             derived_variables.derive_3d_variables(data_3d),
             derived_variables.derive_3d_variables(verif_3d),
-            grid.drop(["tile", "land_sea_mask"]),
+            grid.drop(dropped_grid_vars),
         ),
         "2d": (
             derived_variables.derive_2d_variables(prognostic.data_2d),

--- a/workflows/diagnostics/tests/prognostic/test_savediags.py
+++ b/workflows/diagnostics/tests/prognostic/test_savediags.py
@@ -63,6 +63,7 @@ def test_get_verification_from_catalog(url, expected_cls):
     class Args:
         verification = "hello"
         verification_url = url
+        gsrm = "fv3gfs"
 
     verification = savediags.get_verification(Args, catalog=None)
     assert isinstance(verification, expected_cls), verification


### PR DESCRIPTION
For convenience, we infer whether scream data is used based on whether `ncol` is in the dataset. 

(Delete unused sections)
Added public API:
- `vcm.check_if_scream_dataset`: infer if scream data is used
- Added `vcm.scream.standardize_scream_diagnostics`

Refactored public API:
- `prognostic_run_diags`: takes in `gsrm`, defaults to `fv3gfs`
- `load_run_data.py`: added custom code for loading scream data 

- [ ] Tests added

Coverage reports (updated automatically):
