### PR TITLE
Make report plotting compatible with scream data

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -414,7 +414,8 @@ def _get_verification_diagnostics(ds: xr.Dataset) -> xr.Dataset:
     for var in bin_width_vars:
         verif_diagnostics[var] = ds[var]
     verif_dataset = xr.Dataset(verif_diagnostics)
-    return xr.merge([ds[GRID_VARS], verif_dataset]).assign_attrs(verif_attrs)
+    present_grid_vars = [var for var in GRID_VARS if var in ds.variables]
+    return xr.merge([ds[present_grid_vars], verif_dataset]).assign_attrs(verif_attrs)
 
 
 def get_metadata(diags):

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -123,7 +123,6 @@ def plot_cubed_sphere_map(
     run_metrics: RunMetrics,
     varfilter: str,
     metrics_for_title: Mapping[str, str] = None,
-    gsrm: str = "fv3gfs",
 ) -> str:
     """Plot horizontal maps of cubed-sphere data for diagnostics which match varfilter.
 
@@ -149,9 +148,9 @@ def plot_cubed_sphere_map(
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
-            if gsrm == "fv3gfs":
+            if "lonb" and "latb" in run_diags.variables:
                 COORD_VARS = ["lon", "lat", "lonb", "latb"]
-            elif gsrm == "scream":
+            else:
                 COORD_VARS = ["lon", "lat"]
             ds = run_diags.get_variables(run, COORD_VARS + [varname])
             plot_title = _render_map_title(
@@ -160,7 +159,7 @@ def plot_cubed_sphere_map(
             fig, ax = plt.subplots(
                 figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()}
             )
-            if gsrm == "scream":
+            if "ncol" in ds.sizes:
                 grid_metadata = GridMetadataScream("ncol", "lon", "lat")
                 fv3viz.plot_cube(
                     ds,

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -17,7 +17,6 @@ import fv3viz
 from report import MatplotlibFigure, RawHTML
 from vcm.cubedsphere import GridMetadataScream
 
-COORD_VARS = ["lon", "lat", "lonb", "latb"]
 IGNORE_POLES_LATITUDE = 75.0
 OverlaidPlotData = MutableMapping[str, MutableMapping[str, MatplotlibFigure]]
 
@@ -150,7 +149,9 @@ def plot_cubed_sphere_map(
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
-            if gsrm == "scream":
+            if gsrm == "fv3gfs":
+                COORD_VARS = ["lon", "lat", "lonb", "latb"]
+            elif gsrm == "scream":
                 COORD_VARS = ["lon", "lat"]
             ds = run_diags.get_variables(run, COORD_VARS + [varname])
             plot_title = _render_map_title(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -15,6 +15,7 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
 )
 import fv3viz
 from report import MatplotlibFigure, RawHTML
+from vcm.cubedsphere import GridMetadataScream
 
 COORD_VARS = ["lon", "lat", "lonb", "latb"]
 IGNORE_POLES_LATITUDE = 75.0
@@ -123,6 +124,7 @@ def plot_cubed_sphere_map(
     run_metrics: RunMetrics,
     varfilter: str,
     metrics_for_title: Mapping[str, str] = None,
+    gsrm: str = "fv3gfs",
 ) -> str:
     """Plot horizontal maps of cubed-sphere data for diagnostics which match varfilter.
 
@@ -148,6 +150,8 @@ def plot_cubed_sphere_map(
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
+            if gsrm == "scream":
+                COORD_VARS = ["lon", "lat"]
             ds = run_diags.get_variables(run, COORD_VARS + [varname])
             plot_title = _render_map_title(
                 run_metrics, shortname, run, metrics_for_title
@@ -155,7 +159,19 @@ def plot_cubed_sphere_map(
             fig, ax = plt.subplots(
                 figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()}
             )
-            fv3viz.plot_cube(ds, varname, ax=ax, vmin=vmin, vmax=vmax, cmap=cmap)
+            if gsrm == "scream":
+                grid_metadata = GridMetadataScream("ncol", "lon", "lat")
+                fv3viz.plot_cube(
+                    ds,
+                    varname,
+                    grid_metadata=grid_metadata,
+                    ax=ax,
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap,
+                )
+            else:
+                fv3viz.plot_cube(ds, varname, ax=ax, vmin=vmin, vmax=vmax, cmap=cmap)
             ax.set_title(plot_title)
             plt.subplots_adjust(left=0.01, right=0.75, bottom=0.02)
             data[varname][run] = MatplotlibFigure(fig, width="500px")

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -691,6 +691,13 @@ def _register_report(subparsers):
     parser = subparsers.add_parser("report", help="Generate a static html report.")
     parser.add_argument("input", help="Directory containing multiple run diagnostics.")
     parser.add_argument("output", help="Location to save report html files.")
+    parser.add_argument(
+        "--gsrm",
+        type=str,
+        help="The type of GSRM used to generate the prognostic run,\
+              either `fv3gfs` or `scream`",
+        default="fv3gfs",
+    )
     parser.set_defaults(func=main)
 
 
@@ -704,6 +711,13 @@ def _register_report_from_urls(subparsers):
         help="Folders containing diags.nc. Will be labeled with "
         "increasing numbers in report.",
         nargs="+",
+    )
+    parser.add_argument(
+        "--gsrm",
+        type=str,
+        help="The type of GSRM used to generate the prognostic run,\
+              either `fv3gfs` or `scream`",
+        default="fv3gfs",
     )
     parser.add_argument(
         "-o", "--output", help="Location to save report html files.", required=True

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -338,19 +338,18 @@ def deep_tropical_meridional_mean_hovmoller_plots(
 
 
 def time_mean_cubed_sphere_maps(
-    diagnostics: RunDiagnostics, metrics: pd.DataFrame, gsrm: str = "fv3gfs"
+    diagnostics: RunDiagnostics, metrics: pd.DataFrame
 ) -> HVPlot:
     return plot_cubed_sphere_map(
         diagnostics,
         metrics,
         "time_mean_value",
         metrics_for_title={"Mean": "time_and_global_mean_value"},
-        gsrm=gsrm,
     )
 
 
 def time_mean_bias_cubed_sphere_maps(
-    diagnostics: RunDiagnostics, metrics: pd.DataFrame, gsrm: str = "fv3gfs"
+    diagnostics: RunDiagnostics, metrics: pd.DataFrame
 ) -> HVPlot:
     return plot_cubed_sphere_map(
         diagnostics,
@@ -360,7 +359,6 @@ def time_mean_bias_cubed_sphere_maps(
             "Mean": "time_and_global_mean_bias",
             "RMSE": "rmse_of_time_mean",
         },
-        gsrm=gsrm,
     )
 
 
@@ -552,13 +550,13 @@ def render_hovmollers(metadata, diagnostics):
     )
 
 
-def render_maps(metadata, diagnostics, metrics, gsrm: str = "fv3gfs"):
+def render_maps(metadata, diagnostics, metrics):
     # the plotting functions here require two inputs so can't use a PlotManager
     sections = {
         "Links": navigation,
         "Time-mean maps": [
-            time_mean_cubed_sphere_maps(diagnostics, metrics, gsrm),
-            time_mean_bias_cubed_sphere_maps(diagnostics, metrics, gsrm),
+            time_mean_cubed_sphere_maps(diagnostics, metrics),
+            time_mean_bias_cubed_sphere_maps(diagnostics, metrics),
         ],
     }
     return create_html(
@@ -664,7 +662,7 @@ def _get_public_links(movie_urls: MovieUrls, output: str) -> PublicLinks:
     return public_links
 
 
-def make_report(computed_diagnostics: ComputedDiagnosticsList, output, gsrm):
+def make_report(computed_diagnostics: ComputedDiagnosticsList, output):
     metrics = computed_diagnostics.load_metrics_from_diagnostics()
     movie_urls = computed_diagnostics.find_movie_urls()
     metadata, diagnostics = computed_diagnostics.load_diagnostics()
@@ -676,7 +674,7 @@ def make_report(computed_diagnostics: ComputedDiagnosticsList, output, gsrm):
     pages = {
         "index.html": render_index(metadata, diagnostics, metrics, public_links),
         "hovmoller.html": render_hovmollers(metadata, diagnostics),
-        "maps.html": render_maps(metadata, diagnostics, metrics, gsrm),
+        "maps.html": render_maps(metadata, diagnostics, metrics),
         "zonal_pressure.html": render_zonal_pressures(metadata, diagnostics),
         "process_diagnostics.html": render_process_diagnostics(
             metadata, diagnostics, metrics
@@ -691,13 +689,6 @@ def _register_report(subparsers):
     parser = subparsers.add_parser("report", help="Generate a static html report.")
     parser.add_argument("input", help="Directory containing multiple run diagnostics.")
     parser.add_argument("output", help="Location to save report html files.")
-    parser.add_argument(
-        "--gsrm",
-        type=str,
-        help="The type of GSRM used to generate the prognostic run,\
-              either `fv3gfs` or `scream`",
-        default="fv3gfs",
-    )
     parser.set_defaults(func=main)
 
 
@@ -711,13 +702,6 @@ def _register_report_from_urls(subparsers):
         help="Folders containing diags.nc. Will be labeled with "
         "increasing numbers in report.",
         nargs="+",
-    )
-    parser.add_argument(
-        "--gsrm",
-        type=str,
-        help="The type of GSRM used to generate the prognostic run,\
-              either `fv3gfs` or `scream`",
-        default="fv3gfs",
     )
     parser.add_argument(
         "-o", "--output", help="Location to save report html files.", required=True
@@ -737,13 +721,6 @@ def _register_report_from_json(subparsers):
     )
     parser.add_argument("output", help="Location to save report html files.")
     parser.add_argument(
-        "--gsrm",
-        type=str,
-        help="The type of GSRM used to generate the prognostic run,\
-              either `fv3gfs` or `scream`",
-        default="fv3gfs",
-    )
-    parser.add_argument(
         "-r",
         "--urls-are-rundirs",
         action="store_true",
@@ -761,16 +738,16 @@ def register_parser(subparsers):
 
 def main(args):
     computed_diagnostics = ComputedDiagnosticsList.from_directory(args.input)
-    make_report(computed_diagnostics, args.output, args.gsrm)
+    make_report(computed_diagnostics, args.output)
 
 
 def main_new(args):
     computed_diagnostics = ComputedDiagnosticsList.from_urls(args.inputs)
-    make_report(computed_diagnostics, args.output, args.gsrm)
+    make_report(computed_diagnostics, args.output)
 
 
 def main_json(args):
     computed_diagnostics = ComputedDiagnosticsList.from_json(
         args.input, args.urls_are_rundirs
     )
-    make_report(computed_diagnostics, args.output, args.gsrm)
+    make_report(computed_diagnostics, args.output)


### PR DESCRIPTION
Prognostic run reporting can now plot scream format data. Occasionally the long name and units are missing, we revert back to the variable name in that case.

Refactored public API:
- `plot_cubed_sphere_map`: takes in gsrm type and plot scream formatted data

Coverage reports (updated automatically):
