### PR TITLE
Fix precipitation_sum so it does not return zeroes

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
@@ -134,6 +134,10 @@ def precipitation_sum(
     Returns:
         total precipitation [m]"""
     m_per_mm = 1 / 1000
+    # some steppers do not have a net moistening diagnostic and column_dq2 passed is
+    # an empty data array
+    if column_dq2.size <= 1:
+        column_dq2 = xr.zeros_like(physics_precip)
     ml_precip = -column_dq2 * dt * m_per_mm  # type: ignore
     total_precip = physics_precip + ml_precip
     total_precip = total_precip.where(total_precip >= 0, 0)

--- a/workflows/prognostic_c48_run/tests/test_compute.py
+++ b/workflows/prognostic_c48_run/tests/test_compute.py
@@ -1,0 +1,26 @@
+import numpy as np
+import xarray as xr
+
+from runtime.diagnostics.compute import precipitation_sum, KG_PER_M2_PER_M
+
+
+def test_precipitation_sum():
+    dt = 10.0
+    da = xr.DataArray(np.ones(3), dims=["x"],)
+    physics_precip = da
+    postphysics_integrated_moistening = -2 * da  # m
+    dq2 = postphysics_integrated_moistening * KG_PER_M2_PER_M / dt  # kg/m^2/s
+    sum = precipitation_sum(physics_precip, dq2, dt)
+    np.testing.assert_array_equal(
+        sum, physics_precip - postphysics_integrated_moistening
+    )
+
+
+def test_precipitation_sum_empty_dq2():
+    dt = 10
+    da = xr.DataArray(np.ones(3), dims=["x"],)
+    physics_precip = da
+    # empty data array returned when steppers do not have net moistening diagnostic
+    dq2 = xr.DataArray()
+    sum = precipitation_sum(physics_precip, dq2, dt)
+    np.testing.assert_array_equal(sum, physics_precip)


### PR DESCRIPTION
I found that the `total_precipitation` field was zero  in reservoir training data, even when there was no precipitaiton update in the state update dict:
![image](https://github.com/ai2cm/fv3net/assets/16710132/49a76a6d-0342-494c-8a21-e0b19463474a)

I traced this issue to this line of the postphysics stepper, which autofills a total precipitation update using the `net_moistening` returned by the stepper's `get_diagnostics` method. The problem is that not all postphysics steppers have a net moistening diagnostic, and in the case of the `Prescriber` it just returns an empty data array. When an empty column moistening input is added to the physics precipitation field in the `precipitation_sum` function, the sum is nan and the nonnegative precip limiter converts the nans to all zeros. 

I added a couple lines to `precipitation_sum` to check for empty dq2 inputs and convert to zeros if that is the case.
 
- [x] Tests added
 