### PR TITLE
Add `google-cloud-sdk` to bare-metal prognostic run environments

### DIFF
--- a/.environment-scripts/gaea-c5/install_base_software.sh
+++ b/.environment-scripts/gaea-c5/install_base_software.sh
@@ -16,7 +16,7 @@ conda config --add pkgs_dirs $CONDA_PREFIX/pkgs
 conda config --add envs_dirs $CONDA_PREFIX/envs
 conda deactivate
 
-conda create -n $CONDA_ENV -c conda-forge python==3.8.10 pip pip-tools
+conda create -n $CONDA_ENV -c conda-forge python==3.8.10 google-cloud-sdk pip pip-tools
 conda activate $CONDA_ENV
 
 echo "Compiler settings:"

--- a/.environment-scripts/gaea/install_base_software.sh
+++ b/.environment-scripts/gaea/install_base_software.sh
@@ -15,7 +15,7 @@ conda config --add pkgs_dirs $CONDA_PREFIX/pkgs
 conda config --add envs_dirs $CONDA_PREFIX/envs
 conda deactivate
 
-conda create -n $CONDA_ENV -c conda-forge python==3.8.10 pip pip-tools
+conda create -n $CONDA_ENV -c conda-forge python==3.8.10 google-cloud-sdk pip pip-tools
 conda activate $CONDA_ENV
 
 echo "Compiler settings:"

--- a/.environment-scripts/stellar/install_base_software.sh
+++ b/.environment-scripts/stellar/install_base_software.sh
@@ -22,7 +22,7 @@ conda deactivate
 # preventing a conflict with system versions of the two libraries on Stellar.
 # See discussion in https://github.com/conda/conda/issues/10241
 # for more background
-conda create --yes -n $CONDA_ENV -c conda-forge python==3.8.10 libssh pip pip-tools
+conda create --yes -n $CONDA_ENV -c conda-forge python==3.8.10 google-cloud-sdk libssh pip pip-tools
 conda activate $CONDA_ENV
 
 echo "Python settings:"


### PR DESCRIPTION
It occurred to me that not everyone will already have `google-cloud-sdk` (and namely `gsutil`) installed in their search `PATH` on Stellar or Gaea, so this adds `google-cloud-sdk` to the conda environment created in the `install_base_software.sh` script.  `gsutil` is used within the post-processing step of the prognostic run, and without it one will encounter errors.  No authentication is needed if just moving files around locally (as is the case when running on HPC).  

Note we similarly install `google-cloud-sdk` in the prognostic run docker image, so this is not anything particularly new:

https://github.com/ai2cm/fv3net/blob/61f3a55ddd707d7093149dea7b28c266ed774b76/.environment-scripts/gnu_docker/install_base_software.sh#L50

Coverage reports (updated automatically):
