### PR TITLE
Add capability to specify date range in `prognostic_run_diags save`

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -615,6 +615,15 @@ def add_catalog_and_verification_arguments(parser: ArgumentParser):
     )
 
 
+def add_time_range_arguments(parser: ArgumentParser):
+    parser.add_argument(
+        "--start-date", type=str, help="Start date for diagnostics", default=""
+    )
+    parser.add_argument(
+        "--end-date", type=str, help="End date for diagnostics", default=""
+    )
+
+
 def register_parser(subparsers):
     parser: ArgumentParser = subparsers.add_parser(
         "save", help="Compute the prognostic run diags."
@@ -622,6 +631,7 @@ def register_parser(subparsers):
     parser.add_argument("url", help="Prognostic run output location.")
     parser.add_argument("output", help="Output path including filename.")
     add_catalog_and_verification_arguments(parser)
+    add_time_range_arguments(parser)
     parser.add_argument(
         "--n-jobs",
         type=int,
@@ -673,7 +683,7 @@ def main(args):
 
     grid = load_diags.load_grid(catalog, args.gsrm)
     input_data = load_diags.evaluation_pair_to_input_data(
-        prognostic, verification, grid
+        prognostic, verification, grid, args.start_date, args.end_date
     )
 
     computed_diags = _merge_diag_computes(input_data, registries, args.n_jobs)

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -617,10 +617,10 @@ def add_catalog_and_verification_arguments(parser: ArgumentParser):
 
 def add_time_range_arguments(parser: ArgumentParser):
     parser.add_argument(
-        "--start-date", type=str, help="Start date for diagnostics", default=""
+        "--start-date", type=str, help="Start date for diagnostics", default=None
     )
     parser.add_argument(
-        "--end-date", type=str, help="End date for diagnostics", default=""
+        "--end-date", type=str, help="End date for diagnostics", default=None
     )
 
 

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/compute.py
@@ -624,6 +624,18 @@ def add_time_range_arguments(parser: ArgumentParser):
     )
 
 
+def clean_up_diags_attrs(diags: xr.Dataset) -> xr.Dataset:
+    """
+    Remove attrs from diags that are not serializable.
+    Specifically, we cast start_date and end_date which has default of None to str.
+    """
+    if "start_date" in diags.attrs:
+        diags.attrs["start_date"] = str(diags.attrs["start_date"])
+    if "end_date" in diags.attrs:
+        diags.attrs["end_date"] = str(diags.attrs["end_date"])
+    return diags
+
+
 def register_parser(subparsers):
     parser: ArgumentParser = subparsers.add_parser(
         "save", help="Compute the prognostic run diags."
@@ -699,6 +711,7 @@ def main(args):
 
     logger.info(f"Saving data to {args.output}")
     with fsspec.open(args.output, "wb") as f:
+        diags = clean_up_diags_attrs(diags)
         vcm.dump_nc(diags, f)
 
     StepMetadata(

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -328,8 +328,8 @@ def evaluation_pair_to_input_data(
     prognostic: Simulation,
     verification: Simulation,
     grid: xr.Dataset,
-    start_date: str = "",
-    end_date: str = "",
+    start_date: str = None,
+    end_date: str = None,
 ):
     # 3d data special handling
     data_3d = prognostic.data_3d
@@ -340,11 +340,10 @@ def evaluation_pair_to_input_data(
         dropped_grid_vars = ["land_sea_mask"]
     else:
         dropped_grid_vars = ["tile", "land_sea_mask"]
-    if start_date and end_date:
-        data_3d = data_3d.sel(time=slice(start_date, end_date))
-        verif_3d = verif_3d.sel(time=slice(start_date, end_date))
-        data_2d = data_2d.sel(time=slice(start_date, end_date))
-        verif_2d = verif_2d.sel(time=slice(start_date, end_date))
+    data_3d = data_3d.sel(time=slice(start_date, end_date))
+    verif_3d = verif_3d.sel(time=slice(start_date, end_date))
+    data_2d = data_2d.sel(time=slice(start_date, end_date))
+    verif_2d = verif_2d.sel(time=slice(start_date, end_date))
     return {
         "3d": (
             derived_variables.derive_3d_variables(data_3d),

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -325,15 +325,26 @@ class ScreamSimulation:
 
 
 def evaluation_pair_to_input_data(
-    prognostic: Simulation, verification: Simulation, grid: xr.Dataset
+    prognostic: Simulation,
+    verification: Simulation,
+    grid: xr.Dataset,
+    start_date: str = "",
+    end_date: str = "",
 ):
     # 3d data special handling
     data_3d = prognostic.data_3d
     verif_3d = verification.data_3d
+    data_2d = prognostic.data_2d
+    verif_2d = verification.data_2d
     if check_if_scream_dataset(data_3d):
         dropped_grid_vars = ["land_sea_mask"]
     else:
         dropped_grid_vars = ["tile", "land_sea_mask"]
+    if start_date and end_date:
+        data_3d = data_3d.sel(time=slice(start_date, end_date))
+        verif_3d = verif_3d.sel(time=slice(start_date, end_date))
+        data_2d = data_2d.sel(time=slice(start_date, end_date))
+        verif_2d = verif_2d.sel(time=slice(start_date, end_date))
     return {
         "3d": (
             derived_variables.derive_3d_variables(data_3d),
@@ -341,8 +352,8 @@ def evaluation_pair_to_input_data(
             grid.drop(dropped_grid_vars),
         ),
         "2d": (
-            derived_variables.derive_2d_variables(prognostic.data_2d),
-            derived_variables.derive_2d_variables(verification.data_2d),
+            derived_variables.derive_2d_variables(data_2d),
+            derived_variables.derive_2d_variables(verif_2d),
             grid,
         ),
     }

--- a/workflows/diagnostics/tests/prognostic/test_load_diag_data.py
+++ b/workflows/diagnostics/tests/prognostic/test_load_diag_data.py
@@ -84,6 +84,27 @@ def test_evaluation_pair_to_input_data(regtest):
         _print_input_data_regressions_data(input_data)
 
 
+def test_evaluation_pair_to_input_data_one_day_only():
+    url = "gs://vcm-ml-code-testing-data/sample-prognostic-run-output"
+    catalog = vcm.catalog.catalog
+    prognostic = load_diags.SegmentedRun(url, catalog)
+    grid = load_diags.load_grid(catalog)
+    start_date = "2016-08-05"
+    end_date = "2016-08-05"
+    input_data = load_diags.evaluation_pair_to_input_data(
+        prognostic, prognostic, grid, start_date, end_date
+    )
+    for key, (prognostic_run, verification, grid) in input_data.items():
+        for t in range(len(prognostic_run.time)):
+            assert prognostic_run.time.values[t].year == 2016
+            assert prognostic_run.time.values[t].month == 8
+            assert prognostic_run.time.values[t].day == 5
+
+            assert verification.time.values[t].year == 2016
+            assert verification.time.values[t].month == 8
+            assert verification.time.values[t].day == 5
+
+
 @pytest.mark.parametrize(
     "simulation",
     [


### PR DESCRIPTION
Sometimes prognostic run is incomplete and we will still like to look at error statistics for a specific time frame. This PR adds the capability of specifying the start and end date when saving prognostic run diagnostics.

Added public API:
- `prognostic_run_diags save`: additional flags `--start-date` and `--end-date` 

Significant internal changes:
- When start/end date is specified, we slice the loaded data.

- [x] Tests added

Coverage reports (updated automatically):
