### PR TITLE
Add single-file netCDF tfdataset loader

### DIFF
--- a/external/fv3fit/fv3fit/data/__init__.py
+++ b/external/fv3fit/fv3fit/data/__init__.py
@@ -6,4 +6,4 @@ from .tfdataset import (
     CycleGANLoader,
 )
 from .synthetic import SyntheticNoise, SyntheticWaves
-from .netcdf.load import NCDirLoader
+from .netcdf.load import NCDirLoader, NCFileLoader

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -126,8 +126,8 @@ def open_netcdf_file(path: str) -> xr.Dataset:
 
 
 class _BaseNCLoader(TFDatasetLoader):
-    @abstractmethod
     @property
+    @abstractmethod
     def dim_order(self) -> Optional[Sequence[str]]:
         pass
 

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -188,7 +188,7 @@ class NCFileLoader(_BaseNCLoader):
 
 @register_tfdataset_loader
 @dataclass
-class NCDirLoader(TFDatasetLoader):
+class NCDirLoader(_BaseNCLoader):
     """Loads a folder of netCDF files at given path
 
     Each file must have identical CDL scheme returned by ``ncdump -h``.

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -168,7 +168,14 @@ class _BaseNCLoader(TFDatasetLoader):
 @dataclass
 class NCFileLoader(_BaseNCLoader):
     """
-    Loads a single remote/local netCDF file into a dataset
+    Loads a single remote/local netCDF file into a dataset.  Useful for the
+    case where the directory contains multiple netcdf files for different
+    purposes vs. having to create a new directory for each set of
+    training/validation files.
+
+    Attributes:
+        filepath: a path (local or remote) to the netcdf file
+        dim_order: Order of dimensions in tensors.
     """
 
     filepath: str = ""

--- a/external/fv3fit/fv3fit/data/netcdf/load.py
+++ b/external/fv3fit/fv3fit/data/netcdf/load.py
@@ -1,8 +1,10 @@
 import logging
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, Sequence
 
 from pathlib import Path
+import fsspec
 import numpy as np
 import re
 import tensorflow as tf
@@ -116,6 +118,74 @@ def to_tensor(
     return {key: tf.convert_to_tensor(ds[key], dtype=dtype) for key in variable_names}
 
 
+def open_netcdf_file(path: str) -> xr.Dataset:
+    """Open a netcdf from a local/remote path"""
+    with fsspec.open(path) as f:
+        ds = xr.open_dataset(f, engine="h5netcdf")
+        return ds.load()
+
+
+class _BaseNCLoader(TFDatasetLoader):
+    @abstractmethod
+    @property
+    def dim_order(self) -> Optional[Sequence[str]]:
+        pass
+
+    @property
+    def dtype(self):
+        return tf.float32
+
+    def convert(
+        self, ds: xr.Dataset, variables: Sequence[str]
+    ) -> Mapping[str, tf.Tensor]:
+        tensors = {}
+        for key in variables:
+            data_array = self._ensure_consistent_dims(ds[key])
+            tensors[key] = tf.convert_to_tensor(data_array, dtype=self.dtype)
+        return tensors
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TFDatasetLoader":
+        return dacite.from_dict(cls, d, config=dacite.Config(strict=True))
+
+    def _ensure_consistent_dims(self, data_array: xr.DataArray):
+        if self.dim_order:
+            extra_dims_in_data_array = set(data_array.dims) - set(self.dim_order)
+            missing_dims_in_data_array = set(self.dim_order) - set(data_array.dims)
+            if len(extra_dims_in_data_array) > 0:
+                raise ValueError(
+                    f"Extra dimensions {extra_dims_in_data_array} in data that are not "
+                    f"included in configured dimension order {self.dim_order}."
+                    "Make sure these are included in the configuration dim_order."
+                )
+            for missing_dim in missing_dims_in_data_array:
+                data_array = data_array.expand_dims(dim=missing_dim)
+            data_array = data_array.transpose(*self.dim_order)
+        return data_array
+
+
+@register_tfdataset_loader
+@dataclass
+class NCFileLoader(_BaseNCLoader):
+    """
+    Loads a single remote/local netCDF file into a dataset
+    """
+
+    filepath: str = ""
+    dim_order: Optional[Sequence[str]] = None
+
+    def open_tfdataset(
+        self, local_download_path: Optional[str], variable_names: Sequence[str],
+    ) -> tf.data.Dataset:
+        def convert(x):
+            return self.convert(x, variable_names)
+
+        transform = compose_left(open_netcdf_file, convert)
+        return iterable_to_tfdataset(
+            [self.filepath], transform, varying_first_dim=False
+        ).prefetch(tf.data.AUTOTUNE)
+
+
 @register_tfdataset_loader
 @dataclass
 class NCDirLoader(TFDatasetLoader):
@@ -151,26 +221,14 @@ class NCDirLoader(TFDatasetLoader):
 
     """
 
-    url: str
+    url: str = ""
+    dim_order: Optional[Sequence[str]] = None
     nfiles: Optional[int] = None
     shuffle: bool = True
     seed: int = 0
-    dim_order: Optional[Sequence[str]] = None
     varying_first_dim: bool = False
     sort_files: bool = False
-
-    @property
-    def dtype(self):
-        return tf.float32
-
-    def convert(
-        self, ds: xr.Dataset, variables: Sequence[str]
-    ) -> Mapping[str, tf.Tensor]:
-        tensors = {}
-        for key in variables:
-            data_array = self._ensure_consistent_dims(ds[key])
-            tensors[key] = tf.convert_to_tensor(data_array, dtype=self.dtype)
-        return tensors
+    match: Optional[str] = None
 
     def open_tfdataset(
         self, local_download_path: Optional[str], variable_names: Sequence[str],
@@ -187,23 +245,5 @@ class NCDirLoader(TFDatasetLoader):
             cache=local_download_path,
             varying_first_dim=self.varying_first_dim,
             sort_files=self.sort_files,
+            match=self.match,
         )
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "TFDatasetLoader":
-        return dacite.from_dict(cls, d, config=dacite.Config(strict=True))
-
-    def _ensure_consistent_dims(self, data_array: xr.DataArray):
-        if self.dim_order:
-            extra_dims_in_data_array = set(data_array.dims) - set(self.dim_order)
-            missing_dims_in_data_array = set(self.dim_order) - set(data_array.dims)
-            if len(extra_dims_in_data_array) > 0:
-                raise ValueError(
-                    f"Extra dimensions {extra_dims_in_data_array} in data that are not "
-                    f"included in configured dimension order {self.dim_order}."
-                    "Make sure these are included in the configuration dim_order."
-                )
-            for missing_dim in missing_dims_in_data_array:
-                data_array = data_array.expand_dims(dim=missing_dim)
-            data_array = data_array.transpose(*self.dim_order)
-        return data_array

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -293,6 +293,7 @@ def train_reservoir_model(
             log_variance_scalar_metrics(ds_val, model.output_variables)
         except Exception as e:
             logging.error("Error logging validation metrics to wandb", exc_info=e)
+
     return adapter
 
 

--- a/external/fv3fit/tests/data_/test_netcdf.py
+++ b/external/fv3fit/tests/data_/test_netcdf.py
@@ -146,3 +146,28 @@ def test_error_missing_data_dim_in_specified_order():
 def test_sort_netcdfs(names, sorted_names):
     names = _natural_sort(names)
     assert names == sorted_names
+
+
+def test_NCFileLoader(tmp_path: Path):
+    path = tmp_path / "a.nc"
+    cache = tmp_path / ".cache"
+    ds = vcm.cdl_to_dataset(
+        """
+    netcdf A {
+        dimensions:
+            sample = 4;
+            z = 1;
+        variables:
+            float a(sample, z);
+        data:
+            a = 0, 1, 2, 3;
+    }
+    """
+    )
+
+    ds.to_netcdf(path.as_posix())
+    loader = fv3fit.data.NCFileLoader(path.as_posix())
+    tfds = loader.open_tfdataset(cache.as_posix(), ["a"])
+    for data in tfds.as_numpy_iterator():
+        a = data["a"]
+    np.testing.assert_array_equal(ds["a"], a)

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -34,7 +34,8 @@ def test_train_reservoir():
         .transpose("time", "x", "y", "z")
     )
     train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(4)])
-    val_tfdataset = tfdataset_from_batches([test_dataset])
+    # val_tfdataset = tfdataset_from_batches([test_dataset])
+    # TODO: validation is currently broken for multiple z-dim inputs
     variables = ["var_in_3d", "var_in_2d"]
 
     subdomain_config = CubedsphereSubdomainConfig(
@@ -59,7 +60,7 @@ def test_train_reservoir():
         n_timesteps_synchronize=5,
         input_noise=0.01,
     )
-    adapter = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)
+    adapter = train_reservoir_model(hyperparameters, train_tfdataset, None)
     model = adapter.model
     model.reset_state()
 

--- a/external/fv3fit/tests/training/test_reservoir.py
+++ b/external/fv3fit/tests/training/test_reservoir.py
@@ -34,8 +34,7 @@ def test_train_reservoir():
         .transpose("time", "x", "y", "z")
     )
     train_tfdataset = tfdataset_from_batches([train_dataset for _ in range(4)])
-    # val_tfdataset = tfdataset_from_batches([test_dataset])
-    # TODO: validation is currently broken for multiple z-dim inputs
+    val_tfdataset = tfdataset_from_batches([test_dataset])
     variables = ["var_in_3d", "var_in_2d"]
 
     subdomain_config = CubedsphereSubdomainConfig(
@@ -60,7 +59,7 @@ def test_train_reservoir():
         n_timesteps_synchronize=5,
         input_noise=0.01,
     )
-    adapter = train_reservoir_model(hyperparameters, train_tfdataset, None)
+    adapter = train_reservoir_model(hyperparameters, train_tfdataset, val_tfdataset)
     model = adapter.model
     model.reset_state()
 


### PR DESCRIPTION
Adds a new tfdataset loader that will take in a single netCDF file as the path.  This was useful for the SST training, since we're training a single model per tile and the SST dataset is loaded in a single netCDF.  The adjustment meant I could keep the directory structure of the training files flat for each tile instead of having to have a directory for each file.

Added public API:
- new `TFDatasetLoader` dataclass, `NCFileLoader` that takes in a `filepath` and a `dim_order`.

Significant internal changes:
- Added a new `_BaseNCLoader` class for shared functionality between `NCFileLoader` and `NCDirLoader`

- [x] Tests added

Coverage reports (updated automatically):
