### PR TITLE
Add transformer for normalizing individual spatial grid points

### DIFF
--- a/external/fv3fit/fv3fit/reservoir/adapters.py
+++ b/external/fv3fit/fv3fit/reservoir/adapters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import numpy as np
 import os
 import typing
-from typing import Iterable, Hashable, Sequence, Union, Mapping
+from typing import Iterable, Hashable, Sequence, Union, Mapping, Optional
 import xarray as xr
 
 import fv3fit
@@ -55,15 +55,20 @@ class DatasetAdapter:
         return xr.DataArray(data=arr, dims=dims)
 
     def output_array_to_ds(
-        self, outputs: Sequence[np.ndarray], output_dims: Sequence[str]
+        self, outputs: Sequence[np.ndarray], output_dims: Optional[Sequence[str]] = None
     ) -> xr.Dataset:
 
-        return xr.Dataset(
+        ds = xr.Dataset(
             {
                 var: self._ndarray_to_dataarray(output)
                 for var, output in zip(self.output_variables, outputs)
             }
-        ).transpose(*output_dims)
+        )
+
+        if output_dims is None:
+            output_dims = self.DIM_ORDER
+
+        return ds.transpose(*[dim for dim in output_dims if dim in ds.dims])
 
     def input_dataset_to_arrays(
         self, inputs: xr.Dataset, variables: Iterable[Hashable]
@@ -121,9 +126,8 @@ class ReservoirDatasetAdapter(Predictor):
     def predict(self, inputs: xr.Dataset) -> xr.Dataset:
         # inputs arg is not used, but is required by Predictor signature and prog run
         prediction_arr = self.model.predict()
-        return self.model_adapter.output_array_to_ds(
-            prediction_arr, output_dims=list(inputs.dims)
-        )
+        dims = list(inputs.dims) if inputs else None
+        return self.model_adapter.output_array_to_ds(prediction_arr, output_dims=dims)
 
     def increment_state(self, inputs: xr.Dataset):
         xy_input_arrs = self.model_adapter.input_dataset_to_arrays(

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -94,7 +94,9 @@ class HybridReservoirComputingModel(Predictor):
     def predict(self, hybrid_input: Sequence[np.ndarray]):
         # hybrid input is assumed to be in original spatial xy dims
         # (x, y, feature) and does not include overlaps.
-        encoded_hybrid_input = self.transformers.hybrid.encode_txyz(hybrid_input)
+        encoded_hybrid_input = self.transformers.hybrid.encode_unstacked_xyz(
+            hybrid_input
+        )
 
         flat_hybrid_in = self._hybrid_rank_divider.get_all_subdomains_with_flat_feature(
             encoded_hybrid_input
@@ -111,7 +113,7 @@ class HybridReservoirComputingModel(Predictor):
         prediction = self._output_rank_divider.merge_all_flat_feature_subdomains(
             flat_prediction
         )
-        decoded_prediction = self.transformers.output.decode_txyz(prediction)
+        decoded_prediction = self.transformers.output.decode_unstacked_xyz(prediction)
         return decoded_prediction
 
     def _concatenate_readout_inputs(self, hidden_state_input, flat_hybrid_input):
@@ -231,7 +233,7 @@ class ReservoirComputingModel(Predictor):
         prediction = self._output_rank_divider.merge_all_flat_feature_subdomains(
             flat_prediction
         )
-        decoded_prediction = self.transformers.output.decode_txyz(prediction)
+        decoded_prediction = self.transformers.output.decode_unstacked_xyz(prediction)
         return decoded_prediction
 
     def reset_state(self):
@@ -243,7 +245,7 @@ class ReservoirComputingModel(Predictor):
 
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         # input array is in native x, y, z_feature coordinates
-        encoded_xy_input_arrs = self.transformers.input.encode_txyz(
+        encoded_xy_input_arrs = self.transformers.input.encode_unstacked_xyz(
             prediction_with_overlap
         )
         encoded_flat_sub = self.rank_divider.get_all_subdomains_with_flat_feature(
@@ -253,7 +255,7 @@ class ReservoirComputingModel(Predictor):
 
     def synchronize(self, synchronization_time_series):
         # input arrays in native x, y, z_feature coordinates
-        encoded_timeseries = self.transformers.input.encode_txyz(
+        encoded_timeseries = self.transformers.input.encode_unstacked_xyz(
             synchronization_time_series
         )
         encoded_flat = self.rank_divider.get_all_subdomains_with_flat_feature(

--- a/external/fv3fit/fv3fit/reservoir/model.py
+++ b/external/fv3fit/fv3fit/reservoir/model.py
@@ -12,7 +12,7 @@ from .reservoir import Reservoir
 from .domain2 import RankXYDivider
 from fv3fit._shared import io
 from .utils import square_even_terms
-from .transformers import encode_columns, decode_columns, TransformerGroup
+from .transformers import TransformerGroup
 
 DIMENSION_ORDER = ("x", "y")
 
@@ -94,9 +94,7 @@ class HybridReservoirComputingModel(Predictor):
     def predict(self, hybrid_input: Sequence[np.ndarray]):
         # hybrid input is assumed to be in original spatial xy dims
         # (x, y, feature) and does not include overlaps.
-        encoded_hybrid_input = encode_columns(
-            input_arrs=hybrid_input, transformer=self.transformers.hybrid
-        )
+        encoded_hybrid_input = self.transformers.hybrid.encode_txyz(hybrid_input)
 
         flat_hybrid_in = self._hybrid_rank_divider.get_all_subdomains_with_flat_feature(
             encoded_hybrid_input
@@ -113,9 +111,7 @@ class HybridReservoirComputingModel(Predictor):
         prediction = self._output_rank_divider.merge_all_flat_feature_subdomains(
             flat_prediction
         )
-        decoded_prediction = decode_columns(
-            encoded_output=prediction, transformer=self.transformers.output,
-        )
+        decoded_prediction = self.transformers.output.decode_txyz(prediction)
         return decoded_prediction
 
     def _concatenate_readout_inputs(self, hidden_state_input, flat_hybrid_input):
@@ -235,9 +231,7 @@ class ReservoirComputingModel(Predictor):
         prediction = self._output_rank_divider.merge_all_flat_feature_subdomains(
             flat_prediction
         )
-        decoded_prediction = decode_columns(
-            encoded_output=prediction, transformer=self.transformers.output,
-        )
+        decoded_prediction = self.transformers.output.decode_txyz(prediction)
         return decoded_prediction
 
     def reset_state(self):
@@ -249,8 +243,8 @@ class ReservoirComputingModel(Predictor):
 
     def increment_state(self, prediction_with_overlap: Sequence[np.ndarray]) -> None:
         # input array is in native x, y, z_feature coordinates
-        encoded_xy_input_arrs = encode_columns(
-            prediction_with_overlap, self.transformers.input
+        encoded_xy_input_arrs = self.transformers.input.encode_txyz(
+            prediction_with_overlap
         )
         encoded_flat_sub = self.rank_divider.get_all_subdomains_with_flat_feature(
             encoded_xy_input_arrs
@@ -259,8 +253,8 @@ class ReservoirComputingModel(Predictor):
 
     def synchronize(self, synchronization_time_series):
         # input arrays in native x, y, z_feature coordinates
-        encoded_timeseries = encode_columns(
-            synchronization_time_series, self.transformers.input
+        encoded_timeseries = self.transformers.input.encode_txyz(
+            synchronization_time_series
         )
         encoded_flat = self.rank_divider.get_all_subdomains_with_flat_feature(
             encoded_timeseries

--- a/external/fv3fit/fv3fit/reservoir/train.py
+++ b/external/fv3fit/fv3fit/reservoir/train.py
@@ -10,7 +10,6 @@ import tensorflow as tf
 from typing import Optional, List, Union, cast, Mapping, Sequence
 import wandb
 
-
 from .. import Predictor
 from .utils import (
     square_even_terms,
@@ -21,7 +20,7 @@ from .utils import (
     get_standard_normalizing_transformer,
 )
 from .transformers import TransformerGroup, Transformer
-from .._shared import register_training_function
+from .._shared import register_training_function, get_dir
 from . import (
     ReservoirComputingModel,
     HybridReservoirComputingModel,
@@ -45,6 +44,11 @@ def _add_input_noise(arr: np.ndarray, stddev: float) -> np.ndarray:
     return arr + np.random.normal(loc=0, scale=stddev, size=arr.shape)
 
 
+def _load_transformer(path: str) -> Transformer:
+    with get_dir(path) as f:
+        return cast(Transformer, fv3fit.load(f))
+
+
 def _get_transformers(
     sample_batch: Mapping[str, tf.Tensor], hyperparameters: ReservoirTrainingConfig
 ) -> TransformerGroup:
@@ -53,7 +57,7 @@ def _get_transformers(
     for variable_group in ["input", "output", "hybrid"]:
         path = getattr(hyperparameters.transformers, variable_group, None)
         if path is not None:
-            transformers[variable_group] = cast(Transformer, fv3fit.load(path))
+            transformers[variable_group] = cast(Transformer, _load_transformer(path))
 
     # If input transformer not specified, always create a standard norm transform
     if "input" not in transformers:

--- a/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/__init__.py
@@ -2,9 +2,7 @@ from .autoencoder import Autoencoder, build_concat_and_scale_only_autoencoder
 from .sk_transformer import SkTransformer
 from .transformer import (
     Transformer,
-    encode_columns,
     DoNothingAutoencoder,
-    decode_columns,
     TransformerGroup,
 )
 from typing import Union

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -82,7 +82,7 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
     @property
     def n_latent_dims(self):
-        return len(self._norm_layer) * self._spatial_features[-1]
+        return self._num_variables * self._spatial_features[-1]
 
     @property
     def _flat_spatial_len(self):
@@ -115,7 +115,7 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
         leading_dims = input_arrs[0].shape[:-3]
         # stack xyz
-        spatial_last_dim = [arr.reshape(*leading_dims, -1) for arr in input_arrs]
+        spatial_last_dim = [tf.reshape(arr, (*leading_dims, -1)) for arr in input_arrs]
 
         # stack all xyz-flattened variables
         stacked_feature = np.concatenate(spatial_last_dim, axis=-1)
@@ -130,7 +130,7 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
         # reshape to xyz and then stack z
         normalized_unstacked = [
-            arr.reshape(*leading_dims, *self._spatial_features)
+            tf.reshape(arr, (*leading_dims, *self._spatial_features))
             for arr in normalized_arrs
         ]
         normalized_stacked_z = np.concatenate(normalized_unstacked, axis=-1)
@@ -151,7 +151,9 @@ class ScaleSpatialConcatZTransformer(Transformer):
         self._check_consistent_xyz(normalized_arrs)
 
         # stack all xyz-flattened variables
-        spatial_last_dim = [arr.reshape(*leading_dims, -1) for arr in normalized_arrs]
+        spatial_last_dim = [
+            tf.reshape(arr, (*leading_dims, -1)) for arr in normalized_arrs
+        ]
         stacked_feature = np.concatenate(spatial_last_dim, axis=-1)
 
         # denormalize
@@ -164,7 +166,7 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
         # reshape spatial
         original = [
-            arr.reshape(*leading_dims, *self._spatial_features)
+            tf.reshape(arr, (*leading_dims, *self._spatial_features))
             for arr in unnormalized_arrs
         ]
         return original

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -245,11 +245,22 @@ def build_scale_spatial_concat_z_transformer(
             (x, y, z * num_variables)
     """
 
-    if len(sample_data[0].shape) < 4:
-        raise ValueError(
-            "Expected at least 4 dimensions in the input data, but got "
-            f"{len(sample_data[0].shape)}"
-        )
+    initial_shape = None
+    for i, data in enumerate(sample_data):
+        if len(data.shape) < 4:
+            raise ValueError(
+                "Expected at least 4 dimensions in the input data, but got "
+                f"{len(data.shape)} for array {i}."
+            )
+        if initial_shape is None:
+            initial_shape = data.shape
+        else:
+            if data.shape != initial_shape:
+                raise ValueError(
+                    "All arrays must have the same shape. "
+                    f"Expected {initial_shape} but got {data.shape} "
+                    f"for array {i}."
+                )
 
     leading_dims = sample_data[0].shape[:-3]
     spatial_features = sample_data[0].shape[-3:]

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -40,14 +40,14 @@ class Transformer(BaseTransformer, Reloadable):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def encode_txyz(self, input_arrs: Sequence[np.ndarray]) -> np.ndarray:
+    def encode_unstacked_xyz(self, input_arrs: Sequence[np.ndarray]) -> np.ndarray:
         """Handle non-2D inputs during runtime/training"""
         leading_shape = input_arrs[0].shape[:-1]
         collapsed_arrs = [np.reshape(arr, (-1, arr.shape[-1])) for arr in input_arrs]
         encoded = self.encode(collapsed_arrs)
         return np.reshape(encoded, (*leading_shape, -1))
 
-    def decode_txyz(self, encoded: np.ndarray) -> Sequence[np.ndarray]:
+    def decode_unstacked_xyz(self, encoded: np.ndarray) -> Sequence[np.ndarray]:
         """Handle non-2D inputs during runtime/training"""
         feature_size = encoded.shape[-1]
         leading_shape = encoded.shape[:-1]
@@ -128,7 +128,7 @@ class _ScaleSpatialConcatZTransformer(Transformer):
                     f"for array {i}."
                 )
 
-    def encode_txyz(self, input_arrs: Sequence[ndarray]) -> ndarray:
+    def encode_unstacked_xyz(self, input_arrs: Sequence[ndarray]) -> ndarray:
         # Overloads the original transformer encode_txyz since we want to
         # handle the xyz dimensions differently.
 
@@ -161,7 +161,7 @@ class _ScaleSpatialConcatZTransformer(Transformer):
 
         return normalized_stacked_z
 
-    def decode_txyz(self, encoded: ndarray) -> Sequence[ndarray]:
+    def decode_unstacked_xyz(self, encoded: ndarray) -> Sequence[ndarray]:
         # Overloads the original transformer decode_txyz since we want to
         # handle the xyz dimensions differently.
         leading_dims = encoded.shape[:-3]

--- a/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
+++ b/external/fv3fit/fv3fit/reservoir/transformers/transformer.py
@@ -192,7 +192,8 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
         np.save(os.path.join(path, self._SCALE_NDARRAY), self._norm_layer.scale)
         np.save(os.path.join(path, self._CENTER_NDARRAY), self._norm_layer.center)
-        np.save(os.path.join(path, self._MASK_NDARRAY), self._mask)
+        if self._mask is not None:
+            np.save(os.path.join(path, self._MASK_NDARRAY), self._mask)
 
     @classmethod
     def load(cls, path: str) -> "ScaleSpatialConcatZTransformer":
@@ -201,7 +202,10 @@ class ScaleSpatialConcatZTransformer(Transformer):
 
         scale = np.load(os.path.join(path, cls._SCALE_NDARRAY))
         center = np.load(os.path.join(path, cls._CENTER_NDARRAY))
-        mask = np.load(os.path.join(path, cls._MASK_NDARRAY))
+        if os.path.exists(os.path.join(path, cls._MASK_NDARRAY)):
+            mask = np.load(os.path.join(path, cls._MASK_NDARRAY))
+        else:
+            mask = None
         return cls(center=center, scale=scale, mask=mask, **config)
 
 

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -116,7 +116,7 @@ def process_batch_data(
 
     if autoencoder is not None:
         try:
-            data_encoded = autoencoder.encode_txyz(encoder_inputs)
+            data_encoded = autoencoder.encode_unstacked_xyz(encoder_inputs)
         except ValueError as e:
             # TODO: there is a chicken/egg problem here in that no
             # specification of transforms creates an autoencoder that
@@ -129,7 +129,7 @@ def process_batch_data(
                 "There was an error using pre-trimmed data. Trying again"
                 f" with the original input data. [Error: {e}]"
             )
-            data_encoded = autoencoder.encode_txyz(data)
+            data_encoded = autoencoder.encode_unstacked_xyz(data)
             if trim_halo:
                 data_encoded = rank_divider.trim_halo_from_rank_data(data_encoded)
 

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -112,7 +112,12 @@ def process_batch_data(
     # Concatenate features, normalize and optionally convert data
     # to latent representation
     if trim_halo:
-        data = [rank_divider.trim_halo_from_rank_data(arr) for arr in data]
+        trimmed_data = []
+        for arr in data:
+            tmp_divider = rank_divider.get_new_zdim_rank_divider(arr.shape[-1])
+            trimmed = tmp_divider.trim_halo_from_rank_data(arr)
+            trimmed_data.append(trimmed)
+        data = trimmed_data
 
     if autoencoder is not None:
         data_encoded = autoencoder.encode_txyz(data)

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -4,9 +4,7 @@ import tensorflow as tf
 from typing import Iterable, Mapping, Optional
 
 from fv3fit.reservoir.transformers import (
-    # ReloadableTransformer,
     Transformer,
-    encode_columns,
     build_concat_and_scale_only_autoencoder,
 )
 from fv3fit.reservoir.domain2 import RankXYDivider
@@ -108,7 +106,7 @@ def process_batch_data(
     # Concatenate features, normalize and optionally convert data
     # to latent representation
     if autoencoder is not None:
-        data_encoded = encode_columns(data, autoencoder)
+        data_encoded = autoencoder.encode_txyz(data)
 
     if trim_halo:
         data_trimmed = rank_divider.trim_halo_from_rank_data(data_encoded)

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -105,20 +105,23 @@ def process_batch_data(
 
     # Concatenate features, normalize and optionally convert data
     # to latent representation
+    encoder_inputs = data
     if trim_halo:
         pre_trimmed_data = []
         for arr in data:
             tmp_divider = rank_divider.get_new_zdim_rank_divider(arr.shape[-1])
             trimmed = tmp_divider.trim_halo_from_rank_data(arr)
             pre_trimmed_data.append(trimmed)
+        encoder_inputs = pre_trimmed_data
 
     if autoencoder is not None:
         try:
-            data_encoded = autoencoder.encode_txyz(pre_trimmed_data)
+            data_encoded = autoencoder.encode_txyz(encoder_inputs)
         except ValueError as e:
             # TODO: there is a chicken/egg problem here in that no
             # specification of transforms creates an autoencoder that
-            # expects halo, while pre-trained might not. I'm not quite
+            # expects halo during training, while pre-trained encoder
+            # expect trimmed data inputs. I'm not quite
             # sure how the prognostic run works with an overlap and
             # hybrid data currently... Follow-on PR will be necessary
             # to rectify, but this should be backwards compatible

--- a/external/fv3fit/fv3fit/reservoir/utils.py
+++ b/external/fv3fit/fv3fit/reservoir/utils.py
@@ -103,20 +103,28 @@ def process_batch_data(
     """
     data = get_ordered_X(batch_data, variables)
 
+    # TODO: there is a chicken/egg problem here in that no
+    # specification of transforms creates an autoencoder that
+    # expects halo, while pre-trained might not. I'm not quite
+    # sure how the output transformer works when the readout
+    # outputs are trimmed while the encoder expects halos?
+
     # Concatenate features, normalize and optionally convert data
     # to latent representation
+    if trim_halo:
+        data = [rank_divider.trim_halo_from_rank_data(arr) for arr in data]
+
     if autoencoder is not None:
         data_encoded = autoencoder.encode_txyz(data)
 
     if trim_halo:
-        data_trimmed = rank_divider.trim_halo_from_rank_data(data_encoded)
+        # data_trimmed = rank_divider.trim_halo_from_rank_data(data_encoded)
         no_overlap_rank_divider = rank_divider.get_no_overlap_rank_divider()
         return no_overlap_rank_divider.get_all_subdomains_with_flat_feature(
-            data_trimmed
+            data_encoded
         )
     else:
-        data_trimmed = data_encoded
-        return rank_divider.get_all_subdomains_with_flat_feature(data_trimmed)
+        return rank_divider.get_all_subdomains_with_flat_feature(data_encoded)
 
 
 def get_standard_normalizing_transformer(variables, sample_batch):

--- a/external/fv3fit/tests/reservoir/test_model_adapter.py
+++ b/external/fv3fit/tests/reservoir/test_model_adapter.py
@@ -160,8 +160,8 @@ def test_split_multi_subdomain_model():
     model = get_reservoir_computing_model(
         divider=divider, encoder=encoder, state_size=25, hybrid=True
     )
-    data = get_single_rank_xarray_data_with_overlap()["a"]
-    hybrid_data = get_single_rank_xarray_data()["a"]
+    data = get_single_rank_xarray_data_with_overlap()["a"].values
+    hybrid_data = get_single_rank_xarray_data()["a"].values
 
     model.increment_state([data])
     result = model.predict([hybrid_data])

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -65,7 +65,6 @@ def _get_sample_xyz_data(nx, ny, nz):
     return [a, b]
 
 
-# test encode w/ specified arrays
 @pytest.mark.parametrize("nz", [1, 2], ids=["single-level", "multi-level",])
 def test_scale_per_feature_concat_z_transform(nz):
     nx, ny = 3, 4
@@ -88,8 +87,26 @@ def test_scale_per_feature_concat_z_transform(nz):
     np.testing.assert_allclose(decoded, [a, b], rtol=1e-6)
 
 
-# test mask
-# test encode w/ specified arrays
+def test_scale_per_feature_concat_z_transform_no_leading_dim():
+    nx, ny, nz = 3, 4, 1
+    a, b = _get_sample_xyz_data(nx, ny, nz)
+
+    xyz_like = -1 * np.ones((nx, ny, nz))
+    normalized_and_stacked = np.concatenate([xyz_like, xyz_like], axis=-1)
+
+    transformer = build_scale_spatial_concat_z_transformer([a, b])
+    encoded = transformer.encode_txyz([a[0], b[0]])
+
+    # test that it normalizes
+    nvars = 2
+    assert encoded.shape == (nx, ny, nz * nvars)
+    np.testing.assert_allclose(encoded, normalized_and_stacked, rtol=1e-6)
+
+    # test round trip
+    decoded = transformer.decode_txyz(encoded)
+    np.testing.assert_allclose(decoded, [a[0], b[0]], rtol=1e-6)
+
+
 @pytest.mark.parametrize("nz", [1, 2], ids=["single-level", "multi-level",])
 def test_scale_per_feature_concat_z_transform_mask(nz):
     nx, ny = 3, 4

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -15,41 +15,36 @@ def test_DoNothingAutoencoder(nz, nvars):
     assert len(transformer.decode(encoded_data)) == len(data)
 
 
-# @pytest.mark.parametrize(
-#     "nt, nx, ny, nz, nvars",
-#     [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],
-# )
-# def test_encode_columns(nt, nx, ny, nz, nvars):
-#     shape = tuple([y for y in [nt, nx, ny, nz] if y is not None])
-#     expected_shape = (*shape[:-1], nz * nvars) if nz is not None else shape
-#     transformer = DoNothingAutoencoder([nz for var in range(nvars)])
-#     data_arrs = [np.random.rand(*shape) for var in range(nvars)]
+@pytest.mark.parametrize(
+    "nt, nx, ny, nz, nvars",
+    [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],
+)
+def test_base_encode_txyz(nt, nx, ny, nz, nvars):
+    shape = tuple([y for y in [nt, nx, ny, nz] if y is not None])
+    expected_shape = (*shape[:-1], nz * nvars) if nz is not None else shape
+    transformer = DoNothingAutoencoder([nz for var in range(nvars)])
+    data_arrs = [np.random.rand(*shape) for var in range(nvars)]
 
-#     encoded = encode_columns(data_arrs, transformer=transformer)
+    encoded = transformer.encode_txyz(data_arrs)
 
-#     assert encoded.shape == expected_shape
+    assert encoded.shape == expected_shape
 
 
-# @pytest.mark.parametrize(
-#     "nx, ny, nz, nvars", [(4, 4, 3, 2), (2, 2, 1, 1), (2, 2, 1, 2)]
-# )
-# def test_decode_columns(nx, ny, nz, nvars):
-#     expected_shapes = [
-#         tuple([y for y in [nx, ny, nz] if y is not None]) for var in range(nvars)
-#     ]
+@pytest.mark.parametrize(
+    "nx, ny, nz, nvars", [(4, 4, 3, 2), (2, 2, 1, 1), (2, 2, 1, 2)]
+)
+def test_base_decode_txyz(nx, ny, nz, nvars):
+    expected_shapes = [(nx, ny, nz) for var in range(nvars)]
 
-#     encoded_input_shape = (
-#         (*expected_shapes[0][:-1], nz * nvars) if nz is not None else expected_shapes[0] # noqa
-#     )
-#     transformer = DoNothingAutoencoder([nz for var in range(nvars)])
+    transformer = DoNothingAutoencoder([nz for var in range(nvars)])
 
-#     # need to call encode before decode
-#     data_arrs = [np.random.rand(*shape) for shape in expected_shapes]
-#     transformer.encode(data_arrs)
+    # need to call encode before decode
+    data_arrs = [np.random.rand(*shape) for shape in expected_shapes]
+    transformer.encode_txyz(data_arrs)
 
-#     encoded_input = np.random.rand(*encoded_input_shape)
-#     decoded = decode_columns(encoded_input, transformer=transformer)
+    encoded_input = np.random.rand(nx, ny, transformer.n_latent_dims)
+    decoded = transformer.decode_txyz(encoded_input)
 
-#     assert len(expected_shapes) == len(decoded)
-#     for expected_shape, decoded_output in zip(expected_shapes, decoded):
-#         assert expected_shape == decoded_output.shape
+    assert len(expected_shapes) == len(decoded)
+    for expected_shape, decoded_output in zip(expected_shapes, decoded):
+        assert expected_shape == decoded_output.shape

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -77,7 +77,7 @@ def test_scale_per_feature_concat_z_transform(nz):
     transformer = build_scale_spatial_concat_z_transformer([a, b])
     encoded = transformer.encode_unstacked_xyz([a, b])
 
-    # test that it normalizes
+    # test that it normalizes and encode reshaping
     nsamples, nvars = 2, 2
     assert encoded.shape == (nsamples, nx, ny, nz * nvars)
     np.testing.assert_allclose(encoded, normalized_and_stacked, rtol=1e-6)
@@ -85,6 +85,11 @@ def test_scale_per_feature_concat_z_transform(nz):
     # test round trip
     decoded = transformer.decode_unstacked_xyz(encoded)
     np.testing.assert_allclose(decoded, [a, b], rtol=1e-6)
+
+    # test correct decode reshaping
+    test_encoded = abs(np.concatenate([a, b], axis=-1))
+    decoded = transformer.decode_unstacked_xyz(test_encoded)
+    np.testing.assert_allclose(decoded, [a ** 2, b ** 2], rtol=1e-6)
 
 
 def test_scale_per_feature_concat_z_transform_no_leading_dim():

--- a/external/fv3fit/tests/reservoir/test_transformer.py
+++ b/external/fv3fit/tests/reservoir/test_transformer.py
@@ -1,11 +1,7 @@
 import numpy as np
 import pytest
 
-from fv3fit.reservoir.transformers.transformer import (
-    encode_columns,
-    DoNothingAutoencoder,
-    decode_columns,
-)
+from fv3fit.reservoir.transformers.transformer import DoNothingAutoencoder
 
 
 @pytest.mark.parametrize("nz, nvars", [(2, 2), (2, 1), (1, 2), (1, 1)])
@@ -19,41 +15,41 @@ def test_DoNothingAutoencoder(nz, nvars):
     assert len(transformer.decode(encoded_data)) == len(data)
 
 
-@pytest.mark.parametrize(
-    "nt, nx, ny, nz, nvars",
-    [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],
-)
-def test_encode_columns(nt, nx, ny, nz, nvars):
-    shape = tuple([y for y in [nt, nx, ny, nz] if y is not None])
-    expected_shape = (*shape[:-1], nz * nvars) if nz is not None else shape
-    transformer = DoNothingAutoencoder([nz for var in range(nvars)])
-    data_arrs = [np.random.rand(*shape) for var in range(nvars)]
+# @pytest.mark.parametrize(
+#     "nt, nx, ny, nz, nvars",
+#     [(20, 4, 4, 3, 2), (None, 2, 2, 1, 1), (None, 2, 2, None, 1)],
+# )
+# def test_encode_columns(nt, nx, ny, nz, nvars):
+#     shape = tuple([y for y in [nt, nx, ny, nz] if y is not None])
+#     expected_shape = (*shape[:-1], nz * nvars) if nz is not None else shape
+#     transformer = DoNothingAutoencoder([nz for var in range(nvars)])
+#     data_arrs = [np.random.rand(*shape) for var in range(nvars)]
 
-    encoded = encode_columns(data_arrs, transformer=transformer)
+#     encoded = encode_columns(data_arrs, transformer=transformer)
 
-    assert encoded.shape == expected_shape
+#     assert encoded.shape == expected_shape
 
 
-@pytest.mark.parametrize(
-    "nx, ny, nz, nvars", [(4, 4, 3, 2), (2, 2, 1, 1), (2, 2, 1, 2)]
-)
-def test_decode_columns(nx, ny, nz, nvars):
-    expected_shapes = [
-        tuple([y for y in [nx, ny, nz] if y is not None]) for var in range(nvars)
-    ]
+# @pytest.mark.parametrize(
+#     "nx, ny, nz, nvars", [(4, 4, 3, 2), (2, 2, 1, 1), (2, 2, 1, 2)]
+# )
+# def test_decode_columns(nx, ny, nz, nvars):
+#     expected_shapes = [
+#         tuple([y for y in [nx, ny, nz] if y is not None]) for var in range(nvars)
+#     ]
 
-    encoded_input_shape = (
-        (*expected_shapes[0][:-1], nz * nvars) if nz is not None else expected_shapes[0]
-    )
-    transformer = DoNothingAutoencoder([nz for var in range(nvars)])
+#     encoded_input_shape = (
+#         (*expected_shapes[0][:-1], nz * nvars) if nz is not None else expected_shapes[0] # noqa
+#     )
+#     transformer = DoNothingAutoencoder([nz for var in range(nvars)])
 
-    # need to call encode before decode
-    data_arrs = [np.random.rand(*shape) for shape in expected_shapes]
-    transformer.encode(data_arrs)
+#     # need to call encode before decode
+#     data_arrs = [np.random.rand(*shape) for shape in expected_shapes]
+#     transformer.encode(data_arrs)
 
-    encoded_input = np.random.rand(*encoded_input_shape)
-    decoded = decode_columns(encoded_input, transformer=transformer)
+#     encoded_input = np.random.rand(*encoded_input_shape)
+#     decoded = decode_columns(encoded_input, transformer=transformer)
 
-    assert len(expected_shapes) == len(decoded)
-    for expected_shape, decoded_output in zip(expected_shapes, decoded):
-        assert expected_shape == decoded_output.shape
+#     assert len(expected_shapes) == len(decoded)
+#     for expected_shape, decoded_output in zip(expected_shapes, decoded):
+#         assert expected_shape == decoded_output.shape

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -93,7 +93,7 @@ def test_process_batch_data_trim_workaround(encoder_shape):
         def __init__(self, expected_dimensions):
             self.expected_dimensions = expected_dimensions
 
-        def encode_txyz(self, data):
+        def encode_unstacked_xyz(self, data):
             if data[0].shape[-3:] != self.expected_dimensions:
                 raise ValueError(
                     f"Expected data shape {self.expected_dimensions} "

--- a/external/fv3fit/tests/reservoir/test_utils.py
+++ b/external/fv3fit/tests/reservoir/test_utils.py
@@ -75,6 +75,62 @@ def test_process_batch_data(nz, overlap, trim_halo):
     assert time_series.shape == (nt, rank_divider.n_subdomains, features_per_subdomain,)
 
 
+@pytest.mark.parametrize(
+    "encoder_shape",
+    [(8, 8, 3), (6, 6, 3)],
+    ids=["encoder_expects_halo_input", "encoder_expects_no_halo_input"],
+)
+def test_process_batch_data_trim_workaround(encoder_shape):
+    """
+    This is a temporary test for hanlding the processing when
+    an autoencoder may or may not expect trimmed input data.
+    Once we resolve this issue, this test should be removed.
+    Need some sort of standard on what type of data encoders
+    expect as inputs.
+    """
+
+    class TrimCheckAutoencoder:
+        def __init__(self, expected_dimensions):
+            self.expected_dimensions = expected_dimensions
+
+        def encode_txyz(self, data):
+            if data[0].shape[-3:] != self.expected_dimensions:
+                raise ValueError(
+                    f"Expected data shape {self.expected_dimensions} "
+                    f"but got {data[0].shape[-3:]}"
+                )
+            return data[0]
+
+    nt, nx, ny, nz = 10, 8, 8, 3
+    overlap = 1
+    subdomain_layout = (2, 2)
+    batch_data = {
+        "a": np.ones((nt, nx, ny, nz)),
+    }
+    rank_divider = RankXYDivider(
+        subdomain_layout=subdomain_layout,
+        overlap=overlap,
+        overlap_rank_extent=(nx, ny),
+        z_feature_size=nz,
+    )
+
+    encoder = TrimCheckAutoencoder(encoder_shape)
+
+    time_series = process_batch_data(
+        variables=["a"],
+        batch_data=batch_data,
+        rank_divider=rank_divider,
+        autoencoder=encoder,
+        trim_halo=True,
+    )
+    expected_shape = (
+        nt,
+        rank_divider.n_subdomains,
+        rank_divider.get_no_overlap_rank_divider().flat_subdomain_len,
+    )
+    assert time_series.shape == expected_shape
+
+
 def test_assure_txyz_dims():
     nt, nx, ny, nz = 5, 4, 4, 6
     arr_3d = np.ones((nt, nx, ny, nz))


### PR DESCRIPTION
Add a new encoder `_ScaleSpatialConcatZTransformer` built using `build_scale_spatial_concat_z_transformer` to perform a per grid-point normalization.  This matches the normalization used by Acomano et al. in their coupled atmosphere--ocean hybrid reservoir modeling.

Also adds a workaround for the batch processing in the training to account for the fact that an encoder may expect data with or without a halo.  Previously we assumed that when a halo was provided in the data to process and the output should be trimmed, the encoder would accept halo data.  We should probably standardize this.

Added public API:
- `build_scale_spatial_concat_z_transformer` - a function to create a transformer object that normalizes per grid point and combines along the z features.  (Currently requires all z features to be equivalent across included variables)

Refactored public API:
- `encode_columns` and `decode_columns` removed in favor of adding `encode/decode_txyz` methods to the base `Transformer` class.

Significant internal changes:
- Added a workaround for transformer use in processing tfdataset batch data that may or may not expect data with a halo

- [x] Tests added


Coverage reports (updated automatically):
