### PR TITLE
Scream specific update for end-to-end workflow

### DIFF
--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -285,8 +285,8 @@ def open_nudge_to_fine_scream(
     rename_vars: Mapping[Hashable, Hashable] = {
         "T_mid_tendency_due_to_nudging": "dQ1",
         "qv_tendency_due_to_nudging": "dQ2",
-        "U_tendency_due_to_nudging": "dQxwind",
-        "V_tendency_due_to_nudging": "dQywind",
+        "U_tendency_due_to_nudging": "dQu",
+        "V_tendency_due_to_nudging": "dQv",
         "tendency_of_U_due_to_scream_physics": "pQu",
         "tendency_of_V_due_to_scream_physics": "pQv",
         "tendency_of_T_mid_due_to_scream_physics": "pQ1",

--- a/projects/scream/scream_post/format_output.py
+++ b/projects/scream/scream_post/format_output.py
@@ -3,7 +3,7 @@ import xarray as xr
 import numpy as np
 import os
 import cftime
-import pandas as pd
+import util
 
 
 def make_placeholder_data(
@@ -69,33 +69,44 @@ def rename_delp(ds: xr.Dataset):
     return ds
 
 
-def convert_npdatetime_to_cftime(ds: xr.Dataset):
-    if isinstance(ds.time.values[0], np.datetime64):
-        cf_time = []
-        for date in ds.time.values:
-            date = pd.to_datetime(date)
-            cf_time.append(
-                cftime.DatetimeJulian(
-                    date.year,
-                    date.month,
-                    date.day,
-                    date.hour,
-                    date.minute,
-                    date.second,
-                )
-            )
-        ds["time"] = xr.DataArray(cf_time, coords=ds.time.coords, attrs=ds.time.attrs)
+def rename_water_vapor_path(ds: xr.Dataset):
+    return ds.rename({"VapWaterPath": "water_vapor_path"})
+
+
+def add_rad_fluxes(ds: xr.Dataset):
+    shortwave_transmissivity_of_atmospheric_column = (
+        ds.SW_flux_dn_at_model_bot / ds.SW_flux_dn_at_model_top
+    )
+    shortwave_transmissivity_of_atmospheric_column = shortwave_transmissivity_of_atmospheric_column.where(  # noqa
+        ds.SW_flux_dn_at_model_top != 0.0, 0.0
+    )
+    shortwave_transmissivity_of_atmospheric_column = shortwave_transmissivity_of_atmospheric_column.assign_attrs(  # noqa
+        units="-", long_name="shortwave transmissivity of atmosphericcolumn"
+    )
+    override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface = (  # noqa
+        ds.LW_flux_dn_at_model_bot
+    )
+    override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface = override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface.assign_attrs(  # noqa
+        units="W/m**2", long_name="surface downward longwave flux"
+    )
+    ds[
+        "shortwave_transmissivity_of_atmospheric_column"
+    ] = shortwave_transmissivity_of_atmospheric_column
+    ds[
+        "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface"
+    ] = override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface
     return ds
 
 
-def rename_lev_to_z(ds: xr.Dataset):
-    rename_vars = {"lev": "z", "ilev": "z_interface"}
-    rename_vars = {k: v for k, v in rename_vars.items() if k in ds.dims}
-    return ds.rename(rename_vars)
-
-
-def rename_water_vapor_path(ds: xr.Dataset):
-    return ds.rename({"VapWaterPath": "water_vapor_path"})
+def add_sfc_geopotential_height(
+    ds: xr.Dataset,
+    path="/usr/gdata/climdat/ccsm3data/inputdata/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc",  # noqa
+):
+    sfc_geo = xr.open_dataset(path)
+    phis = sfc_geo.PHIS
+    phis = phis.expand_dims(dim={"time": ds.time}, axis=0)
+    ds["surface_geopotential"] = phis
+    return ds
 
 
 def _get_parser() -> argparse.ArgumentParser:
@@ -114,13 +125,12 @@ def _get_parser() -> argparse.ArgumentParser:
         type=str,
         help="List of nudging variables deliminated with commas",
     )
-    parser.add_argument("chunk_size", type=int, help="Chunk size for output zarrs.")
     parser.add_argument(
-        "--split-horiz-winds",
-        type=bool,
-        default=False,
-        help="Split horiz_winds to u and v",
+        "tend_processes",
+        type=str,
+        help="List of tendency processes deliminated with commas",
     )
+    parser.add_argument("chunk_size", type=int, help="Chunk size for output zarrs.")
     parser.add_argument(
         "--calc-physics-tend",
         type=bool,
@@ -160,6 +170,22 @@ def _get_parser() -> argparse.ArgumentParser:
         default=False,
         help="Rename VapWaterPath to water_vapor_path",
     )
+
+    parser.add_argument(
+        "--split-horiz-winds-tend",
+        type=bool,
+        default=False,
+        help="Rename horiz_winds ",
+    )
+    parser.add_argument(
+        "--add-rad-fluxes",
+        type=bool,
+        default=False,
+        help="Add derived radiative fluxes",
+    )
+    parser.add_argument(
+        "--add-phis", type=bool, default=False, help="Add surface geopotential height",
+    )
     return parser
 
 
@@ -168,18 +194,35 @@ if __name__ == "__main__":
     args = parser.parse_args()
     ds = xr.open_mfdataset(args.input_data)
     nudging_vars = [str(item) for item in args.nudging_variables.split(",")]
+    if args.split_horiz_winds_tend:
+        tend_processes = [str(item) for item in args.tend_processes.split(",")]
+        for i in range(len(tend_processes)):
+            print(f"Splitting {tend_processes[i]} horiz winds tendency")
+            ds = util.split_horiz_winds_tend(ds, tend_processes[i])
     if args.calc_physics_tend:
+        print("Calculating scream physics tendencies")
         ds = compute_tendencies_due_to_scream_physics(ds, nudging_vars)
     if args.rename_nudging_tend:
+        print("Renaming nudging tendencies")
         ds = rename_nudging_tendencies(ds, nudging_vars)
     if args.rename_delp:
+        print("Renaming nudging delp")
         ds = rename_delp(ds)
     if args.convert_to_cftime:
-        ds = convert_npdatetime_to_cftime(ds)
+        print("Converting timestamps to cftime")
+        ds = util.convert_npdatetime_to_cftime(ds)
     if args.rename_lev_to_z:
-        ds = rename_lev_to_z(ds)
+        print("Renaming lev to z")
+        ds = util.rename_lev_to_z(ds)
     if args.rename_water_vapor_path:
+        print("Renaming water vapor path")
         ds = rename_water_vapor_path(ds)
+    if args.add_rad_fluxes:
+        print("Adding derived radiative fluxes")
+        ds = add_rad_fluxes(ds)
+    if args.add_phis:
+        print("Adding surface geopotential height")
+        ds = add_sfc_geopotential_height(ds)
     nudging_variables_tendencies = [
         f"{var}_tendency_due_to_nudging" for var in nudging_vars
     ]

--- a/projects/scream/scream_post/format_output.py
+++ b/projects/scream/scream_post/format_output.py
@@ -115,7 +115,7 @@ def _get_parser() -> argparse.ArgumentParser:
         "--catalog_path",
         type=str,
         default=vcm.catalog.catalog_path,
-        help=("The location of the catalog.yaml file"),
+        help="The location of the catalog.yaml file",
     )
     parser.add_argument(
         "--calc-physics-tend",

--- a/projects/scream/scream_post/translate_prognostic_output.py
+++ b/projects/scream/scream_post/translate_prognostic_output.py
@@ -1,6 +1,6 @@
 import argparse
 import xarray as xr
-from typing import Mapping, Hashable
+from typing import Mapping, Hashable, List
 import vcm
 import os
 from util import (
@@ -132,16 +132,17 @@ def add_additional_surface_fields(ds):
 
 
 def determine_nudging_or_ML_run(ds):
-    if "nudging_T_mid_tend" in ds.variables:
-        return "nudging"
-    elif "machine_learning_T_mid_tend" in ds.variables:
-        return "machine_learning"
-    else:
-        return None
+    label = None
+    for var in ds.variables:
+        if "nudging" in var:
+            label = "nudging"
+        elif "machine_learning" in var:
+            label = "machine_learning"
+    return label
 
 
 def compute_prognostic_run_diagnostics(
-    ds: xr.DataArray, label: str, tendency_variables: [], hydrostatic: bool = False
+    ds: xr.DataArray, label: str, tendency_variables: List, hydrostatic: bool = False
 ):
     """
     Compute diagnostics for a prognostic run

--- a/projects/scream/scream_post/translate_prognostic_output.py
+++ b/projects/scream/scream_post/translate_prognostic_output.py
@@ -23,7 +23,7 @@ SCREAM_TO_FV3_CONVENTION = {
     "VapWaterPath": "water_vapor_path",
     "ps": "PRESsfc",
     "pseudo_density": "pressure_thickness_of_atmospheric_layer",
-    "surf_evap": "LHTFLsfc",
+    "surf_evap": "surf_evap",
     "surf_sens_flux": "SHTFLsfc",
     "surf_radiative_T": "TMPsfc",
     "z_mid_at_500hPa": "h500",

--- a/projects/scream/scream_post/translate_prognostic_output.py
+++ b/projects/scream/scream_post/translate_prognostic_output.py
@@ -1,0 +1,274 @@
+import argparse
+import xarray as xr
+from typing import Mapping, Hashable
+import vcm
+import os
+from util import *
+
+SCREAM_TO_FV3_CONVENTION = {
+    "T_mid": "air_temperature",
+    "qv": "specific_humidity",
+    "U": "eastward_wind",
+    "V": "northward_wind",
+    "nudging_T_mid_tend": "air_temperature_tendency_due_to_nudging",
+    "nudging_qv_tend": "specific_humidity_tendency_due_to_nudging",
+    "nudging_U_tend": "eastward_wind_tendency_due_to_nudging",
+    "nudging_V_tend": "northward_wind_tendency_due_to_nudging",
+    "physics_T_mid_tend": "air_temperature_tendency_due_to_scream_physics",
+    "physics_qv_tend": "specific_humidity_tendency_due_to_scream_physics",
+    "machine_learning_U_tend": "dQu",
+    "machine_learning_V_tend": "dQv",    
+    "machine_learning_T_mid_tend": "dQ1",
+    "machine_learning_qv_tend": "dQ2",
+    "VapWaterPath": "water_vapor_path",
+    "ps": "PRESsfc",
+    "pseudo_density": "pressure_thickness_of_atmospheric_layer",
+    "surf_evap": "LHTFLsfc",
+    "surf_sens_flux": "SHTFLsfc",
+    "surf_radiative_T": "TMPsfc",
+    "z_mid_at_500hPa": "h500",
+    "T_mid_at_850hPa": "TMP850",
+    "T_mid_at_700hPa": "TMP700",
+    "T_mid_at_500hPa": "TMP500",
+    "T_mid_at_200hPa": "TMP200",
+    "omega_at_500hPa": "w500",
+    "RelativeHumidity_at_850hPa": "RH850",
+    "RelativeHumidity_at_700hPa": "RH700",
+    "RelativeHumidity_at_500hPa": "RH500",
+    "SeaLevelPressure": "PRMSL",
+    "SW_flux_dn_at_model_bot": "DSWRFsfc",
+    "LW_flux_dn_at_model_bot": "DLWRFsfc",
+    "LW_flux_up_at_model_bot": "ULWRFsfc",
+    "SW_flux_up_at_model_bot": "USWRFsfc",    
+    "SW_flux_up_at_model_top": "USWRFtoa",
+    "LW_flux_up_at_model_top": "ULWRFtoa",
+    "SW_flux_dn_at_model_top": "DSWRFtoa",
+}
+
+RENAME_ML_CORRECTION_TO_MACHINE_LEARNING = {
+    "mlcorrection_T_mid_tend": "machine_learning_T_mid_tend",
+    "mlcorrection_qv_tend": "machine_learning_qv_tend",
+    "mlcorrection_horiz_winds_tend": "machine_learning_horiz_winds_tend",
+}
+
+TEMP = "T_mid"
+SPHUM = "qv"
+DELP = "pseudo_density"
+EASTWARD_WIND = "U"
+NORTHWARD_WIND = "V"
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "input_data",
+        type=str,
+        default=None,
+        help=("Input netcdf."),
+    )
+    parser.add_argument(
+        "output_path",
+        type=str,
+        help="Local or remote path where output will be written.",
+    )
+    parser.add_argument(
+        "process_label",
+        type=str,
+        help="Either nudging or machine_learning",
+    )
+    parser.add_argument(
+        "nudging_variables",
+        type=str,
+        help="List of nudging variables deliminated with commas",
+    )
+    parser.add_argument("chunk_size", type=int, help="Chunk size for output zarrs.")
+    parser.add_argument("save_to_disk", type=str, help="Either 2d or 3d.")
+    parser.add_argument(
+        "--subset",
+        help="Whether to subset to a smaller set of timesteps",
+        action="store_true",
+    )    
+    return parser
+
+
+def compute_PRATEsfc(ds):
+    """
+    Compute PRATEsfc from precip_liq_surf_mass_flux and precip_ice_surf_mass_flux
+    """
+    if "PrecipIceSurfMassFlux" in ds.variables:
+        ds = ds.rename({"PrecipIceSurfMassFlux": "precip_liq_surf_mass_flux"})
+    if "PrecipLiqSurfMassFlux" in ds.variables:
+            ds = ds.rename({"PrecipLiqSurfMassFlux": "precip_ice_surf_mass_flux"})        
+    PRATEsfc = (ds.precip_liq_surf_mass_flux + ds.precip_ice_surf_mass_flux) * 1000.0
+    PRATEsfc = PRATEsfc.assign_attrs(units="kg/m^2/s")
+    return PRATEsfc
+
+def add_additional_surface_fields(ds):
+    """
+    Add shortwave_transmissivity_of_atmospheric_column
+    and override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface
+    for training ML radiaitve fluxes
+    """
+    shortwave_transmissivity_of_atmospheric_column = ds.SW_flux_dn_at_model_bot / ds.SW_flux_dn_at_model_top
+    shortwave_transmissivity_of_atmospheric_column = shortwave_transmissivity_of_atmospheric_column.where(ds.SW_flux_dn_at_model_top!=0.,0.)
+    shortwave_transmissivity_of_atmospheric_column = shortwave_transmissivity_of_atmospheric_column.assign_attrs(units="-", long_name="shortwave transmissivity of atmospheric column")
+    override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface = ds.LW_flux_dn_at_model_bot
+    override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface = override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface.assign_attrs(units="W/m**2", long_name="surface downward longwave flux")
+    ds["shortwave_transmissivity_of_atmospheric_column"] = shortwave_transmissivity_of_atmospheric_column
+    ds["override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface"] = override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface
+    return ds
+
+def compute_prognostic_run_diagnostics(
+    ds: xr.DataArray, label: str, tendency_variables: [], hydrostatic: bool = False
+):
+    """
+    Compute diagnostics for a prognostic run
+
+    Args:
+        ds: xarray dataset containing prognostic run output
+        label: either "machine_learning" or "nudging"
+        tendency_variables: list of variables that are either nudged or ML corrected
+        hydrostatic: whether the run is hydrostatic
+    """
+    delp = ds[DELP]
+    temperature_tendency_name = f"{label}_{TEMP}_tend"
+    humidity_tendency_name = f"{label}_{SPHUM}_tend"
+    temperature_tendency = ds[temperature_tendency_name]
+    humidity_tendency = ds[humidity_tendency_name]
+    water_vapor_path = ds["VapWaterPath"]
+    # compute column-integrated diagnostics
+    if hydrostatic:
+        net_heating = vcm.column_integrated_heating_from_isobaric_transition(
+            temperature_tendency, delp, "lev"
+        )
+    else:
+        net_heating = vcm.column_integrated_heating_from_isochoric_transition(
+            temperature_tendency, delp, "lev"
+        )
+    diags = {
+        f"net_moistening_due_to_{label}": vcm.mass_integrate(
+            humidity_tendency, delp, dim="lev"
+        ).assign_attrs(
+            units="kg/m^2/s",
+            description=f"column integrated moisture tendency due to {label}",
+        ),
+        f"column_heating_due_to_{label}": net_heating.assign_attrs(
+            units="W/m^2"
+        ).assign_attrs(description=f"column integrated heating due to {label}"),
+        f"water_vapor_path": water_vapor_path.assign_attrs(units="kg/m^2").assign_attrs(
+            description=f"water vapor path"
+        ),
+    }
+    # add 3D tendencies to diagnostics
+    if label == "nudging":
+        diags_3d: Mapping[Hashable, xr.DataArray] = {
+            f"{k}_tendency_due_to_nudging": ds[f"{label}_{k}_tend"]
+            for k in tendency_variables
+        }
+    elif label == "machine_learning":
+        diags_3d = {
+            "dQ1": temperature_tendency.assign_attrs(units="K/s").assign_attrs(
+                description=f"air temperature tendency due to {label}"
+            ),
+            "dQ2": humidity_tendency.assign_attrs(units="kg/kg/s").assign_attrs(
+                description=f"specific humidity tendency due to {label}"
+            ),
+        }
+    diags.update(diags_3d)
+    if label == "machine_learning" and "U" in tendency_variables and "V" in tendency_variables:
+        diags.update(compute_ml_momentum_diagnostics(ds))
+    return xr.Dataset(diags)
+
+def compute_ml_momentum_diagnostics(ds: xr.DataArray):
+    delp = ds[DELP]
+    dQu = ds["machine_learning_U_tend"]
+    dQv = ds["machine_learning_V_tend"]
+    column_integrated_dQu = vcm.mass_integrate(dQu, delp, "lev")
+    column_integrated_dQv = vcm.mass_integrate(dQv, delp, "lev")
+    momentum = dict(
+        dQu=dQu.assign_attrs(units="m s^-2").assign_attrs(
+            description="zonal wind tendency due to ML"
+        ),
+        dQv=dQv.assign_attrs(units="m s^-2").assign_attrs(
+            description="meridional wind tendency due to ML"
+        ),
+        column_integrated_dQu_stress=column_integrated_dQu.assign_attrs(
+            units="Pa", description="column integrated zonal wind tendency due to ML",
+        ),
+        column_integrated_dQv_stress=column_integrated_dQv.assign_attrs(
+            units="Pa",
+            description="column integrated meridional wind tendency due to ML",
+        ),
+    )
+    return xr.Dataset(momentum)
+
+def truncate_and_rename_scream_variables(ds: xr.Dataset):
+    output_var_list = [
+        var for var in SCREAM_TO_FV3_CONVENTION.keys() if var in ds.variables
+    ]
+    grid_var = ["lat", "lon", "area"]
+    output_var_list += grid_var
+    ds["PRATEsfc"] = compute_PRATEsfc(ds)
+    ds = add_additional_surface_fields(ds)
+    output_var_list += ["PRATEsfc", "shortwave_transmissivity_of_atmospheric_column", "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface"]
+    ds = ds[output_var_list]
+    rename_vars = {k: v for k, v in SCREAM_TO_FV3_CONVENTION.items() if k in ds}
+    ds = ds.rename(rename_vars)
+    return ds
+
+def convert_time_and_change_lev_to_z(ds):
+    ds = convert_npdatetime_to_cftime(ds)
+    ds = rename_lev_to_z(ds)
+    return ds    
+
+def get_3d_vars(ds: xr.Dataset):
+    return [var for var in ds.variables if ds[var].dims == ("time", "ncol", "z")]
+
+
+def get_2d_vars(ds: xr.Dataset):
+    return [var for var in ds.variables if ds[var].dims == ("time", "ncol")]
+
+
+if __name__ == "__main__":
+    parser = _get_parser()
+    args = parser.parse_args()
+    ds = xr.open_mfdataset(args.input_data)
+    if args.subset:
+        ds = ds.isel(time=slice(100))
+    nudging_vars = [str(item) for item in args.nudging_variables.split(",")]
+    if args.process_label == "machine_learning":
+        rename_vars = {
+            k: v for k, v in RENAME_ML_CORRECTION_TO_MACHINE_LEARNING.items() if k in ds
+        }
+        ds = ds.rename(rename_vars)
+    if "U" in nudging_vars or "V" in nudging_vars:
+        ds = split_horiz_winds_tend(ds, args.process_label)
+    if args.process_label == "nudging" or args.process_label == "machine_learning":
+        diags = compute_prognostic_run_diagnostics(ds, args.process_label, nudging_vars)
+        ds = truncate_and_rename_scream_variables(ds)    
+        ds = ds.drop(
+            [var for var in ds.variables if var in diags.variables and var != "time"]
+        )
+        ds = xr.merge([ds, diags])
+    else:
+        ds = truncate_and_rename_scream_variables(ds)
+    ds = convert_time_and_change_lev_to_z(ds)
+    grid_var = ["lat", "lon", "area"]
+    ds_2d = ds[grid_var + get_2d_vars(ds)]
+    ds_3d = ds[grid_var + get_3d_vars(ds)]
+    if args.save_to_disk == "2d":
+        ds_2d.chunk({"time": args.chunk_size}).to_zarr(
+            os.path.join(args.output_path, "data_2d.zarr"), consolidated=True
+        )
+    elif args.save_to_disk == "3d":    
+        ds_3d.chunk({"time": args.chunk_size}).to_zarr(
+            os.path.join(args.output_path, "data_3d.zarr"), consolidated=True
+        )
+    elif args.save_to_disk == "all": 
+        ds_2d.chunk({"time": args.chunk_size}).to_zarr(
+            os.path.join(args.output_path, "data_2d.zarr"), consolidated=True
+        )        
+        ds_3d.chunk({"time": args.chunk_size}).to_zarr(
+            os.path.join(args.output_path, "data_3d.zarr"), consolidated=True
+        )

--- a/projects/scream/scream_post/util.py
+++ b/projects/scream/scream_post/util.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import cftime
 
+
 def convert_npdatetime_to_cftime(ds: xr.Dataset):
     if isinstance(ds.time.values[0], np.datetime64):
         cf_time = []
@@ -26,6 +27,7 @@ def rename_lev_to_z(ds: xr.Dataset):
     rename_vars = {"lev": "z", "ilev": "z_interface"}
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds.dims}
     return ds.rename(rename_vars)
+
 
 def split_horiz_winds_tend(ds: xr.Dataset, label: str):
     u = ds[f"{label}_horiz_winds_tend"].isel(dim2=0).rename({f"{label}_U_tend"})

--- a/projects/scream/scream_post/util.py
+++ b/projects/scream/scream_post/util.py
@@ -1,0 +1,36 @@
+import xarray as xr
+import numpy as np
+import pandas as pd
+import cftime
+
+def convert_npdatetime_to_cftime(ds: xr.Dataset):
+    if isinstance(ds.time.values[0], np.datetime64):
+        cf_time = []
+        for date in ds.time.values:
+            date = pd.to_datetime(date)
+            cf_time.append(
+                cftime.DatetimeJulian(
+                    date.year,
+                    date.month,
+                    date.day,
+                    date.hour,
+                    date.minute,
+                    date.second,
+                )
+            )
+        ds["time"] = xr.DataArray(cf_time, coords=ds.time.coords, attrs=ds.time.attrs)
+    return ds
+
+
+def rename_lev_to_z(ds: xr.Dataset):
+    rename_vars = {"lev": "z", "ilev": "z_interface"}
+    rename_vars = {k: v for k, v in rename_vars.items() if k in ds.dims}
+    return ds.rename(rename_vars)
+
+def split_horiz_winds_tend(ds: xr.Dataset, label: str):
+    u = ds[f"{label}_horiz_winds_tend"].isel(dim2=0).rename({f"{label}_U_tend"})
+    v = ds[f"{label}_horiz_winds_tend"].isel(dim2=1).rename({f"{label}_V_tend"})
+    ds = ds.drop(f"{label}_horiz_winds_tend")
+    ds[f"{label}_U_tend"] = u
+    ds[f"{label}_V_tend"] = v
+    return ds

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -121,6 +121,7 @@ DIURNAL_CYCLE_VARS = [
     "total_precip_to_surface",
     "PRATEsfc",
     "LHTFLsfc",
+    "surf_evap",
 ]
 
 TIME_MEAN_VARS = [

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/derived_variables.py
@@ -83,7 +83,10 @@ def _column_pq1(ds: xr.Dataset) -> xr.DataArray:
 
 
 def _column_pq2(ds: xr.Dataset) -> xr.DataArray:
-    evap = vcm.latent_heat_flux_to_evaporation(ds.LHTFLsfc)
+    if "surf_evap" in ds.variables:
+        evap = ds.surf_evap
+    else:
+        evap = vcm.latent_heat_flux_to_evaporation(ds.LHTFLsfc)
     column_pq2 = SECONDS_PER_DAY * (evap - ds.PRATEsfc)
     column_pq2.attrs = {
         "long_name": "<pQ2> column integrated moistening from physics",

--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/diurnal_cycle.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/diurnal_cycle.py
@@ -53,8 +53,10 @@ def _add_diurnal_moisture_components(diurnal_cycles: xr.Dataset):
     and attributes.  The naming is used by report generation to determine the
     component shorthand.  E.g., diurn_component_<component_name>
     """
-
-    evap = vcm.latent_heat_flux_to_evaporation(diurnal_cycles["LHTFLsfc"])
+    if "surf_evap" in diurnal_cycles.variables:
+        evap = diurnal_cycles.surf_evap
+    else:
+        evap = vcm.latent_heat_flux_to_evaporation(diurnal_cycles["LHTFLsfc"])
     evap *= SECONDS_PER_DAY
     evap.attrs = {"long_name": "Evaporation", "units": "mm/day"}
     diurnal_cycles["diurn_component_evaporation"] = evap


### PR DESCRIPTION
This PR includes various changes required to work with the latest round of scream native output with the end-to-end workflow (training and prognostic_run diag).

Significant internal changes:
- `external/loaders/loaders/mappers/_nudged/_nudged.py`: renaming from `dQxwind` to `dQu` - there's only one definition of horizontal wind in scream and the output is `u` and `v`
- `projects/scream/scream_post/format_output.py`: adding additional fields we need to post process for training surface radiative fluxes
- `projects/scream/scream_post/translate_prognostic_output.py`: we use this script to post process scream online prognostic run output, then run them through prognostic_run diag
- `projects/scream/scream_post/util.py`: moved several functions shared between format_output and translate_prognostic_output
- `constants.py`, `derived_variables.py`, `diurnal_cycle.py`: scream outputs `surf_evap`, which is different from fv3's `LHTFLsfc`. We allow `surf_evap` to be a valid variable when present in the dataset and treat it as evaporation.

