### PR TITLE
fv3kube: update `package_data` in `setup.py`

### DIFF
--- a/external/fv3kube/setup.py
+++ b/external/fv3kube/setup.py
@@ -9,6 +9,6 @@ setup(
     author_email="oliverwm@allenai.org",
     packages=find_packages(),
     package_dir={"": "."},
-    package_data={"fv3kube": ["base_yamls/*/fv3config.yml"]},
+    package_data={"fv3kube": ["base_yamls/**/**/fv3config.yml"]},
     install_requires=["fsspec>=0.7.4", "pyyaml>=5.3.0", "kubernetes>=11", "fv3config"],
 )


### PR DESCRIPTION
#2377 reorganized the `base_yamls` directory in fv3kube to make room for SHiELD reference configurations, but neglected to update the `package_data` parameter in `setup.py` accordingly.  Without this change, installing `fv3kube` via something like:

```
$ pip install git+https://github.com/ai2cm/fv3net.git@b8e2f83b5206539724a4d096d0433ceeb3bc805a#egg=fv3kube&subdirectory=external/fv3kube
```

does not include the `base_yamls` files, which are an important component of the library.  I've tested this locally and it fixes the issue, e.g. use:

```
$ pip install git+https://github.com/ai2cm/fv3net.git@8fe01cd6c49ea635a1b07afd4ee4615db7555ce6#egg=fv3kube&subdirectory=external/fv3kube
```

and check for the existence of the `base_yamls` directory (note the different SHA from the original example).