### PR TITLE
Add NIR/VIS diffuse/direct fractions to derived variables

### DIFF
--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -2,12 +2,15 @@ import abc
 from typing import Hashable, Iterable, Tuple
 from fv3fit._shared.predictor import Predictor
 import xarray as xr
+
 try:
     import cupy as cp
-    import cupy_xarray
+    import cupy_xarray  # noqa
+
     xp = cp
 except ImportError:
     import numpy as np
+
     xp = np
 
 import logging
@@ -46,11 +49,7 @@ class NoveltyDetector(Predictor, abc.ABC):
         diagnostics = self.predict(X)
 
         arr = diagnostics[self._CENTERED_SCORE_OUTPUT_VAR].data
-        logger.info(f"In predict_novelty array type and device: {type(arr)} {arr.device} {arr.dtype}")
-
-        is_novelty = xr.where(
-            diagnostics[self._CENTERED_SCORE_OUTPUT_VAR] > cutoff, np.asarray(1), np.asarray(0)
-        )
+        is_novelty = xr.where(arr > cutoff, np.asarray(1), np.asarray(0),)
         diagnostics[self._NOVELTY_OUTPUT_VAR] = is_novelty
 
         return diagnostics[self._CENTERED_SCORE_OUTPUT_VAR], diagnostics

--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -48,8 +48,11 @@ class NoveltyDetector(Predictor, abc.ABC):
     ) -> Tuple[xr.DataArray, xr.Dataset]:
         diagnostics = self.predict(X)
 
-        arr = diagnostics[self._CENTERED_SCORE_OUTPUT_VAR].data
-        is_novelty = xr.where(arr > cutoff, xp.asarray(1), xp.asarray(0),)
+        is_novelty = xr.where(
+            diagnostics[self._CENTERED_SCORE_OUTPUT_VAR] > cutoff,
+            xp.asarray(1),
+            xp.asarray(0),
+        )
         diagnostics[self._NOVELTY_OUTPUT_VAR] = is_novelty
 
         return diagnostics[self._CENTERED_SCORE_OUTPUT_VAR], diagnostics

--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -2,8 +2,13 @@ import abc
 from typing import Hashable, Iterable, Tuple
 from fv3fit._shared.predictor import Predictor
 import xarray as xr
-import cupy_xarray
-import cupy as cp
+try:
+    import cupy as cp
+    import cupy_xarray
+    xp = cp
+except ImportError:
+    import numpy as np
+    xp = np
 
 import logging
 
@@ -44,7 +49,7 @@ class NoveltyDetector(Predictor, abc.ABC):
         logger.info(f"In predict_novelty array type and device: {type(arr)} {arr.device} {arr.dtype}")
 
         is_novelty = xr.where(
-            diagnostics[self._CENTERED_SCORE_OUTPUT_VAR] > cutoff, cp.asarray(1), cp.asarray(0)
+            diagnostics[self._CENTERED_SCORE_OUTPUT_VAR] > cutoff, np.asarray(1), np.asarray(0)
         )
         diagnostics[self._NOVELTY_OUTPUT_VAR] = is_novelty
 

--- a/external/fv3fit/fv3fit/_shared/novelty_detector.py
+++ b/external/fv3fit/fv3fit/_shared/novelty_detector.py
@@ -49,7 +49,7 @@ class NoveltyDetector(Predictor, abc.ABC):
         diagnostics = self.predict(X)
 
         arr = diagnostics[self._CENTERED_SCORE_OUTPUT_VAR].data
-        is_novelty = xr.where(arr > cutoff, np.asarray(1), np.asarray(0),)
+        is_novelty = xr.where(arr > cutoff, xp.asarray(1), xp.asarray(0),)
         diagnostics[self._NOVELTY_OUTPUT_VAR] = is_novelty
 
         return diagnostics[self._CENTERED_SCORE_OUTPUT_VAR], diagnostics

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -19,7 +19,7 @@ import pandas as pd
 import tensorflow as tf
 
 try:
-    import cupy_xarray
+    import cupy_xarray  # noqa
 except ImportError:
     pass
 

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 
 try:
     import cupy_xarray  # noqa
+
     CUPY_AVAILABLE = True
 except ImportError:
     CUPY_AVAILABLE = False

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -15,6 +15,7 @@ from .config import PackerConfig, SliceConfig
 import dataclasses
 import numpy as np
 import xarray as xr
+import cupy_xarray
 import pandas as pd
 import tensorflow as tf
 
@@ -120,9 +121,9 @@ def pack(
 
     data_clipped = xr.Dataset(clip(data, config.clip))
     stacked = data_clipped.to_stacked_array(feature_dim_name, sample_dims=sample_dims)
-    stacked = stacked.dropna(feature_dim_name)
+    # stacked = stacked.dropna(feature_dim_name)
     return (
-        stacked.transpose(*sample_dims, feature_dim_name).values,
+        stacked.transpose(*sample_dims, feature_dim_name).data,
         stacked.indexes[feature_dim_name],
     )
 

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -24,7 +24,6 @@ try:
     CUPY_AVAILABLE = True
 except ImportError:
     CUPY_AVAILABLE = False
-    pass
 
 
 def _feature_dims(data: xr.Dataset, sample_dims: Sequence[str]) -> Sequence[str]:

--- a/external/fv3fit/fv3fit/_shared/packer.py
+++ b/external/fv3fit/fv3fit/_shared/packer.py
@@ -15,9 +15,13 @@ from .config import PackerConfig, SliceConfig
 import dataclasses
 import numpy as np
 import xarray as xr
-import cupy_xarray
 import pandas as pd
 import tensorflow as tf
+
+try:
+    import cupy_xarray
+except ImportError:
+    pass
 
 
 def _feature_dims(data: xr.Dataset, sample_dims: Sequence[str]) -> Sequence[str]:

--- a/external/fv3fit/fv3fit/_shared/taper_function.py
+++ b/external/fv3fit/fv3fit/_shared/taper_function.py
@@ -5,7 +5,8 @@ import logging
 
 try:
     import cupy as cp
-    import cupy_xarray
+    import cupy_xarray  # noqa
+
     CUPY_AVAILABLE = True
 except ImportError:
     CUPY_AVAILABLE = False
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 def _is_cupy_array(arr):
     return CUPY_AVAILABLE and isinstance(arr, cp.ndarray)
+
 
 def get_xpy_module(arr):
     return cp if _is_cupy_array(arr) else np
@@ -30,7 +32,9 @@ def taper_mask(
     """
     arr = novelty_score.data
     xp = get_xpy_module(arr)
-    logger.info(f"In taper_mask array type and device: {type(arr)} {arr.device} {arr.dtype}")
+    logger.info(
+        f"In taper_mask array type and device: {type(arr)} {arr.device} {arr.dtype}"
+    )
     return xr.where(novelty_score > cutoff, xp.asarray(0), xp.asarray(1))
 
 

--- a/external/fv3fit/fv3fit/_shared/taper_function.py
+++ b/external/fv3fit/fv3fit/_shared/taper_function.py
@@ -32,9 +32,6 @@ def taper_mask(
     """
     arr = novelty_score.data
     xp = get_xpy_module(arr)
-    logger.info(
-        f"In taper_mask array type and device: {type(arr)} {arr.device} {arr.dtype}"
-    )
     return xr.where(novelty_score > cutoff, xp.asarray(0), xp.asarray(1))
 
 

--- a/external/fv3fit/fv3fit/data/batches.py
+++ b/external/fv3fit/fv3fit/data/batches.py
@@ -48,9 +48,7 @@ def cache(
 ) -> loaders.typing.Batches:
     logger.info("saving batches data to %s", local_download_path)
     os.makedirs(local_download_path, exist_ok=True)
-    save_batches(
-        batches, output_path=local_download_path,
-    )
+    save_batches(batches, output_path=local_download_path, num_jobs=4)
     return loaders.batches_from_netcdf(
         path=local_download_path, variable_names=variable_names
     )

--- a/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
@@ -130,4 +130,9 @@ class TrainingLoopConfig:
                 )
             else:
                 validation_fit = None
-            model.fit(Xy_fit, validation_data=validation_fit, verbose=self.log_verbosity, **fit_kwargs)
+            model.fit(
+                Xy_fit,
+                validation_data=validation_fit,
+                verbose=self.log_verbosity,
+                **fit_kwargs,
+            )

--- a/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
+++ b/external/fv3fit/fv3fit/keras/_models/shared/training_loop.py
@@ -74,6 +74,7 @@ class TrainingLoopConfig:
     shuffle_buffer_size: int = 50_000
     batch_size: int = 16
     in_memory: bool = True
+    log_verbosity: int = 1
 
     def __post_init__(self):
         if self.in_memory:
@@ -110,6 +111,7 @@ class TrainingLoopConfig:
                 y=Xy_fit[1],
                 validation_data=validation_fit,
                 batch_size=self.batch_size,
+                verbose=self.log_verbosity,
                 **fit_kwargs,
             )
         else:
@@ -128,4 +130,4 @@ class TrainingLoopConfig:
                 )
             else:
                 validation_fit = None
-            model.fit(Xy_fit, validation_data=validation_fit, **fit_kwargs)
+            model.fit(Xy_fit, validation_data=validation_fit, verbose=self.log_verbosity, **fit_kwargs)

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -6,7 +6,13 @@ import dacite
 import fsspec
 import joblib
 import numpy as np
-import cupy as cp
+
+try:
+    import cupy as cp
+    import cupy_xarray
+    xp = cp
+except ImportError:
+    xp = np
 
 from sklearn.pipeline import Pipeline, make_pipeline
 import yaml
@@ -130,7 +136,7 @@ class OCSVMNoveltyDetector(NoveltyDetector):
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
         )
         stacked_scores = -1 * self.pipeline.score_samples(X.get())
-        stacked_scores = cp.asarray(stacked_scores)
+        stacked_scores = xp.asarray(stacked_scores)
         self.logger.info(
             f"stcked_scores type and device {type(stacked_scores)} "
             f"{stacked_scores.device} {stacked_scores.dtype}"

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -136,12 +136,8 @@ class OCSVMNoveltyDetector(NoveltyDetector):
         X, _ = pack(
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
         )
-        stacked_scores = -1 * self.pipeline.score_samples(X.get())
+        stacked_scores = -1 * self.pipeline.score_samples(np.asarray(X))
         stacked_scores = xp.asarray(stacked_scores)
-        self.logger.info(
-            f"stcked_scores type and device {type(stacked_scores)} "
-            f"{stacked_scores.device} {stacked_scores.dtype}"
-        )
 
         new_coords = {
             k: v for (k, v) in stacked_data.coords.items() if k not in Z_DIM_NAMES

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -6,6 +6,7 @@ import dacite
 import fsspec
 import joblib
 import numpy as np
+import cupy as cp
 
 from sklearn.pipeline import Pipeline, make_pipeline
 import yaml
@@ -128,7 +129,12 @@ class OCSVMNoveltyDetector(NoveltyDetector):
         X, _ = pack(
             stacked_data[self.input_variables], [SAMPLE_DIM_NAME], self.packer_config
         )
-        stacked_scores = -1 * self.pipeline.score_samples(X)
+        stacked_scores = -1 * self.pipeline.score_samples(X.get())
+        stacked_scores = cp.asarray(stacked_scores)
+        self.logger.info(
+            f"stcked_scores type and device {type(stacked_scores)} "
+            f"{stacked_scores.device} {stacked_scores.dtype}"
+        )
 
         new_coords = {
             k: v for (k, v) in stacked_data.coords.items() if k not in Z_DIM_NAMES

--- a/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
+++ b/external/fv3fit/fv3fit/sklearn/_ocsvm_novelty_detector.py
@@ -9,7 +9,8 @@ import numpy as np
 
 try:
     import cupy as cp
-    import cupy_xarray
+    import cupy_xarray  # noqa
+
     xp = cp
 except ImportError:
     xp = np

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -75,7 +75,9 @@ def save_batches(batches, output_path, num_jobs):
     logger.info(f"batches object created, saving {n_batches} batches to {output_path}")
     os.makedirs(output_path, exist_ok=True)
 
-    jobs = [joblib.delayed(_save_batch)((i, batches, output_path)) for i in range(n_batches)]
+    jobs = [
+        joblib.delayed(_save_batch)((i, batches, output_path)) for i in range(n_batches)
+    ]
     joblib.Parallel(n_jobs=num_jobs)(jobs)
 
 

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -75,7 +75,7 @@ def save_batches(batches, output_path, num_jobs):
     logger.info(f"batches object created, saving {n_batches} batches to {output_path}")
     os.makedirs(output_path, exist_ok=True)
 
-    jobs = joblib.delayed(_save_batch)((i, batches, output_path) for i in range(n_batches))
+    jobs = [joblib.delayed(_save_batch)((i, batches, output_path)) for i in range(n_batches)]
     joblib.Parallel(n_jobs=num_jobs)(jobs)
 
 

--- a/external/loaders/loaders/batches/save.py
+++ b/external/loaders/loaders/batches/save.py
@@ -7,6 +7,7 @@ import os.path
 import logging
 import sys
 import os
+import joblib
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -39,6 +40,12 @@ def get_parser() -> argparse.ArgumentParser:
             "passed to BatchesLoader.load_batches"
         ),
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=8,
+        help="number of workers to use when saving batches",
+    )
     return parser
 
 
@@ -48,22 +55,28 @@ def main(data_config: str, output_path: str, variable_names: Sequence[str]):
     loader = BatchesLoader.from_dict(config)
     logger.info("configuration loaded, creating batches object")
     batches = loader.load_batches(variables=variable_names)
-    save_batches(batches, output_path)
+    save_batches(batches, output_path, num_jobs=args.num_workers)
 
 
-def save_batches(batches, output_path):
+def _save_batch(args):
+    i, batches, output_path = args
+    out_filename = os.path.join(output_path, f"{i:05}.nc")
+    logger.info(f"saving batch {i}")
+    try:
+        batches[i].to_netcdf(out_filename, engine="h5netcdf")
+    except NotImplementedError:
+        batches[i].reset_index(dims_or_levels=[SAMPLE_DIM_NAME]).to_netcdf(
+            out_filename, engine="h5netcdf"
+        )
+
+
+def save_batches(batches, output_path, num_jobs):
     n_batches = len(batches)
     logger.info(f"batches object created, saving {n_batches} batches to {output_path}")
     os.makedirs(output_path, exist_ok=True)
-    for i, batch in enumerate(batches):
-        out_filename = os.path.join(output_path, f"{i:05}.nc")
-        logger.info(f"saving batch {i}")
-        try:
-            batch.to_netcdf(out_filename, engine="h5netcdf")
-        except NotImplementedError:
-            batch.reset_index(dims_or_levels=[SAMPLE_DIM_NAME]).to_netcdf(
-                out_filename, engine="h5netcdf"
-            )
+
+    jobs = joblib.delayed(_save_batch)((i, batches, output_path) for i in range(n_batches))
+    joblib.Parallel(n_jobs=num_jobs)(jobs)
 
 
 if __name__ == "__main__":

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -10,6 +10,11 @@ from .._xarray import XarrayMapper
 from loaders._config import mapper_functions
 from loaders.typing import Mapper
 
+try:
+    import vcm
+except ImportError:
+    vcm = None
+
 logger = logging.getLogger(__name__)
 
 Z_DIM_NAME = "z"
@@ -293,4 +298,7 @@ def open_nudge_to_fine_scream(
         "tendency_of_qv_due_to_scream_physics": "pQ2",
     }
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds}
-    return XarrayMapper(ds.rename(rename_vars))
+    mapper = XarrayMapper(ds.rename(rename_vars))
+    if vcm is not None:
+        mapper = vcm.DerivedMapping(mapper)
+    return mapper

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -291,6 +291,13 @@ def open_nudge_to_fine_scream(
         "tendency_of_V_due_to_scream_physics": "pQv",
         "tendency_of_T_mid_due_to_scream_physics": "pQ1",
         "tendency_of_qv_due_to_scream_physics": "pQ2",
+        "LW_flux_dn_at_model_bot": "total_sky_downward_longwave_flux_at_surface",
+        "LW_flux_up_at_model_bot": "total_sky_upward_longwave_flux_at_surface",
+        "LW_flux_up_at_model_top": "total_sky_upward_longwave_flux_at_top_of_atmosphere",
+        "SW_flux_dn_at_model_bot": "total_sky_downward_shortwave_flux_at_surface",
+        "SW_flux_up_at_model_bot": "total_sky_upward_shortwave_flux_at_surface",
+        "SW_flux_up_at_model_top": "total_sky_upward_shortwave_flux_at_top_of_atmosphere",
+        "SW_flux_dn_at_model_top": "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
     }
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds}
     return XarrayMapper(ds.rename(rename_vars))

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -10,11 +10,6 @@ from .._xarray import XarrayMapper
 from loaders._config import mapper_functions
 from loaders.typing import Mapper
 
-try:
-    import vcm
-except ImportError:
-    vcm = None
-
 logger = logging.getLogger(__name__)
 
 Z_DIM_NAME = "z"
@@ -298,7 +293,4 @@ def open_nudge_to_fine_scream(
         "tendency_of_qv_due_to_scream_physics": "pQ2",
     }
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds}
-    mapper = XarrayMapper(ds.rename(rename_vars))
-    if vcm is not None:
-        mapper = vcm.DerivedMapping(mapper)
-    return mapper
+    return XarrayMapper(ds.rename(rename_vars))

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -293,11 +293,11 @@ def open_nudge_to_fine_scream(
         "tendency_of_qv_due_to_scream_physics": "pQ2",
         "LW_flux_dn_at_model_bot": "total_sky_downward_longwave_flux_at_surface",
         "LW_flux_up_at_model_bot": "total_sky_upward_longwave_flux_at_surface",
-        "LW_flux_up_at_model_top": "total_sky_upward_longwave_flux_at_top_of_atmosphere",
+        "LW_flux_up_at_model_top": "total_sky_upward_longwave_flux_at_top_of_atmosphere",  # noqa
         "SW_flux_dn_at_model_bot": "total_sky_downward_shortwave_flux_at_surface",
         "SW_flux_up_at_model_bot": "total_sky_upward_shortwave_flux_at_surface",
-        "SW_flux_up_at_model_top": "total_sky_upward_shortwave_flux_at_top_of_atmosphere",
-        "SW_flux_dn_at_model_top": "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+        "SW_flux_up_at_model_top": "total_sky_upward_shortwave_flux_at_top_of_atmosphere",  # noqa
+        "SW_flux_dn_at_model_top": "total_sky_downward_shortwave_flux_at_top_of_atmosphere",  # noqa
     }
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds}
     return XarrayMapper(ds.rename(rename_vars))

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -222,17 +222,6 @@ def downward_shortwave_sfc_flux_via_transmissivity(self):
     toa_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
     transmissivity = self["shortwave_transmissivity_of_atmospheric_column"]
     return transmissivity * toa_flux
-@DerivedMapping.register(
-    "downward_shortwave_sfc_flux_via_transmissivity",
-    required_inputs=[
-        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
-        "shortwave_transmissivity_of_atmospheric_column",
-    ],
-)
-def downward_shortwave_sfc_flux_via_transmissivity(self):
-    toa_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    transmissivity = self["shortwave_transmissivity_of_atmospheric_column"]
-    return transmissivity * toa_flux
 
 
 @DerivedMapping.register(
@@ -260,70 +249,145 @@ def _limit_sw_positive(da, downward_toa_shortwave_flux):
     "shortwave_transmissivity_of_atmospheric_column",
     required_inputs=[
         "total_sky_downward_shortwave_flux_at_surface",
-        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
     ],
-    use_nonderived_if_exists=True
+    use_nonderived_if_exists=True,
 )
 def shortwave_transmissivity_of_atmospheric_column(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    transmissivity = self["total_sky_downward_shortwave_flux_at_surface"] / downward_toa_shortwave_flux
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    transmissivity = (
+        self["total_sky_downward_shortwave_flux_at_surface"]
+        / downward_toa_shortwave_flux
+    )
     return _limit_sw_positive(transmissivity, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_shortwave_total_nir_at_surface", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
+@DerivedMapping.register(
+    "downward_shortwave_total_nir_at_surface",
+    required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"],
+)
 def downward_shortwave_total_nir_at_surface(self):
     return self["sfc_flux_dir_nir"] + self["sfc_flux_dif_nir"]
 
 
-@DerivedMapping.register("downward_shortwave_total_vis_at_surface", required_inputs=["sfc_flux_dir_vis", "sfc_flux_dif_vis"])
+@DerivedMapping.register(
+    "downward_shortwave_total_vis_at_surface",
+    required_inputs=["sfc_flux_dir_vis", "sfc_flux_dif_vis"],
+)
 def downward_shortwave_total_vis_at_surface(self):
     return self["sfc_flux_dir_vis"] + self["sfc_flux_dif_vis"]
 
 
 @DerivedMapping.register(
     "downward_vis_fraction_at_surface",
-    required_inputs=["total_sky_downward_shortwave_flux_at_surface", "downward_shortwave_total_nir_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"],
-    use_nonderived_if_exists=True
+    required_inputs=[
+        "total_sky_downward_shortwave_flux_at_surface",
+        "downward_shortwave_total_nir_at_surface",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
+    use_nonderived_if_exists=True,
 )
 def downward_vis_fraction_at_surface(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"] 
-    downward_vis_frac_sfc = self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    downward_vis_frac_sfc = (
+        self["downward_shortwave_total_vis_at_surface"]
+        / self["total_sky_downward_shortwave_flux_at_surface"]
+    )
     return _limit_sw_positive(downward_vis_frac_sfc, downward_toa_shortwave_flux)
 
 
 @DerivedMapping.register(
     "downward_nir_fraction_at_surface",
-    required_inputs=["downward_vis_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    required_inputs=[
+        "downward_vis_fraction_at_surface",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
 )
 def downward_nir_fraction_at_surface(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    return _limit_sw_positive(1 - self["downward_vis_fraction_at_surface"], downward_toa_shortwave_flux)
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    return _limit_sw_positive(
+        1 - self["downward_vis_fraction_at_surface"], downward_toa_shortwave_flux
+    )
 
 
-@DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
+@DerivedMapping.register(
+    "downward_vis_diffuse_fraction_at_surface",
+    required_inputs=[
+        "downward_shortwave_total_vis_at_surface",
+        "sfc_flux_dif_vis",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
+    use_nonderived_if_exists=True,
+)
 def downward_vis_diffuse_fraction_at_surface(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    vis_diffuse_fraction = self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    vis_diffuse_fraction = (
+        self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    )
     return _limit_sw_positive(vis_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
+@DerivedMapping.register(
+    "downward_vis_direct_fraction_at_surface",
+    required_inputs=[
+        "downward_vis_diffuse_fraction_at_surface",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
+    use_nonderived_if_exists=True,
+)
 def downward_vis_direct_fraction_at_surface(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    return _limit_sw_positive(1 - self["downward_vis_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    return _limit_sw_positive(
+        1 - self["downward_vis_diffuse_fraction_at_surface"],
+        downward_toa_shortwave_flux,
+    )
 
 
-@DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
+@DerivedMapping.register(
+    "downward_nir_diffuse_fraction_at_surface",
+    required_inputs=[
+        "downward_shortwave_total_nir_at_surface",
+        "sfc_flux_dif_nir",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
+    use_nonderived_if_exists=True,
+)
 def downward_nir_diffuse_fraction_at_surface(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    nir_diffuse_fraction = self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    nir_diffuse_fraction = (
+        self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    )
     return _limit_sw_positive(nir_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
+@DerivedMapping.register(
+    "downward_nir_direct_fraction_at_surface",
+    required_inputs=[
+        "downward_nir_diffuse_fraction_at_surface",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere",
+    ],
+    use_nonderived_if_exists=True,
+)
 def downward_nir_direct_fraction(self):
-    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    return _limit_sw_positive(1 - self["downward_nir_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)
+    downward_toa_shortwave_flux = self[
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ]
+    return _limit_sw_positive(
+        1 - self["downward_nir_diffuse_fraction_at_surface"],
+        downward_toa_shortwave_flux,
+    )
 
 
 @DerivedMapping.register(

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -275,20 +275,20 @@ def downward_shortwave_total_vis_at_surface(self):
 
 
 @DerivedMapping.register(
-    "downward_visible_fraction_at_surface",
+    "downward_vis_fraction_at_surface",
     required_inputs=["total_sky_downward_shortwave_flux_at_surface", "downward_shortwave_total_nir_at_surface"],
     use_nonderived_if_exists=True
 )
-def downward_visible_fraction_at_surface(self):
+def downward_vis_fraction_at_surface(self):
     return self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
 
 
 @DerivedMapping.register(
     "downward_nir_fraction_at_surface",
-    required_inputs=["downward_visible_fraction_at_surface"]
+    required_inputs=["downward_vis_fraction_at_surface"]
 )
 def downward_nir_fraction_at_surface(self):
-    return 1 - self["downward_visible_fraction_at_surface"]
+    return 1 - self["downward_vis_fraction_at_surface"]
 
 
 @DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
@@ -296,7 +296,7 @@ def downward_vis_diffuse_fraction_at_surface(self):
     return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
 
 
-@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["donward_vis_diffuse_fraction"])
+@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface"])
 def downward_vis_direct_fraction_at_surface(self):
     return 1 - self["downward_vis_diffuse_fraction_at_surface"]
 

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -307,7 +307,7 @@ def downward_vis_diffuse_fraction_at_surface(self):
     return _limit_sw_positive(vis_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"])
+@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
 def downward_vis_direct_fraction_at_surface(self):
     downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
     return _limit_sw_positive(1 - self["downward_vis_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)
@@ -320,7 +320,7 @@ def downward_nir_diffuse_fraction_at_surface(self):
     return _limit_sw_positive(nir_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"])
+@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
 def downward_nir_direct_fraction(self):
     downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
     return _limit_sw_positive(1 - self["downward_nir_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -250,49 +250,65 @@ def net_shortwave_sfc_flux_via_transmissivity(self):
 
 # TODO: make congruent with fv3net naming and make sure renames happen on load
 # This section of radiation is for EAMXX radiation model
-@DerivedMapping.register("shortwave_transmissivity_of_atmospheric_column", required_inputs=["SW_flux_dn_at_model_bot", "SW_flux_dn_at_model_top"], use_nonderived_if_exists=True)
+# NIR and VISIBLE sum to the total downwelling SW at the surface
+# From this we can piece out the fractional components for prediction
+@DerivedMapping.register(
+    "shortwave_transmissivity_of_atmospheric_column",
+    required_inputs=[
+        "total_sky_downward_shortwave_flux_at_surface",
+        "total_sky_downward_shortwave_flux_at_top_of_atmosphere"
+    ],
+    use_nonderived_if_exists=True
+)
 def shortwave_transmissivity_of_atmospheric_column(self):
-    return self["SW_flux_dn_at_model_bot"] / self["SW_flux_dn_at_model_top"]
+    return self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
 
 
-@DerivedMapping.register("downward_shortwave_total_nir", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
-def downward_shortwave_total_nir(self):
+@DerivedMapping.register("downward_shortwave_total_nir_at_surface", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
+def downward_shortwave_total_nir_at_surface(self):
     return self["sfc_flux_dir_nir"] + self["sfc_flux_dif_nir"]
 
 
-@DerivedMapping.register("downward_shortwave_total_vis", required_inputs=["sfc_flux_dir_vis", "sfc_flux_dif_vis"])
-def downward_shortwave_total_vis(self):
+@DerivedMapping.register("downward_shortwave_total_vis_at_surface", required_inputs=["sfc_flux_dir_vis", "sfc_flux_dif_vis"])
+def downward_shortwave_total_vis_at_surface(self):
     return self["sfc_flux_dir_vis"] + self["sfc_flux_dif_vis"]
 
 
-@DerivedMapping.register("downward_shortwave_fraction_nir", required_inputs=["SW_flux_dn_at_model_bot", "downward_shortwave_total_nir"], use_nonderived_if_exists=True)
-def downward_shortwave_fraction_nir(self):
-    return self["downward_shortwave_total_nir"] / self["SW_flux_dn_at_model_bot"]
+@DerivedMapping.register(
+    "downward_visible_fraction_at_surface",
+    required_inputs=["total_sky_downward_shortwave_flux_at_surface", "downward_shortwave_total_nir_at_surface"],
+    use_nonderived_if_exists=True
+)
+def downward_visible_fraction_at_surface(self):
+    return self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
 
 
-@DerivedMapping.register("downward_shortwave_fraction_vis", required_inputs=["SW_flux_dn_at_model_bot", "downward_shortwave_total_vis"], use_nonderived_if_exists=True)
-def downward_shortwave_fraction_vis(self):
-    return self["downward_shortwave_total_vis"] / self["SW_flux_dn_at_model_bot"]
+@DerivedMapping.register(
+    "downward_nir_fraction_at_surface",
+    required_inputs=["downward_visible_fraction_at_surface"]
+)
+def downward_nir_fraction_at_surface(self):
+    return 1 - self["downward_visible_fraction_at_surface"]
 
 
-@DerivedMapping.register("downward_vis_diffuse_fraction", required_inputs=["downward_shortwave_total_vis", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
-def downward_vis_diffuse_fraction(self):
-    return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis"]
+@DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
+def downward_vis_diffuse_fraction_at_surface(self):
+    return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
 
 
-@DerivedMapping.register("downward_vis_direct_fraction", required_inputs=["donward_vis_diffuse_fraction"])
-def downward_vis_direct_fraction(self):
-    return 1 - self["downward_vis_diffuse_fraction"]
+@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["donward_vis_diffuse_fraction"])
+def downward_vis_direct_fraction_at_surface(self):
+    return 1 - self["downward_vis_diffuse_fraction_at_surface"]
 
 
-@DerivedMapping.register("downward_nir_diffuse_fraction", required_inputs=["downward_shortwave_total_nir", "sfc_flux_dif_nir"], use_nonderived_if_exists=True)
-def downward_nir_diffuse_fraction(self):
-    return self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir"]
+@DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir"], use_nonderived_if_exists=True)
+def downward_nir_diffuse_fraction_at_surface(self):
+    return self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
 
 
-@DerivedMapping.register("downward_nir_direct_fraction", required_inputs=["downward_nir_diffuse_fraction"])
+@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface"])
 def downward_nir_direct_fraction(self):
-    return 1 - self["downward_nir_diffuse_fraction"]
+    return 1 - self["downward_nir_diffuse_fraction_at_surface"]
 
 
 @DerivedMapping.register(

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -261,7 +261,8 @@ def net_shortwave_sfc_flux_via_transmissivity(self):
     use_nonderived_if_exists=True
 )
 def shortwave_transmissivity_of_atmospheric_column(self):
-    return self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    transmissivity = self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    return transmissivity.where(transmissivity.notnull(), 0.0) 
 
 
 @DerivedMapping.register("downward_shortwave_total_nir_at_surface", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
@@ -280,35 +281,40 @@ def downward_shortwave_total_vis_at_surface(self):
     use_nonderived_if_exists=True
 )
 def downward_visible_fraction_at_surface(self):
-    return self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
-
+    vis_frac_sfc = self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
+    return vis_frac_sfc.where(vis_frac_sfc.notnull(), 0.0)
 
 @DerivedMapping.register(
     "downward_nir_fraction_at_surface",
     required_inputs=["downward_visible_fraction_at_surface"]
 )
 def downward_nir_fraction_at_surface(self):
-    return 1 - self["downward_visible_fraction_at_surface"]
+    vis_frac_sfc = self["downward_visible_fraction_at_surface"]
+    return (1 - vis_frac_sfc).where(vis_frac_sfc != 0.0, 0.0)
 
 
 @DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
 def downward_vis_diffuse_fraction_at_surface(self):
-    return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    dif_frac_vis = self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    return dif_frac_vis.where(dif_frac_vis.notnull(), 0.0)
 
 
 @DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["donward_vis_diffuse_fraction"])
 def downward_vis_direct_fraction_at_surface(self):
-    return 1 - self["downward_vis_diffuse_fraction_at_surface"]
+    dif_frac_vis = self["downward_vis_diffuse_fraction_at_surface"]
+    return (1 - dif_frac_vis).where(dif_frac_vis != 0.0, 0.0) 
 
 
 @DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir"], use_nonderived_if_exists=True)
 def downward_nir_diffuse_fraction_at_surface(self):
-    return self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    dif_frac_nir = self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    return dif_frac_nir.where(dif_frac_nir.notnull(), 0.0)
 
 
 @DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface"])
 def downward_nir_direct_fraction(self):
-    return 1 - self["downward_nir_diffuse_fraction_at_surface"]
+    dif_frac_nir = self["downward_nir_diffuse_fraction_at_surface"]
+    return (1 - dif_frac_nir).where(dif_frac_nir != 0.0, 0.0)
 
 
 @DerivedMapping.register(

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -261,8 +261,7 @@ def net_shortwave_sfc_flux_via_transmissivity(self):
     use_nonderived_if_exists=True
 )
 def shortwave_transmissivity_of_atmospheric_column(self):
-    transmissivity = self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
-    return transmissivity.where(transmissivity.notnull(), 0.0) 
+    return self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
 
 
 @DerivedMapping.register("downward_shortwave_total_nir_at_surface", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
@@ -281,40 +280,35 @@ def downward_shortwave_total_vis_at_surface(self):
     use_nonderived_if_exists=True
 )
 def downward_visible_fraction_at_surface(self):
-    vis_frac_sfc = self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
-    return vis_frac_sfc.where(vis_frac_sfc.notnull(), 0.0)
+    return self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
+
 
 @DerivedMapping.register(
     "downward_nir_fraction_at_surface",
     required_inputs=["downward_visible_fraction_at_surface"]
 )
 def downward_nir_fraction_at_surface(self):
-    vis_frac_sfc = self["downward_visible_fraction_at_surface"]
-    return (1 - vis_frac_sfc).where(vis_frac_sfc != 0.0, 0.0)
+    return 1 - self["downward_visible_fraction_at_surface"]
 
 
 @DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
 def downward_vis_diffuse_fraction_at_surface(self):
-    dif_frac_vis = self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
-    return dif_frac_vis.where(dif_frac_vis.notnull(), 0.0)
+    return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
 
 
 @DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["donward_vis_diffuse_fraction"])
 def downward_vis_direct_fraction_at_surface(self):
-    dif_frac_vis = self["downward_vis_diffuse_fraction_at_surface"]
-    return (1 - dif_frac_vis).where(dif_frac_vis != 0.0, 0.0) 
+    return 1 - self["downward_vis_diffuse_fraction_at_surface"]
 
 
 @DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir"], use_nonderived_if_exists=True)
 def downward_nir_diffuse_fraction_at_surface(self):
-    dif_frac_nir = self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
-    return dif_frac_nir.where(dif_frac_nir.notnull(), 0.0)
+    return self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
 
 
 @DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface"])
 def downward_nir_direct_fraction(self):
-    dif_frac_nir = self["downward_nir_diffuse_fraction_at_surface"]
-    return (1 - dif_frac_nir).where(dif_frac_nir != 0.0, 0.0)
+    return 1 - self["downward_nir_diffuse_fraction_at_surface"]
 
 
 @DerivedMapping.register(

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -252,6 +252,10 @@ def net_shortwave_sfc_flux_via_transmissivity(self):
 # This section of radiation is for EAMXX radiation model
 # NIR and VISIBLE sum to the total downwelling SW at the surface
 # From this we can piece out the fractional components for prediction
+def _limit_sw_positive(da, downward_toa_shortwave_flux):
+    return xr.where(downward_toa_shortwave_flux > 0, da, 0.0)
+
+
 @DerivedMapping.register(
     "shortwave_transmissivity_of_atmospheric_column",
     required_inputs=[
@@ -261,7 +265,9 @@ def net_shortwave_sfc_flux_via_transmissivity(self):
     use_nonderived_if_exists=True
 )
 def shortwave_transmissivity_of_atmospheric_column(self):
-    return self["total_sky_downward_shortwave_flux_at_surface"] / self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    transmissivity = self["total_sky_downward_shortwave_flux_at_surface"] / downward_toa_shortwave_flux
+    return _limit_sw_positive(transmissivity, downward_toa_shortwave_flux)
 
 
 @DerivedMapping.register("downward_shortwave_total_nir_at_surface", required_inputs=["sfc_flux_dir_nir", "sfc_flux_dif_nir"])
@@ -276,39 +282,48 @@ def downward_shortwave_total_vis_at_surface(self):
 
 @DerivedMapping.register(
     "downward_vis_fraction_at_surface",
-    required_inputs=["total_sky_downward_shortwave_flux_at_surface", "downward_shortwave_total_nir_at_surface"],
+    required_inputs=["total_sky_downward_shortwave_flux_at_surface", "downward_shortwave_total_nir_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"],
     use_nonderived_if_exists=True
 )
 def downward_vis_fraction_at_surface(self):
-    return self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"] 
+    downward_vis_frac_sfc = self["downward_shortwave_total_vis_at_surface"] / self["total_sky_downward_shortwave_flux_at_surface"]
+    return _limit_sw_positive(downward_vis_frac_sfc, downward_toa_shortwave_flux)
 
 
 @DerivedMapping.register(
     "downward_nir_fraction_at_surface",
-    required_inputs=["downward_vis_fraction_at_surface"]
+    required_inputs=["downward_vis_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
 )
 def downward_nir_fraction_at_surface(self):
-    return 1 - self["downward_vis_fraction_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    return _limit_sw_positive(1 - self["downward_vis_fraction_at_surface"], downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis"], use_nonderived_if_exists=True)
+@DerivedMapping.register("downward_vis_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_vis_at_surface", "sfc_flux_dif_vis", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
 def downward_vis_diffuse_fraction_at_surface(self):
-    return self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    vis_diffuse_fraction = self["sfc_flux_dif_vis"] / self["downward_shortwave_total_vis_at_surface"]
+    return _limit_sw_positive(vis_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface"])
+@DerivedMapping.register("downward_vis_direct_fraction_at_surface", required_inputs=["downward_vis_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"])
 def downward_vis_direct_fraction_at_surface(self):
-    return 1 - self["downward_vis_diffuse_fraction_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    return _limit_sw_positive(1 - self["downward_vis_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir"], use_nonderived_if_exists=True)
+@DerivedMapping.register("downward_nir_diffuse_fraction_at_surface", required_inputs=["downward_shortwave_total_nir_at_surface", "sfc_flux_dif_nir", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"], use_nonderived_if_exists=True)
 def downward_nir_diffuse_fraction_at_surface(self):
-    return self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    nir_diffuse_fraction = self["sfc_flux_dif_nir"] / self["downward_shortwave_total_nir_at_surface"]
+    return _limit_sw_positive(nir_diffuse_fraction, downward_toa_shortwave_flux)
 
 
-@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface"])
+@DerivedMapping.register("downward_nir_direct_fraction_at_surface", required_inputs=["downward_nir_diffuse_fraction_at_surface", "total_sky_downward_shortwave_flux_at_top_of_atmosphere"])
 def downward_nir_direct_fraction(self):
-    return 1 - self["downward_nir_diffuse_fraction_at_surface"]
+    downward_toa_shortwave_flux = self["total_sky_downward_shortwave_flux_at_top_of_atmosphere"]
+    return _limit_sw_positive(1 - self["downward_nir_diffuse_fraction_at_surface"], downward_toa_shortwave_flux)
 
 
 @DerivedMapping.register(


### PR DESCRIPTION
SCREAM requires some additional inputs to the surface scheme for radiation.  This PR provides additional derived variables so we can train models to output fractions of the downwelling shortwave to allocate to NIR/VIS direct/diffuse components.

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

Coverage reports (updated automatically):
