### PR TITLE
xtorch_harmonics: work around `xarray.merge` attribute promotion issue

### DIFF
--- a/external/xtorch_harmonics/xtorch_harmonics/xtorch_harmonics.py
+++ b/external/xtorch_harmonics/xtorch_harmonics/xtorch_harmonics.py
@@ -177,12 +177,14 @@ def _roundtrip_filter_dataset(
     results = []
     for da in ds.data_vars.values():
         if not horizontal_dims.issubset(da.dims):
-            results.append(da)
+            result = da
         else:
             result = _roundtrip_filter_dataarray(
                 da, forward_grid, inverse_grid, lat_dim, lon_dim, fraction_modes_kept
             )
-            results.append(result)
+        # Convert DataArrays to Datasets before merging due to an attribute
+        # promotion issue: https://github.com/pydata/xarray/issues/5436
+        results.append(result.to_dataset())
     return xr.merge(results).assign_attrs(ds.attrs)
 
 


### PR DESCRIPTION
When merging DataArrays, a known issue (pydata/xarray#5436) is that xarray will promote DataArray-level attributes to Dataset-level ones:
```
>>> a = xr.DataArray(0, name="a", attrs={"x": "y"})
>>> b = xr.DataArray(0, name="b", attrs={"m": "n"})
>>> xr.merge([a, b])
<xarray.Dataset>
Dimensions:  ()
Data variables:
    a        int64 0
    b        int64 0
Attributes:
    x:        y
```
This is generally not correct, and leads to distracting Dataset-level attributes on the results of `xtorch_harmonics.roundtrip_filter`.  A suggested workaround is to convert DataArrays to Datasets prior to passing to `merge`: https://github.com/pydata/xarray/issues/5436#issuecomment-1255120923.  This PR implements this suggestion and tests that DataArray-level attributes are no longer added at the Dataset level.

- [x] Tests added

Coverage reports (updated automatically):
