### PR TITLE
Add SCREAM prescribed radiation to online diagnostic variables

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/constants.py
@@ -122,6 +122,8 @@ DIURNAL_CYCLE_VARS = [
     "PRATEsfc",
     "LHTFLsfc",
     "surf_evap",
+    "sfc_flux_lw_dn",  # SCREAM Variables
+    "sfc_flux_sw_net",
 ]
 
 TIME_MEAN_VARS = [
@@ -144,6 +146,8 @@ TIME_MEAN_VARS = [
     "DLWRFsfc",
     "USWRFtoa",
     "ULWRFtoa",
+    "sfc_flux_lw_dn",  # SCREAM Variables
+    "sfc_flux_sw_net",
 ]
 
 PRESSURE_INTERPOLATED_VARS = [


### PR DESCRIPTION
Adds the prescribed/predicted radiation variables net sfc SW and net LW down to the online diagnostics to compare to the physics rather than adding more confusion to the renaming matrix.