### PR TITLE
Fix bug to remove net ML moistening from SCREAM surface precip for diags

### DIFF
--- a/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
+++ b/workflows/diagnostics/fv3net/diagnostics/prognostic_run/load_run_data.py
@@ -192,7 +192,7 @@ def _fix_moistening_and_prate_units_for_ml_diags(ds):
     dq2_key = "net_moistening_due_to_machine_learning"
     if prate_key in ds and dq2_key in ds:
         logger.info("Removing ML precip from SCREAM PRATEsfc")
-        ds[prate_key] = ds[prate_key] - ds[dq2_key]
+        ds[prate_key] = ds[prate_key] + ds[dq2_key]
 
     if dq2_key in ds:
         logger.info("Changing units of ml net moistening to mm/day")


### PR DESCRIPTION
The net moistening removal from SCREAM run output for diagnostics incorrectly subtracted the ML quantity (essentially doubling the precip).  This PR switches that removal to the correct sign.