### PR TITLE
`fv3kube` test environment fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,9 +158,12 @@ jobs:
           name: Install dependencies
           command: |
             apt-get install -y wget jq make gettext gzip
-            python3 -m venv .venv
-            source .venv/bin/activate
+            apt install python3.11-venv
+            VENV_DIR="$(pwd)/.venv"
+            python3 -m venv $VENV_DIR
+            source "${VENV_DIR}/bin/activate"
             pip3 install yq==2.11.0
+            echo "source ${VENV_DIR}/bin/activate" >> $BASH_ENV
 
             # install kustomize
             wget "https://raw.githubusercontent.com/\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Install dependencies
           command: |
             apt-get install -y wget jq make gettext gzip
-            apt install -y python3.11-venv
+            apt install -y python3-venv
             VENV_DIR="$(pwd)/.venv"
             python3 -m venv $VENV_DIR
             source "${VENV_DIR}/bin/activate"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,8 @@ jobs:
           name: Install dependencies
           command: |
             apt-get install -y wget jq make gettext gzip
+            python3 -m venv .venv
+            source .venv/bin/activate
             pip3 install yq==2.11.0
 
             # install kustomize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Install dependencies
           command: |
             apt-get install -y wget jq make gettext gzip
-            apt install python3.11-venv
+            apt install -y python3.11-venv
             VENV_DIR="$(pwd)/.venv"
             python3 -m venv $VENV_DIR
             source "${VENV_DIR}/bin/activate"

--- a/external/fv3kube/requirements.txt
+++ b/external/fv3kube/requirements.txt
@@ -1,7 +1,5 @@
-pytest
 fsspec
 pyyaml
 kubernetes
 fv3config
 py
-pytest-regtest

--- a/external/fv3kube/tox.ini
+++ b/external/fv3kube/tox.ini
@@ -4,6 +4,8 @@ skipsdist = true
 
 [testenv]
 deps =
+    pytest==4.6.11
+    pytest-regtest==1.4.4
     coverage
     -rrequirements.txt
 


### PR DESCRIPTION
Restores passing unit and end-to-end integration tests:

- Fixes a `tox` environment problem that cropped up in the `fv3kube` tests due to unpinned test packages and pinned repo code. 
- Fixes a CircleCI environment problem installing dependencies necessary to launch the integration test.
