### PR TITLE
fv3kube: remove `gfdl_mp_nml.rh_ins` and `gfdl_mp_nml.ql_gen` from SHiELD PIRE-like config

### DIFF
--- a/external/fv3kube/fv3kube/base_yamls/SHiELD/PIRE-like/fv3config.yml
+++ b/external/fv3kube/fv3kube/base_yamls/SHiELD/PIRE-like/fv3config.yml
@@ -146,7 +146,6 @@ namelist:
     prog_ccn: false
     qi0_crt: 8.0e-05
     qi_lim: 1.0
-    ql_gen: 0.001
     ql_mlt: 0.002
     qs0_crt: 0.003
     qs_mlt: 1.0e-6
@@ -160,7 +159,6 @@ namelist:
     rewmin: 5.0  # Moved from cld_eff_rad_nml
     rh_inc: 0.2
     rh_inr: 0.3
-    rh_ins: 0.3
     rthresh: 8.0e-6
     snow_grauple_combine: false  # Restore default from PIRE simulation codebase (current default is true)
     tau_i2s: 1000.0


### PR DESCRIPTION
This PR removes `gfdl_mp_nml.rh_ins` and `gfdl_mp_nml.ql_gen` from the SHiELD PIRE-like config in fv3kube.  These namelist parameters were removed in the 202411 release of the dynamical core. See https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/364 for more details. These namelist parameters were already obviated—i.e. they had no impact on simulations—but had just not been removed. We remove them from the config now to avoid errors when running with the latest code base.  

I have verified that removing these namelist parameters in simulations with the old codebase has no effect on simulations (i.e. it would not have changed the answers of any simulations that we ran based on this config).